### PR TITLE
fix: update transport command to use the correct example server

### DIFF
--- a/examples/clients/src/stdio_integration.rs
+++ b/examples/clients/src/stdio_integration.rs
@@ -24,10 +24,16 @@ async fn main() -> Result<(), ClientError> {
     // Create the transport
     let transport = StdioTransport::new(
         "cargo",
-        vec!["run", "-p", "mcp-server-examples", "--example", "counter-server"]
-            .into_iter()
-            .map(|s| s.to_string())
-            .collect(),
+        vec![
+            "run",
+            "-p",
+            "mcp-server-examples",
+            "--example",
+            "counter-server",
+        ]
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect(),
         HashMap::new(),
     );
 

--- a/examples/clients/src/stdio_integration.rs
+++ b/examples/clients/src/stdio_integration.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), ClientError> {
     // Create the transport
     let transport = StdioTransport::new(
         "cargo",
-        vec!["run", "-p", "mcp-server"]
+        vec!["run", "-p", "mcp-server-examples", "--example", "counter-server"]
             .into_iter()
             .map(|s| s.to_string())
             .collect(),


### PR DESCRIPTION
`stdio_integration` does not work if we just pass `run -p mcp-server`

Here is the log

```shell
❯ cargo run -p mcp-client-examples --example stdio_integration                                                                                                            
warning: /Users/situ/Codes/mcp-rust-sdk/examples/servers/Cargo.toml: version requirement `0.11.0+wasi-snapshot-preview1` for dependency `wasi` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/examples/stdio_integration`
2025-03-18T15:08:15.412701Z DEBUG mcp_client::transport::stdio: Sending outgoing message Request(JsonRpcRequest { jsonrpc: "2.0", id: Some(1), method: "initialize", params: Some(Object {"capabilities": Object {}, "clientInfo": Object {"name": String("test-client"), "version": String("1.0.0")}, "protocolVersion": String("1.0.0")}) })
2025-03-18T15:08:15.461832Z ERROR mcp_client::transport::stdio: Child process ended (EOF on stdout)
2025-03-18T15:08:15.461865Z DEBUG mcp_client::transport::stdio: Stdin handler completed: ()
2025-03-18T15:08:15.461880Z  INFO mcp_client::transport::stdio: Process stderr: error: a bin target must be available for `cargo run`

2025-03-18T15:08:15.461922Z DEBUG mcp_client::transport::stdio: Found error: StdioProcessError("error: a bin target must be available for `cargo run`\n")
Error: McpServerError { method: "initialize", server: "", source: ServerBoxError(StdioProcessError("error: a bin target must be available for `cargo run`\n")) }
```