### PR TITLE
Implement client ping

### DIFF
--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -1,5 +1,5 @@
 use mcp_core::protocol::{
-    CallToolResult, GetPromptResult, Implementation, InitializeResult, JsonRpcError,
+    CallToolResult, EmptyResult, GetPromptResult, Implementation, InitializeResult, JsonRpcError,
     JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, ListPromptsResult,
     ListResourcesResult, ListToolsResult, ReadResourceResult, ServerCapabilities, METHOD_NOT_FOUND,
 };
@@ -97,6 +97,8 @@ pub trait McpClientTrait: Send + Sync {
     async fn list_prompts(&self, next_cursor: Option<String>) -> Result<ListPromptsResult, Error>;
 
     async fn get_prompt(&self, name: &str, arguments: Value) -> Result<GetPromptResult, Error>;
+
+    async fn ping(&self) -> Result<EmptyResult, Error>;
 }
 
 /// The MCP client is the interface for MCP operations.
@@ -387,5 +389,11 @@ where
         let params = serde_json::json!({ "name": name, "arguments": arguments });
 
         self.send_request("prompts/get", params).await
+    }
+
+    async fn ping(&self) -> Result<EmptyResult, Error> {
+        let params = serde_json::json!({});
+
+        self.send_request("ping", params).await
     }
 }


### PR DESCRIPTION
Add client-side ping functionality

## Motivation and Context
Allow clients to check for aliveness of MCP servers. Needed by other SDKs too, e.g. [python](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/session.py#L123). 

## How Has This Been Tested?
This PR is copies from the prior [goose](https://github.com/block/goose) client. See commit [5bacbb](https://github.com/spiceai/goose/commit/5bacbba75925d76cbda53421115151d9097bed17). Used by https://github.com/spiceai/spiceai 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
