### PR TITLE
test: add test with js server

### DIFF
--- a/crates/rmcp/tests/test_with_js.rs
+++ b/crates/rmcp/tests/test_with_js.rs
@@ -1,4 +1,7 @@
-use rmcp::transport::sse_server::SseServer;
+use rmcp::{
+    ServiceExt,
+    transport::{SseServer, TokioChildProcess},
+};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 mod common;
 use common::calculator::Calculator;
@@ -32,5 +35,34 @@ async fn test_with_js_client() -> anyhow::Result<()> {
         .await?;
     assert!(exit_status.success());
     ct.cancel();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_with_js_server() -> anyhow::Result<()> {
+    let _ = tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "debug".to_string().into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .try_init();
+    tokio::process::Command::new("npm")
+        .arg("install")
+        .current_dir("tests/test_with_js")
+        .spawn()?
+        .wait()
+        .await?;
+    let transport = TokioChildProcess::new(
+        tokio::process::Command::new("node").arg("tests/test_with_js/server.js"),
+    )?;
+
+    let client = ().serve(transport).await?;
+    let resources = client.list_all_resources().await?;
+    tracing::info!("{:#?}", resources);
+    let tools = client.list_all_tools().await?;
+    tracing::info!("{:#?}", tools);
+
+    client.cancel().await?;
     Ok(())
 }

--- a/crates/rmcp/tests/test_with_js/package.json
+++ b/crates/rmcp/tests/test_with_js/package.json
@@ -6,7 +6,6 @@
   "name": "test_with_ts",
   "version": "1.0.0",
   "main": "index.js",
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/crates/rmcp/tests/test_with_js/server.js
+++ b/crates/rmcp/tests/test_with_js/server.js
@@ -1,0 +1,35 @@
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const server = new McpServer({
+  name: "Demo",
+  version: "1.0.0"
+});
+
+server.resource(
+  "greeting",
+  new ResourceTemplate("greeting://{name}", { list: undefined }),
+  async (uri, { name }) => ({
+    contents: [{
+      uri: uri.href,
+      text: `Hello, ${name}`
+    }]
+  })
+);
+
+server.tool(
+  "add",
+  { a: z.number(), b: z.number() },
+  async ({ a, b }) => ({
+    "content": [
+      {
+        "type": "text",
+        "text": `${a + b}`
+      }
+    ]
+  })
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
I would like to contribute to the sdk by doing simple things, adding test case for server mcp for javascript test, just like the python counterpart. But I have no idea why the test case failing.

<details><summary>JS Server Test Case Log</summary>
<p>

```
2025-03-30T08:49:34.118421Z  INFO serve_inner: rmcp::service: Service initialized as client peer_info=InitializeResult { protocol_version: ProtocolVersion("2024-11-05"), capabilities: ServerCapabilities { experimental: None, logging: None, prompts: None, resources: Some(ResourcesCapability { subscribe: None, list_changed: None }), tools: Some(ToolsCapability { list_changed: None }) }, server_info: Implementation { name: "Demo", version: "1.0.0" }, instructions: None }
2025-03-30T08:49:34.118836Z DEBUG rmcp::service: new event evt=ProxyMessage(Request(ListResourcesRequest(Request { method: ListResourcesRequestMethod, params: Some(PaginatedRequestParamInner { cursor: None }) }), Number(1), Sender { inner: Some(Inner { state: State { is_complete: false, is_closed: false, is_rx_task_set: true, is_tx_task_set: false } }) }))
2025-03-30T08:49:34.119635Z DEBUG rmcp::service: new event evt=PeerMessage(Response(ListResourcesResult(ListResourcesResult { next_cursor: None, resources: [] }), Number(1)))
2025-03-30T08:49:34.119704Z  INFO test_with_js: []
2025-03-30T08:49:34.119723Z DEBUG rmcp::service: new event evt=ProxyMessage(Request(ListToolsRequest(Request { method: ListToolsRequestMethod, params: Some(PaginatedRequestParamInner { cursor: None }) }), Number(2), Sender { inner: Some(Inner { state: State { is_complete: false, is_closed: false, is_rx_task_set: true, is_tx_task_set: false } }) }))
2025-03-30T08:49:34.120690Z DEBUG rmcp::service: new event evt=PeerMessage(Response(EmptyResult(EmptyObject), Number(2)))
test test_with_js_server ... FAILED

failures:

---- test_with_js_server stdout ----
Error: Unexpected response type


failures:
    test_with_js_server
```

</p>
</details> 

<details><summary>Python Server Test Case Log</summary>
<p>

```
2025-03-30T08:27:11.016214Z  INFO serve_inner: rmcp::service: Service initialized as client peer_info=InitializeResult { protocol_version: ProtocolVersion("2024-11-05"), capabilities: ServerCapabilities { experimental: Some({}), logging: None, prompts: Some(PromptsCapability { list_changed: Some(false) }), resources: Some(ResourcesCapability { subscribe: Some(false), list_changed: Some(false) }), tools: Some(ToolsCapability { list_changed: Some(false) }) }, server_info: Implementation { name: "Demo", version: "1.6.0" }, instructions: None }

2025-03-30T08:27:11.016504Z DEBUG rmcp::service: new event evt=ProxyMessage(Request(ListResourcesRequest(Request { method: ListResourcesRequestMethod, params: Some(PaginatedRequestParamInner { cursor: None }) }), Number(1), Sender { inner: Some(Inner { state: State { is_complete: false, is_closed: false, is_rx_task_set: true, is_tx_task_set: false } }) }))
[03/30/25 15:27:11] INFO     Processing request of type ListResourcesRequest                                                                           server.py:534
2025-03-30T08:27:11.019780Z DEBUG rmcp::service: new event evt=PeerMessage(Response(ListResourcesResult(ListResourcesResult { next_cursor: None, resources: [] }), Number(1)))
2025-03-30T08:27:11.019835Z  INFO test_with_python: []

2025-03-30T08:27:11.019854Z DEBUG rmcp::service: new event evt=ProxyMessage(Request(ListToolsRequest(Request { method: ListToolsRequestMethod, params: Some(PaginatedRequestParamInner { cursor: None }) }), Number(2), Sender { inner: Some(Inner { state: State { is_complete: false, is_closed: false, is_rx_task_set: true, is_tx_task_set: false } }) }))

                    INFO     Processing request of type ListToolsRequest                                                                               server.py:534
2025-03-30T08:27:11.021136Z DEBUG rmcp::service: new event evt=PeerMessage(Response(ListToolsResult(ListToolsResult { next_cursor: None, tools: [Tool { name: "add", description: "Add two numbers", input_schema: {"properties": Object {"a": Object {"title": String("A"), "type": String("integer")}, "b": Object {"title": String("B"), "type": String("integer")}}, "required": Array [String("a"), String("b")], "title": String("addArguments"), "type": String("object")} }] }), Number(2)))
2025-03-30T08:27:11.021182Z  INFO test_with_python: [
    Tool {
        name: "add",
        description: "Add two numbers",
        input_schema: {
            "properties": Object {
                "a": Object {
                    "title": String("A"),
                    "type": String("integer"),
                },
                "b": Object {
                    "title": String("B"),
                    "type": String("integer"),
                },
            },
            "required": Array [
                String("a"),
                String("b"),
            ],
            "title": String("addArguments"),
            "type": String("object"),
        },
    },
]
2025-03-30T08:27:11.021236Z  INFO rmcp::service: task cancelled
2025-03-30T08:27:11.021244Z  INFO rmcp::service: serve finished quit_reason=Cancelled
```

</p>
</details> 

Testing using MCP Inspector works fine

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/c5b6546d-f7db-4a4d-b181-bf8908d3c452" />

Did I miss anything?

## How Has This Been Tested?
By running the test case

## Breaking Changes
n/a

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
