### PR TITLE
chore: reduce noisy logging

### DIFF
--- a/crates/rmcp/src/transport/sse_server.rs
+++ b/crates/rmcp/src/transport/sse_server.rs
@@ -90,7 +90,7 @@ async fn sse_handler(
     State(app): State<App>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, io::Error>>>, Response<String>> {
     let session = session_id();
-    tracing::info!(%session, "sse connection");
+    tracing::debug!(%session, "sse connection");
     use tokio_stream::{StreamExt, wrappers::ReceiverStream};
     use tokio_util::sync::PollSender;
     let (from_client_tx, from_client_rx) = tokio::sync::mpsc::channel(64);
@@ -232,7 +232,7 @@ impl SseServer {
         let ct = sse_server.config.ct.child_token();
         let server = axum::serve(listener, service).with_graceful_shutdown(async move {
             ct.cancelled().await;
-            tracing::info!("sse server cancelled");
+            tracing::debug!("sse server cancelled");
         });
         tokio::spawn(
             async move {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
For our users, it's not super polite to spam log messages for everything that happens in the MCP server. We should make these to the debug level, including one warning that was about LLM hallucinating more than anything being seriously broken in the MCP server.

The info/warn/error channels should be more quiet, because in a busy server they will hide actually important logs.

## How Has This Been Tested?
Tried it out in our server, saw reduced amount of logs.

## Breaking Changes
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

If this is not what you want, let's work together to calm down the logs a bit. It's rough to fork a project this early and then rebase fixes every week...
