### PR TITLE
Upgrade Rust 1.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [workspace]
 members = ["crates/rmcp", "crates/rmcp-macros", "examples/*"]
 resolver = "2"
@@ -15,10 +13,7 @@ authors = ["4t145 <u4t145@163.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/modelcontextprotocol/rust-sdk/"
 description = "Rust SDK for Model Context Protocol"
-keywords = ["mcp", "sdk", "tokio", "modelcontextprotocol"]
+keywords = ["mcp", "modelcontextprotocol", "sdk", "tokio"]
 homepage = "https://github.com/modelcontextprotocol/rust-sdk"
-categories = [
-    "network-programming",
-    "asynchronous",
-]
+categories = ["asynchronous", "network-programming"]
 readme = "README.md"

--- a/crates/rmcp-macros/Cargo.toml
+++ b/crates/rmcp-macros/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "rmcp-macros"
 license = { workspace = true }
@@ -15,7 +13,7 @@ documentation = "https://docs.rs/rmcp-macros"
 proc-macro = true
 
 [dependencies]
-syn = {version = "2", features = ["full"]}
+syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 

--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "rmcp"
 license = { workspace = true }
@@ -19,7 +17,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "2"
 chrono = { version = "0.4.38", features = ["serde"] }
-tokio = { version = "1", features = ["sync", "macros", "rt", "time"] }
+tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 futures = "0.3"
 tracing = { version = "0.1" }
 tokio-util = { version = "0.7" }
@@ -35,8 +33,8 @@ base64 = { version = "0.21", optional = true }
 # for SSE client
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
-    "stream",
     "rustls-tls",
+    "stream",
 ], optional = true }
 sse-stream = { version = "0.1.3", optional = true }
 url = { version = "2.4", optional = true }
@@ -54,22 +52,22 @@ rand = { version = "0.9", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 
 # macro
-rmcp-macros = { version = "0.1", workspace = true, optional = true }
+rmcp-macros = { workspace = true, optional = true }
 
 [features]
 default = ["base64", "macros", "server"]
 client = []
-server = ["transport-async-rw", "dep:schemars"]
-macros = ["dep:rmcp-macros", "dep:paste"]
+server = ["dep:schemars", "transport-async-rw"]
+macros = ["dep:paste", "dep:rmcp-macros"]
 transport-sse = ["dep:reqwest", "dep:sse-stream", "dep:url"]
-transport-async-rw = ["tokio/io-util", "tokio-util/codec"]
-transport-io = ["transport-async-rw", "tokio/io-std"]
-transport-child-process = ["transport-async-rw", "tokio/process"]
+transport-async-rw = ["tokio-util/codec", "tokio/io-util"]
+transport-io = ["tokio/io-std", "transport-async-rw"]
+transport-child-process = ["tokio/process", "transport-async-rw"]
 transport-sse-server = [
-    "transport-async-rw",
     "dep:axum",
     "dep:rand",
     "dep:tokio-stream",
+    "transport-async-rw",
 ]
 # transport-ws = ["transport-io", "dep:tokio-tungstenite"]
 tower = ["dep:tower-service"]
@@ -80,8 +78,8 @@ schemars = { version = "0.8" }
 anyhow = "1.0"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
-    "std",
     "fmt",
+    "std",
 ] }
 [[test]]
 name = "test_tool_macros"
@@ -90,7 +88,13 @@ path = "tests/test_tool_macros.rs"
 
 [[test]]
 name = "test_with_python"
-required-features = ["server", "client", "transport-sse-server", "transport-sse", "transport-child-process"]
+required-features = [
+    "client",
+    "server",
+    "transport-child-process",
+    "transport-sse",
+    "transport-sse-server",
+]
 path = "tests/test_with_python.rs"
 
 [[test]]

--- a/examples/clients/Cargo.toml
+++ b/examples/clients/Cargo.toml
@@ -1,17 +1,15 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "mcp-client-examples"
 version = "0.1.5"
