### PR TITLE
refactor(sse_server): separate router and server startup

### DIFF
--- a/crates/rmcp/src/transport/sse_server.rs
+++ b/crates/rmcp/src/transport/sse_server.rs
@@ -237,6 +237,8 @@ impl SseServer {
         Ok(sse_server)
     }
 
+    /// Warning: This function creates a new SseServer instance with the provided configuration.
+    /// `App.post_path` may be incorrect if using `Router` as an embedded router.
     pub fn new(config: SseServerConfig) -> (SseServer, Router) {
         let (app, transport_rx) = App::new(config.post_path.clone());
         let router = Router::new()

--- a/examples/servers/Cargo.toml
+++ b/examples/servers/Cargo.toml
@@ -34,3 +34,7 @@ path = "src/std_io.rs"
 [[example]]
 name = "axum"
 path = "src/axum.rs"
+
+[[example]]
+name = "axum_router"
+path = "src/axum_router.rs"

--- a/examples/servers/src/axum_router.rs
+++ b/examples/servers/src/axum_router.rs
@@ -24,14 +24,16 @@ async fn main() -> anyhow::Result<()> {
         ct: tokio_util::sync::CancellationToken::new(),
     };
 
-    let (sse_server, router) = SseServer::new(&config);
+    let (sse_server, router) = SseServer::new(config);
 
     // Do something with the router, e.g., add routes or middleware
 
-    let listener = tokio::net::TcpListener::bind(config.bind).await?;
+    let listener = tokio::net::TcpListener::bind(sse_server.config.bind).await?;
+
+    let ct = sse_server.config.ct.child_token();
 
     let server = axum::serve(listener, router).with_graceful_shutdown(async move {
-        config.ct.cancelled().await;
+        ct.cancelled().await;
         tracing::info!("sse server cancelled");
     });
 

--- a/examples/servers/src/axum_router.rs
+++ b/examples/servers/src/axum_router.rs
@@ -1,0 +1,49 @@
+use rmcp::transport::sse_server::{SseServer, SseServerConfig};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use tracing_subscriber::{self};
+mod common;
+use common::counter::Counter;
+
+const BIND_ADDRESS: &str = "127.0.0.1:8000";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "debug".to_string().into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let config = SseServerConfig {
+        bind: BIND_ADDRESS.parse()?,
+        sse_path: "/sse".to_string(),
+        post_path: "/message".to_string(),
+        ct: tokio_util::sync::CancellationToken::new(),
+    };
+
+    let (sse_server, router) = SseServer::new(&config);
+
+    // Do something with the router, e.g., add routes or middleware
+
+    let listener = tokio::net::TcpListener::bind(config.bind).await?;
+
+    let server = axum::serve(listener, router).with_graceful_shutdown(async move {
+        config.ct.cancelled().await;
+        tracing::info!("sse server cancelled");
+    });
+
+    tokio::spawn(async move {
+        if let Err(e) = server.await {
+            tracing::error!(error = %e, "sse server shutdown with error");
+        }
+    });
+
+    let ct = sse_server.with_service(Counter::new);
+
+    tokio::signal::ctrl_c().await?;
+    ct.cancel();
+    Ok(())
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->  
This PR refactors SSE server initialization by separating router creation from server startup. Added `SseServer::new()` method to create router and server instance independently.

---

## Motivation and Context  
<!-- Why is this change needed? What problem does it solve? -->  
**Problem**: The original implementation coupled server startup (`serve_with_config`) with router creation, making it hard to test or reuse the router configuration.  
**Solution**: Introduced a factory method `SseServer::new()` that:  
1. Decouples router/state creation from server execution  
2. Enables reusing the router configuration in tests  
3. Allows pre-building services before binding ports

---

## How Has This Been Tested?  
<!-- Have you tested this in a real application? Which scenarios were tested? -->  

---

## Breaking Changes  
<!-- Will users need to update their code or configurations? -->  
**No breaking changes**

---

## Types of Changes  
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

---

## Checklist  
<!-- Put an `x` in all the boxes that apply: -->  
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

---

## Additional Context  
<!-- Add any other context or design decisions -->  
