### PR TITLE
Remove Send + Sync bounds

### DIFF
--- a/crates/mcp-core/src/handler.rs
+++ b/crates/mcp-core/src/handler.rs
@@ -39,7 +39,7 @@ pub enum PromptError {
 
 /// Trait for implementing MCP tools
 #[async_trait]
-pub trait ToolHandler: Send + Sync + 'static {
+pub trait ToolHandler: 'static {
     /// The name of the tool
     fn name(&self) -> &'static str;
 
@@ -55,7 +55,7 @@ pub trait ToolHandler: Send + Sync + 'static {
 
 /// Trait for implementing MCP resources
 #[async_trait]
-pub trait ResourceTemplateHandler: Send + Sync + 'static {
+pub trait ResourceTemplateHandler: 'static {
     /// The URL template for this resource
     fn template() -> &'static str;
 

--- a/crates/mcp-macros/src/lib.rs
+++ b/crates/mcp-macros/src/lib.rs
@@ -119,7 +119,7 @@ pub fn tool(args: TokenStream, input: TokenStream) -> TokenStream {
         #[derive(Default)]
         struct #struct_name;
 
-        #[async_trait::async_trait]
+        #[async_trait::async_trait(?Send)]
         impl mcp_core::handler::ToolHandler for #struct_name {
             fn name(&self) -> &'static str {
                 #tool_name

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -127,9 +127,8 @@ pub struct Server<S> {
 
 impl<S> Server<S>
 where
-    S: Service<JsonRpcRequest, Response = JsonRpcResponse> + Send,
+    S: Service<JsonRpcRequest, Response = JsonRpcResponse>,
     S::Error: Into<BoxError>,
-    S::Future: Send,
 {
     pub fn new(service: S) -> Self {
         Self { service }
@@ -166,23 +165,20 @@ where
                             );
 
                             // Process the request using our service
-                            let response = match service.call(request).await {
-                                Ok(resp) => resp,
-                                Err(e) => {
-                                    let error_msg = e.into().to_string();
-                                    tracing::error!(error = %error_msg, "Request processing failed");
-                                    JsonRpcResponse {
-                                        jsonrpc: "2.0".to_string(),
-                                        id,
-                                        result: None,
-                                        error: Some(mcp_core::protocol::ErrorData {
-                                            code: mcp_core::protocol::INTERNAL_ERROR,
-                                            message: error_msg,
-                                            data: None,
-                                        }),
-                                    }
+                            let response = service.call(request).await.unwrap_or_else(|e| {
+                                let error_msg = e.into().to_string();
+                                tracing::error!(error = %error_msg, "Request processing failed");
+                                JsonRpcResponse {
+                                    jsonrpc: "2.0".to_string(),
+                                    id,
+                                    result: None,
+                                    error: Some(mcp_core::protocol::ErrorData {
+                                        code: mcp_core::protocol::INTERNAL_ERROR,
+                                        message: error_msg,
+                                        data: None,
+                                    }),
                                 }
-                            };
+                            });
 
                             // Serialize response for logging
                             let response_json = serde_json::to_string(&response)

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -97,7 +97,7 @@ impl mcp_server::Router for CounterRouter {
         &self,
         tool_name: &str,
         _arguments: Value,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Content>, ToolError>> + Send + 'static>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Content>, ToolError>> + 'static>> {
         let this = self.clone();
         let tool_name = tool_name.to_string();
 
@@ -130,7 +130,7 @@ impl mcp_server::Router for CounterRouter {
     fn read_resource(
         &self,
         uri: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<String, ResourceError>> + Send + 'static>> {
+    ) -> Pin<Box<dyn Future<Output = Result<String, ResourceError>> + 'static>> {
         let uri = uri.to_string();
         Box::pin(async move {
             match uri.as_str() {
@@ -166,7 +166,7 @@ impl mcp_server::Router for CounterRouter {
     fn get_prompt(
         &self,
         prompt_name: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<String, PromptError>> + Send + 'static>> {
+    ) -> Pin<Box<dyn Future<Output = Result<String, PromptError>> + 'static>> {
         let prompt_name = prompt_name.to_string();
         Box::pin(async move {
             match prompt_name.as_str() {


### PR DESCRIPTION
In the interest of starting PRs rather than more issues, I'd like to use this PR discuss whether we use `Send + Sync` bounds everywhere.

## Motivation and Context
There's a fair bit of writing on how async Rust becomes more elegant without `Send + Sync` everywhere [[1]] [[2]], some discussion [[3]], and for balance some disagreement too [[4]]. Ultimately, these bounds are only required because tokio is a work-stealing multi-OS-threaded executor. Their unfortunate side effect is you need to use `Arc`s and `Mutex`es everywhere.

In my fork (which I'll break down and PR up), I've been experimenting with injecting state structs into tool handlers (discussion [here](https://github.com/modelcontextprotocol/rust-sdk/issues/31#issuecomment-2736285245)). One thing I did to make life easier while POC'ing was remove the `Send + Sync` bounds. Aside from making the internal code nicer, more importantly, it made the application code easier to write.

I wonder whether we should have them at all. I'd expect workloads to be primarily IO bound. In which case, running a non-work-stealing executor (or tokio in local mode with, say, a `LocalSet`) should let us get rid of the `Send`, and if it's single-threaded then the `Sync` can go too. That would mean user code can also avoid `Arc` and `Mutex` if they don't need it. There's also some inspiration from actix-web here, with [their individual workers](https://docs.rs/actix-web/latest/actix_web/rt/index.html) using single-threaded runtimes, and the application being able to opt in to multiple workers / shared state across workers if it wishes (and if so, they'd then need to be `Send + Sync` on the state), see [here](https://actix.rs/docs/application#shared-mutable-state).

The cost of futures would no longer work with the work-stealing functionality of the runtime.

## How Has This Been Tested?
`counter_server` compiles and runs. The axum example does not. I think it can be modified to work though.

## Breaking Changes
Yes, but we're pre-alpha!

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

[1]: https://emschwartz.me/async-rust-can-be-a-pleasure-to-work-with-without-send-sync-static/
[2]: https://maciej.codes/2022-06-09-local-async.html
[3]: https://blog.yoshuawuyts.com/tasks-are-the-wrong-abstraction/
[4]: https://without.boats/blog/thread-per-core/