-edition = "2024"
+edition = { workspace = true }
 publish = false
 
 [dependencies]
 rmcp = { path = "../../crates/rmcp", features = [
     "client",
-    "transport-sse",
+    "tower",
     "transport-child-process",
-    "tower"
+    "transport-sse",
 ] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -39,4 +37,3 @@ path = "src/everything_stdio.rs"
 [[example]]
 name = "collection"
 path = "src/collection.rs"
-

--- a/examples/rig-integration/Cargo.toml
+++ b/examples/rig-integration/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "rig-integration"
 edition = { workspace = true }
@@ -20,7 +18,7 @@ rmcp = { path = "../../crates/rmcp", features = [
     "client",
     "transport-child-process",
     "transport-sse",
-], no-default-features = true }
+] }
 anyhow = "1.0"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/examples/servers/Cargo.toml
+++ b/examples/servers/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "mcp-server-examples"
 version = "0.1.5"
@@ -7,16 +5,26 @@ edition = "2024"
 publish = false
 
 [dependencies]
-rmcp= { path = "../../crates/rmcp", features = ["server", "transport-sse-server", "transport-io"] }
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-std", "signal"] }
+rmcp = { path = "../../crates/rmcp", features = [
+    "server",
+    "transport-io",
+    "transport-sse-server",
+] }
+tokio = { version = "1", features = [
+    "io-std",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "signal",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
-    "std",
     "fmt",
+    "std",
 ] }
 futures = "0.3"
 rand = { version = "0.9" }

--- a/examples/transport/Cargo.toml
+++ b/examples/transport/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "transport"
 edition = { workspace = true }
@@ -17,14 +15,14 @@ readme = { workspace = true }
 all-features = true
 
 [dependencies]
-rmcp = { path = "../../crates/rmcp", features = ["server", "client"] }
+rmcp = { path = "../../crates/rmcp", features = ["client", "server"] }
 tokio = { version = "1", features = [
+    "fs",
+    "io-std",
     "macros",
+    "net",
     "rt",
     "rt-multi-thread",
-    "io-std",
-    "net",
-    "fs",
     "time",
 ] }
 serde = { version = "1.0", features = ["derive"] }
@@ -33,13 +31,13 @@ anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
-    "std",
     "fmt",
+    "std",
 ] }
 futures = "0.3"
 rand = { version = "0.8" }
 schemars = { version = "0.8", optional = true }
-hyper = { version = "1", features = ["client", "server", "http1"] }
+hyper = { version = "1", features = ["client", "http1", "server"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 tokio-tungstenite = "0.26.2"
 reqwest = { version = "0.12" }

--- a/examples/wasi/Cargo.toml
+++ b/examples/wasi/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "wasi"
 edition = { workspace = true }
@@ -17,13 +15,19 @@ readme = { workspace = true }
 crate-type = ["cdylib"]
 
 [dependencies]
-wasi = { version = "0.14.2+wasi-0.2.4"}
-tokio = { version = "1", features = ["rt", "io-util", "sync", "macros", "time"] }
-rmcp= { path = "../../crates/rmcp", features = ["server", "macros"] }
-serde = { version  = "1", features = ["derive"]}
+wasi = { version = "0.14.2" }
+tokio = { version = "1", features = [
+    "io-util",
+    "macros",
+    "rt",
+    "sync",
+    "time",
+] }
+rmcp = { path = "../../crates/rmcp", features = ["macros", "server"] }
+serde = { version = "1", features = ["derive"] }
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
-    "std",
     "fmt",
+    "std",
 ] }
 tracing = "0.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"
-components = ["rustc", "rust-std", "cargo", "clippy", "rustfmt", "rust-docs"]
+channel = "1.86"
+components = ["cargo", "clippy", "rust-docs", "rust-std", "rustc", "rustfmt"]


### PR DESCRIPTION
# Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Upgraded Rust version to 1.86.
Fixed code according to new Clippy lints introduced in this version.
Also removed warnings shown during cargo clippy.

# How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tested locally using Rust 1.86.
Confirmed all tests pass with cargo test and no warnings from cargo clippy.

# Breaking Changes
<!-- Will users need to update their code or configurations? -->

No breaking changes in functionality.
However, developers will need to use Rust 1.86 or later.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed