### PR TITLE
Use `rust-cache` instead of `actions/cache` for better CI performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -93,15 +85,7 @@ jobs:
       - name: Create venv for python
         run: uv venv
         
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --all-features
@@ -117,15 +101,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Cargo login
         run: cargo login ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Replace `actions/cache` with `rust-cache`

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

rust-cache (https://github.com/Swatinem/rust-cache) not only caches necessary files and directories such as `~/.cargo` and `target`, but also removes unused dependencies before caching. Additionally, it disables incremental compilation `CARGO_INCREMENTAL=0`, which is unnecessary for CI environments.

rust-cache is used in large Rust open-source software projects such as axum and others.
ref: https://github.com/tokio-rs/axum/blob/cd2d5e1417e82b6fdc69c84847e438d9b37cd6a2/.github/workflows/CI.yml#L21

I confirmed that rust-cache works in an empty commit, which was removed.

```
... Restoring cache ...
Cache hit for: v0-rust-test-Linux-x64-c733e78c-c821e4bd
Received 134217728 of 288542975 (46.5%), 127.5 MBs/sec
Received 288542975 of 288542975 (100.0%), 153.9 MBs/sec
Cache Size: ~275 MB (288542975 B)
```

With caching, the execution time of the "Rust tests" job has been reduced from 1m 54s (without cache) to 1m 16s (with cache).

- With cache (1m 16s) https://github.com/modelcontextprotocol/rust-sdk/actions/runs/14146152574
- Without cache (1m 54s) https://github.com/modelcontextprotocol/rust-sdk/actions/runs/14146111023

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
