### PR TITLE
move RouterService to examples

### DIFF
--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -161,23 +161,20 @@ where
                             );
 
                             // Process the request using our service
-                            let response = match service.call(request).await {
-                                Ok(resp) => resp,
-                                Err(e) => {
-                                    let error_msg = e.into().to_string();
-                                    tracing::error!(error = %error_msg, "Request processing failed");
-                                    JsonRpcResponse {
-                                        jsonrpc: "2.0".to_string(),
-                                        id,
-                                        result: None,
-                                        error: Some(mcp_core::protocol::ErrorData {
-                                            code: mcp_core::protocol::INTERNAL_ERROR,
-                                            message: error_msg,
-                                            data: None,
-                                        }),
-                                    }
+                            let response = service.call(request).await.unwrap_or_else(|e| {
+                                let error_msg = e.into().to_string();
+                                tracing::error!(error = %error_msg, "Request processing failed");
+                                JsonRpcResponse {
+                                    jsonrpc: "2.0".to_string(),
+                                    id,
+                                    result: None,
+                                    error: Some(mcp_core::protocol::ErrorData {
+                                        code: mcp_core::protocol::INTERNAL_ERROR,
+                                        message: error_msg,
+                                        data: None,
+                                    }),
                                 }
-                            };
+                            });
 
                             // Serialize response for logging
                             let response_json = serde_json::to_string(&response)

--- a/examples/servers/Cargo.toml
+++ b/examples/servers/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
+tower-service = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"

--- a/examples/servers/src/axum.rs
+++ b/examples/servers/src/axum.rs
@@ -13,7 +13,6 @@ use tokio_util::codec::FramedRead;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use anyhow::Result;
-use mcp_server::router::RouterService;
 use std::sync::Arc;
 use tokio::{
     io::{self, AsyncWriteExt},
@@ -22,6 +21,7 @@ use tokio::{
 use tracing_subscriber::{self};
 mod common;
 use common::counter;
+use common::counter::RouterService;
 
 type C2SWriter = Arc<Mutex<io::WriteHalf<io::SimplexStream>>>;
 type SessionId = Arc<str>;

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -1,5 +1,4 @@
-use std::{future::Future, pin::Pin, sync::Arc};
-
+use mcp_core::protocol::{JsonRpcRequest, JsonRpcResponse};
 use mcp_core::{
     handler::{PromptError, ResourceError},
     prompt::{Prompt, PromptArgument},
@@ -7,8 +6,13 @@ use mcp_core::{
     Content, Resource, Tool, ToolError,
 };
 use mcp_server::router::CapabilitiesBuilder;
+use mcp_server::{BoxError, Router, RouterError};
 use serde_json::Value;
+use std::task::{Context, Poll};
+use std::{future::Future, pin::Pin, sync::Arc};
 use tokio::sync::Mutex;
+use tower_service::Service;
+
 
 #[derive(Clone)]
 pub struct CounterRouter {
@@ -179,6 +183,44 @@ impl mcp_server::Router for CounterRouter {
                     prompt_name
                 ))),
             }
+        })
+    }
+}
+
+pub struct RouterService<T>(pub T);
+
+impl<T> Service<JsonRpcRequest> for RouterService<T>
+where
+    T: Router + Clone + Send + Sync + 'static,
+{
+    type Response = JsonRpcResponse;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output =std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: JsonRpcRequest) -> Self::Future {
+        let this = self.0.clone();
+
+        Box::pin(async move {
+            let result = match req.method.as_str() {
+                "initialize" => this.handle_initialize(req).await,
+                "tools/list" => this.handle_tools_list(req).await,
+                "tools/call" => this.handle_tools_call(req).await,
+                "resources/list" => this.handle_resources_list(req).await,
+                "resources/read" => this.handle_resources_read(req).await,
+                "prompts/list" => this.handle_prompts_list(req).await,
+                "prompts/get" => this.handle_prompts_get(req).await,
+                _ => {
+                    let mut response = this.create_response(req.id);
+                    response.error = Some(RouterError::MethodNotFound(req.method).into());
+                    Ok(response)
+                }
+            };
+
+            result.map_err(BoxError::from)
         })
     }
 }

--- a/examples/servers/src/counter_server.rs
+++ b/examples/servers/src/counter_server.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use mcp_server::router::RouterService;
+use common::counter::RouterService;
 use mcp_server::{ByteTransport, Server};
 use tokio::io::{stdin, stdout};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Move an example from the core crate to the examples directory. Follows up on https://github.com/modelcontextprotocol/rust-sdk/issues/6 and https://github.com/modelcontextprotocol/rust-sdk/pull/10

Also a minor syntactical update to `crates/mcp-server/src/lib.rs` (can make the match expr more idiomatic)

## How Has This Been Tested?
It compiles and runs:
* `cargo run -p mcp-server-examples --example counter-server`
* `cargo run -p mcp-server-examples --example axum`

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
