### PR TITLE
Upgrade Rust 1.86

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -54,7 +54,7 @@ rand = { version = "0.9", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 
 # macro
-rmcp-macros = { version = "0.1", workspace = true, optional = true }
+rmcp-macros = { workspace = true, optional = true }
 
 [features]
 default = ["base64", "macros", "server"]

--- a/examples/rig-integration/Cargo.toml
+++ b/examples/rig-integration/Cargo.toml
@@ -18,7 +18,7 @@ rmcp = { path = "../../crates/rmcp", features = [
     "client",
     "transport-child-process",
     "transport-sse",
-], no-default-features = true }
+] }
 anyhow = "1.0"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/examples/wasi/Cargo.toml
+++ b/examples/wasi/Cargo.toml
@@ -17,7 +17,7 @@ readme = { workspace = true }
 crate-type = ["cdylib"]
 
 [dependencies]
-wasi = { version = "0.14.2+wasi-0.2.4"}
+wasi = { version = "0.14.2"}
 tokio = { version = "1", features = ["rt", "io-util", "sync", "macros", "time"] }
 rmcp= { path = "../../crates/rmcp", features = ["server", "macros"] }
 serde = { version  = "1", features = ["derive"]}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"
-components = ["rustc", "rust-std", "cargo", "clippy", "rustfmt", "rust-docs"]
+channel = "1.86"
+components = ["cargo", "clippy", "rust-docs", "rust-std", "rustc", "rustfmt"]


### PR DESCRIPTION
# Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Upgraded Rust version to 1.86.
Fixed code according to new Clippy lints introduced in this version.
Also removed warnings shown during cargo check.

# How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tested locally using Rust 1.86.
Confirmed all tests pass with cargo test and no warnings from cargo check.

# Breaking Changes
<!-- Will users need to update their code or configurations? -->

No breaking changes in functionality.
However, developers will need to use Rust 1.86 or later.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed