### PR TITLE
add server side resource template functionality

### DIFF
--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -6,7 +6,7 @@ pub use role::Role;
 pub mod tool;
 pub use tool::{Tool, ToolCall};
 pub mod resource;
-pub use resource::{Resource, ResourceContents};
+pub use resource::{Resource, ResourceContents, ResourceTemplate};
 pub mod protocol;
 pub use handler::{ToolError, ToolResult};
 pub mod prompt;

--- a/crates/mcp-core/src/protocol.rs
+++ b/crates/mcp-core/src/protocol.rs
@@ -185,6 +185,7 @@ pub struct PromptsCapability {
 pub struct ResourcesCapability {
     pub subscribe: Option<bool>,
     pub list_changed: Option<bool>,
+    pub templates: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -204,6 +205,21 @@ pub struct ListResourcesResult {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ReadResourceResult {
     pub contents: Vec<ResourceContents>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceTemplate {
+    pub uri_template: String,
+    pub name: String,
+    pub description: String,
+    pub mime_type: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ListResourceTemplatesResult {
+    pub resource_templates: Vec<ResourceTemplate>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/crates/mcp-core/src/protocol.rs
+++ b/crates/mcp-core/src/protocol.rs
@@ -2,8 +2,8 @@
 use crate::{
     content::Content,
     prompt::{Prompt, PromptMessage},
-    resource::Resource,
     resource::ResourceContents,
+    resource::{Resource, ResourceTemplate},
     tool::Tool,
 };
 use serde::{Deserialize, Serialize};
@@ -205,15 +205,6 @@ pub struct ListResourcesResult {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ReadResourceResult {
     pub contents: Vec<ResourceContents>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct ResourceTemplate {
-    pub uri_template: String,
-    pub name: String,
-    pub description: String,
-    pub mime_type: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -29,13 +29,14 @@ pub struct Resource {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceTemplate {
-    /// URI representing the resource template location (e.g., "file:///path/to/file" or "str:///content")
+    /// URI template following RFC 6570
     pub uri_template: String,
-    /// Name of the resource template
+    // Human-readable name for this type
     pub name: String,
-    /// Optional description of the resource template
+    // Optional description
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    // Optional MIME type for all matching resources
     #[serde(default = "default_mime_type")]
     pub mime_type: String,
 }

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -37,8 +37,7 @@ pub struct ResourceTemplate {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     // Optional MIME type for all matching resources
-    #[serde(default = "default_mime_type")]
-    pub mime_type: String,
+    pub mime_type: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -63,7 +62,7 @@ fn default_mime_type() -> String {
 }
 
 impl ResourceTemplate {
-    pub fn new<S: AsRef<str>>(uri_template: S, name: &str, mime_type: &str) -> Result<Self> {
+    pub fn new<S: AsRef<str>>(uri_template: S, name: &str) -> Result<Self> {
         let uri_template = uri_template.as_ref();
         let url_template = Url::parse(uri_template).map_err(|e| anyhow!("Invalid URI: {}", e))?;
 
@@ -71,12 +70,17 @@ impl ResourceTemplate {
             uri_template: url_template.to_string(),
             name: name.to_string(),
             description: None,
-            mime_type: mime_type.to_string(),
+            mime_type: None,
         })
     }
 
     pub fn with_description<S: Into<String>>(mut self, description: S) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    pub fn with_mime_type<S: Into<String>>(mut self, mime_type: S) -> Self {
+        self.mime_type = Some(mime_type.into());
         self
     }
 }

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -73,6 +73,11 @@ impl ResourceTemplate {
             mime_type: mime_type.to_string(),
         })
     }
+
+    pub fn with_description<S: Into<String>>(mut self, description: S) -> Self {
+        self.description = Some(description.into());
+        self
+    }
 }
 
 impl Resource {

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -33,7 +33,10 @@ pub struct ResourceTemplate {
     pub uri_template: String,
     /// Name of the resource template
     pub name: String,
-    pub description: String,
+    /// Optional description of the resource template
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default = "default_mime_type")]
     pub mime_type: String,
 }
 
@@ -59,13 +62,16 @@ fn default_mime_type() -> String {
 }
 
 impl ResourceTemplate {
-    pub fn new(uri_template: &str, name: &str, description: &str, mime_type: &str) -> Self {
-        Self {
-            uri_template: uri_template.to_string(),
+    pub fn new<S: AsRef<str>>(uri_template: S, name: &str, mime_type: &str) -> Result<Self> {
+        let uri_template = uri_template.as_ref();
+        let url_template = Url::parse(uri_template).map_err(|e| anyhow!("Invalid URI: {}", e))?;
+
+        Ok(Self {
+            uri_template: url_template.to_string(),
             name: name.to_string(),
-            description: description.to_string(),
+            description: None,
             mime_type: mime_type.to_string(),
-        }
+        })
     }
 }
 

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -29,7 +29,9 @@ pub struct Resource {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceTemplate {
+    /// URI representing the resource template location (e.g., "file:///path/to/file" or "str:///content")
     pub uri_template: String,
+    /// Name of the resource template
     pub name: String,
     pub description: String,
     pub mime_type: String,
@@ -54,6 +56,17 @@ pub enum ResourceContents {
 
 fn default_mime_type() -> String {
     "text".to_string()
+}
+
+impl ResourceTemplate {
+    pub fn new(uri_template: &str, name: &str, description: &str, mime_type: &str) -> Self {
+        Self {
+            uri_template: uri_template.to_string(),
+            name: name.to_string(),
+            description: description.to_string(),
+            mime_type: mime_type.to_string(),
+        }
+    }
 }
 
 impl Resource {

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -64,10 +64,8 @@ fn default_mime_type() -> String {
 impl ResourceTemplate {
     pub fn new<S: AsRef<str>>(uri_template: S, name: &str) -> Result<Self> {
         let uri_template = uri_template.as_ref();
-        let url_template = Url::parse(uri_template).map_err(|e| anyhow!("Invalid URI: {}", e))?;
-
         Ok(Self {
-            uri_template: url_template.to_string(),
+            uri_template: uri_template.to_string(),
             name: name.to_string(),
             description: None,
             mime_type: None,

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -27,6 +27,15 @@ pub struct Resource {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceTemplate {
+    pub uri_template: String,
+    pub name: String,
+    pub description: String,
+    pub mime_type: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum ResourceContents {
     TextResourceContents {

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -293,4 +293,31 @@ mod tests {
         let result = Resource::new("not-a-uri", None, None);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_resource_template_new() -> Result<()> {
+        let template = ResourceTemplate::new("file://{path}", "Project Files")?;
+        assert_eq!(template.uri_template, "file://{path}");
+        assert_eq!(template.name, "Project Files");
+        Ok(())
+    }
+
+    #[test]
+    fn test_resource_template_with_description() -> Result<()> {
+        let template = ResourceTemplate::new("file://{path}", "Project Files")?
+            .with_description("Access files in the project directory");
+        assert_eq!(
+            template.description,
+            Some("Access files in the project directory".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_resource_template_with_mime_type() -> Result<()> {
+        let template =
+            ResourceTemplate::new("file://{path}", "Project Files")?.with_mime_type("text");
+        assert_eq!(template.mime_type, Some("text".to_string()));
+        Ok(())
+    }
 }

--- a/crates/mcp-server/src/router.rs
+++ b/crates/mcp-server/src/router.rs
@@ -13,8 +13,8 @@ use mcp_core::{
     protocol::{
         CallToolResult, GetPromptResult, Implementation, InitializeResult, JsonRpcRequest,
         JsonRpcResponse, ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult,
-        ListToolsResult, PromptsCapability, ReadResourceResult, ResourceTemplate,
-        ResourcesCapability, ServerCapabilities, ToolsCapability,
+        ListToolsResult, PromptsCapability, ReadResourceResult, ResourcesCapability,
+        ServerCapabilities, ToolsCapability,
     },
     ResourceContents,
 };
@@ -94,6 +94,7 @@ pub trait Router: Send + Sync + 'static {
         arguments: Value,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<Content>, ToolError>> + Send + 'static>>;
     fn list_resources(&self) -> Vec<mcp_core::resource::Resource>;
+    fn list_resource_templates(&self) -> Vec<mcp_core::resource::ResourceTemplate>;
     fn read_resource(
         &self,
         uri: &str,
@@ -254,13 +255,7 @@ pub trait Router: Send + Sync + 'static {
         req: JsonRpcRequest,
     ) -> impl Future<Output = Result<JsonRpcResponse, RouterError>> + Send {
         async move {
-            // Default implementation - return a file template
-            let resource_templates = vec![ResourceTemplate {
-                uri_template: "file:///{path}".to_string(),
-                name: "Project Files".to_string(),
-                description: "Access files in the project directory".to_string(),
-                mime_type: "application/octet-stream".to_string(),
-            }];
+            let resource_templates = self.list_resource_templates();
 
             let result = ListResourceTemplatesResult { resource_templates };
 

--- a/crates/mcp-server/src/router.rs
+++ b/crates/mcp-server/src/router.rs
@@ -12,9 +12,9 @@ use mcp_core::{
     prompt::{Prompt, PromptMessage, PromptMessageRole},
     protocol::{
         CallToolResult, GetPromptResult, Implementation, InitializeResult, JsonRpcRequest,
-        JsonRpcResponse, ListPromptsResult, ListResourcesResult, ListToolsResult,
-        PromptsCapability, ReadResourceResult, ResourcesCapability, ServerCapabilities,
-        ToolsCapability,
+        JsonRpcResponse, ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult,
+        ListToolsResult, PromptsCapability, ReadResourceResult, ResourceTemplate,
+        ResourcesCapability, ServerCapabilities, ToolsCapability,
     },
     ResourceContents,
 };
@@ -255,18 +255,14 @@ pub trait Router: Send + Sync + 'static {
     ) -> impl Future<Output = Result<JsonRpcResponse, RouterError>> + Send {
         async move {
             // Default implementation - return a file template
-            let resource_templates = vec![
-                mcp_core::protocol::ResourceTemplate {
-                    uri_template: "file:///{path}".to_string(),
-                    name: "Project Files".to_string(),
-                    description: "Access files in the project directory".to_string(),
-                    mime_type: "application/octet-stream".to_string(),
-                },
-            ];
+            let resource_templates = vec![ResourceTemplate {
+                uri_template: "file:///{path}".to_string(),
+                name: "Project Files".to_string(),
+                description: "Access files in the project directory".to_string(),
+                mime_type: "application/octet-stream".to_string(),
+            }];
 
-            let result = mcp_core::protocol::ListResourceTemplatesResult {
-                resource_templates,
-            };
+            let result = ListResourceTemplatesResult { resource_templates };
 
             let mut response = self.create_response(req.id);
             response.result =

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -47,10 +47,9 @@ impl CounterRouter {
         &self,
         uri_template: &str,
         name: &str,
-        description: &str,
         mime_type: &str,
     ) -> ResourceTemplate {
-        ResourceTemplate::new(uri_template, name, description, mime_type)
+        ResourceTemplate::new(uri_template, name, mime_type).unwrap()
     }
 }
 
@@ -141,7 +140,6 @@ impl mcp_server::Router for CounterRouter {
         vec![self._create_resource_template(
             "file:///{path}",
             "Project Files",
-            "Access files in the project directory",
             "application/octet-stream",
         )]
     }

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -50,9 +50,10 @@ impl CounterRouter {
         mime_type: &str,
         description: &str,
     ) -> ResourceTemplate {
-        ResourceTemplate::new(uri_template, name, mime_type)
+        ResourceTemplate::new(uri_template, name)
             .unwrap()
             .with_description(description)
+            .with_mime_type(mime_type)
     }
 }
 

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -4,7 +4,7 @@ use mcp_core::{
     handler::{PromptError, ResourceError},
     prompt::{Prompt, PromptArgument},
     protocol::ServerCapabilities,
-    Content, Resource, Tool, ToolError,
+    Content, Resource, ResourceTemplate, Tool, ToolError,
 };
 use mcp_server::router::CapabilitiesBuilder;
 use serde_json::Value;
@@ -42,6 +42,16 @@ impl CounterRouter {
     fn _create_resource_text(&self, uri: &str, name: &str) -> Resource {
         Resource::new(uri, Some("text/plain".to_string()), Some(name.to_string())).unwrap()
     }
+
+    fn _create_resource_template(
+        &self,
+        uri_template: &str,
+        name: &str,
+        description: &str,
+        mime_type: &str,
+    ) -> ResourceTemplate {
+        ResourceTemplate::new(uri_template, name, description, mime_type)
+    }
 }
 
 impl mcp_server::Router for CounterRouter {
@@ -56,7 +66,7 @@ impl mcp_server::Router for CounterRouter {
     fn capabilities(&self) -> ServerCapabilities {
         CapabilitiesBuilder::new()
             .with_tools(false)
-            .with_resources(false, false)
+            .with_resources(false, false, false)
             .with_prompts(false)
             .build()
     }
@@ -125,6 +135,15 @@ impl mcp_server::Router for CounterRouter {
             self._create_resource_text("str:////Users/to/some/path/", "cwd"),
             self._create_resource_text("memo://insights", "memo-name"),
         ]
+    }
+
+    fn list_resource_templates(&self) -> Vec<ResourceTemplate> {
+        vec![self._create_resource_template(
+            "file:///{path}",
+            "Project Files",
+            "Access files in the project directory",
+            "application/octet-stream",
+        )]
     }
 
     fn read_resource(

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -48,8 +48,11 @@ impl CounterRouter {
         uri_template: &str,
         name: &str,
         mime_type: &str,
+        description: &str,
     ) -> ResourceTemplate {
-        ResourceTemplate::new(uri_template, name, mime_type).unwrap()
+        ResourceTemplate::new(uri_template, name, mime_type)
+            .unwrap()
+            .with_description(description)
     }
 }
 
@@ -141,6 +144,7 @@ impl mcp_server::Router for CounterRouter {
             "file:///{path}",
             "Project Files",
             "application/octet-stream",
+            "Access files in the project directory",
         )]
     }
 


### PR DESCRIPTION
Add server side resource template functionality

## Motivation and Context

The current implementation lacks resource templates functionality, which is referenced at https://spec.modelcontextprotocol.io/specification/2024-11-05/server/resources/#resource-templates. 
This feature would provide developers with the ability to standardize resource creation and management across implementations. Without resource templates, developers need to implement custom solutions for common resource patterns, leading to inconsistency and increased development overhead. Adding this functionality would improve standardization and reduce duplication of effort across different implementations of the specification.
This pull request aims to address this gap by proposing the addition of resource templates to the specification, which would benefit the community by providing a more complete and usable framework for model context management.

## How Has This Been Tested?

All added tests for the resource templates functionality are passing
All existing tests in the test suite continue to pass successfully
Verified that the counter_server example in the examples directory operates correctly when inspected with @modelcontextprotocol/inspector

## Breaking Changes

Yes

The signature of the with_resources method in CapabilitiesBuilder has been modified to accommodate resource templates functionality. The method now accepts an additional boolean parameter:

Previous implementation

```
CapabilitiesBuilder::new()
            .with_tools(false)
            .with_resources(false, false)
            .with_prompts(false)
            .build()
```

New implementation

```
CapabilitiesBuilder::new()
            .with_tools(false)
            .with_resources(false, false, false)
            .with_prompts(false)
            .build()
```

This change affects existing code that uses the CapabilitiesBuilder to configure resource capabilities. Projects using this builder pattern will need to update their implementation to include the additional parameter for resource templates support.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

