### PR TITLE
feat: update mcp-core prompt to match spec, add mcp list/get to mcp-client

### DIFF
--- a/crates/mcp-client/examples/stdio_integration.rs
+++ b/crates/mcp-client/examples/stdio_integration.rs
@@ -82,5 +82,16 @@ async fn main() -> Result<(), ClientError> {
     let resource = client.read_resource("memo://insights").await?;
     println!("Resource: {resource:?}\n");
 
+    let prompts = client.list_prompts(None).await?;
+    println!("Prompts: {prompts:?}\n");
+
+    let prompt = client
+        .get_prompt(
+            "example_prompt",
+            serde_json::json!({"message": "hello there!"}),
+        )
+        .await?;
+    println!("Prompt: {prompt:?}\n");
+
     Ok(())
 }

--- a/crates/mcp-client/src/transport/stdio.rs
+++ b/crates/mcp-client/src/transport/stdio.rs
@@ -87,10 +87,18 @@ impl StdioActor {
                             "Received incoming message"
                         );
 
-                        if let JsonRpcMessage::Response(response) = &message {
-                            if let Some(id) = &response.id {
-                                pending_requests.respond(&id.to_string(), Ok(message)).await;
+                        match &message {
+                            JsonRpcMessage::Response(response) => {
+                                if let Some(id) = &response.id {
+                                    pending_requests.respond(&id.to_string(), Ok(message)).await;
+                                }
                             }
+                            JsonRpcMessage::Error(error) => {
+                                if let Some(id) = &error.id {
+                                    pending_requests.respond(&id.to_string(), Ok(message)).await;
+                                }
+                            }
+                            _ => {} // TODO: Handle other variants (Request, etc.)
                         }
                     }
                     line.clear();

--- a/crates/mcp-core/src/prompt.rs
+++ b/crates/mcp-core/src/prompt.rs
@@ -10,22 +10,28 @@ use serde::{Deserialize, Serialize};
 pub struct Prompt {
     /// The name of the prompt
     pub name: String,
-    /// A description of what the prompt does
-    pub description: String,
-    /// The arguments that can be passed to customize the prompt
-    pub arguments: Vec<PromptArgument>,
+    /// Optional description of what the prompt does
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional arguments that can be passed to customize the prompt
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<Vec<PromptArgument>>,
 }
 
 impl Prompt {
     /// Create a new prompt with the given name, description and arguments
-    pub fn new<N, D>(name: N, description: D, arguments: Vec<PromptArgument>) -> Self
+    pub fn new<N, D>(
+        name: N,
+        description: Option<D>,
+        arguments: Option<Vec<PromptArgument>>,
+    ) -> Self
     where
         N: Into<String>,
         D: Into<String>,
     {
         Prompt {
             name: name.into(),
-            description: description.into(),
+            description: description.map(Into::into),
             arguments,
         }
     }
@@ -37,9 +43,11 @@ pub struct PromptArgument {
     /// The name of the argument
     pub name: String,
     /// A description of what the argument is used for
-    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Whether this argument is required
-    pub required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
 }
 
 /// Represents the role of a message sender in a prompt conversation
@@ -151,6 +159,6 @@ pub struct PromptTemplate {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PromptArgumentTemplate {
     pub name: String,
-    pub description: String,
-    pub required: bool,
+    pub description: Option<String>,
+    pub required: Option<bool>,
 }

--- a/crates/mcp-server/src/router.rs
+++ b/crates/mcp-server/src/router.rs
@@ -305,18 +305,21 @@ pub trait Router: Send + Sync + 'static {
             };
 
             // Validate required arguments
-            for arg in &prompt.arguments {
-                if arg.required
-                    && (!arguments.contains_key(&arg.name)
-                        || arguments
-                            .get(&arg.name)
-                            .and_then(Value::as_str)
-                            .is_none_or(str::is_empty))
-                {
-                    return Err(RouterError::InvalidParams(format!(
-                        "Missing required argument: '{}'",
-                        arg.name
-                    )));
+            if let Some(args) = &prompt.arguments {
+                for arg in args {
+                    if arg.required.is_some()
+                        && arg.required.unwrap()
+                        && (!arguments.contains_key(&arg.name)
+                            || arguments
+                                .get(&arg.name)
+                                .and_then(Value::as_str)
+                                .is_none_or(str::is_empty))
+                    {
+                        return Err(RouterError::InvalidParams(format!(
+                            "Missing required argument: '{}'",
+                            arg.name
+                        )));
+                    }
                 }
             }
 


### PR DESCRIPTION
Update `Prompt` structs for align with MCP spec, and add list/get prompts to the `mcp-client`

## Motivation and Context
* [Prompts](https://modelcontextprotocol.io/docs/concepts/prompts#prompt-structure) `description` and `arguments` are optional fields, use optional in the structs
   * similarly `PromptArguments` `description` and `required` are optional too
* add `list_prompts` and `get_prompt` method to the `McpClientTrait`
* add implementation of `list_prompts` and `get_prompt` to call `prompts/list` and `prompts/get` respectively
* update `stdio` and `sse` clients to handle `JsonRpcMessage::Error` responses to send back to the user instead of doing nothing

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested locally with goose, and tested listing, and getting prompts and getting errors
Added implementation to `crates/mcp-server/src/main.rs` and usage of it in `crates/mcp-client/examples/stdio_integration.rs`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
* The `Prompt` struct API has changed `description` and `arguments` to be `Option<T>`
* The `PromptArgument` struct API has changed `description` and `required` to be `Option<T>`
* `Router`: `get_prompt` and `list_prompt` are now required to be implemented by types that want to `impl Router` to keep it consistent with how `tools` and `resources` are handled.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
