### PR TITLE
Add Claude desktop quick start and update Cargo.toml of examples/servers, examples/clients

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,4 @@
-# Quick Start With Cluade Desktop
+# Quick Start With Claude Desktop
 
 1. **Build the Server (Counter Example)**
     ```sh

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,34 @@
+# Quick Start With Cluade Desktop
+
+1. **Build the Server (Counter Example)**
+    ```sh
+    cargo build --release --example servers_std_io
+    ```
+    This builds a standard input/output MCP server binary.
+
+2. **Add or update this section in your** `~/.config/claude-desktop/config.toml`
+    ```json
+    {
+        "mcpServers": {
+            "counter": {
+            "command": "PATH-TO/rust-sdk/target/release/examples/servers_std_io.exe",
+            "args": []
+            }
+        }
+    }
+    ```
+
+3. **Once Claude Desktop is running, try chatting:**
+    ```text
+    counter.say_hello
+    ```
+    Or test other tools like:
+    ```text
+    counter.increment
+    counter.get_value
+    counter.sum {"a": 3, "b": 4}
+    ```
+
 # Client Examples
 
 - [Client SSE](clients/src/sse.rs), using reqwest and eventsource-client.

--- a/examples/clients/Cargo.toml
+++ b/examples/clients/Cargo.toml
@@ -25,18 +25,18 @@ anyhow = "1.0"
 tower = "0.5"
 
 [[example]]
-name = "sse"
+name = "clients_sse"
 path = "src/sse.rs"
 
 [[example]]
-name = "std_io"
+name = "clients_std_io"
 path = "src/std_io.rs"
 
 [[example]]
-name = "everything_stdio"
+name = "clients_everything_stdio"
 path = "src/everything_stdio.rs"
 
 [[example]]
-name = "collection"
+name = "clients_collection"
 path = "src/collection.rs"
 

--- a/examples/servers/Cargo.toml
+++ b/examples/servers/Cargo.toml
@@ -30,13 +30,13 @@ tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7", features = ["codec"] }
 
 [[example]]
-name = "std_io"
+name = "servers_std_io"
 path = "src/std_io.rs"
 
 [[example]]
-name = "axum"
+name = "servers_axum"
 path = "src/axum.rs"
 
 [[example]]
-name = "axum_router"
+name = "servers_axum_router"
 path = "src/axum_router.rs"


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add quick-start documentation for using MCP `counter` example with Claude Desktop.
Improves onboarding for developers testing custom MCP servers with Claude.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Currently, there's no example in the documentation on how to configure and run a custom MCP Rust server with Claude Desktop. 
This PR adds a clear step-by-step guide to help users build, configure, and interact with the `counter` example via Claude Desktop.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Currently, there's no example in the documentation on how to configure and run a custom MCP Rust server with Claude Desktop. 
This PR adds a clear step-by-step guide to help users build, configure, and interact with the `counter` example via Claude Desktop.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Tested locally on:
- Windows 11
- Claude Desktop v0.9.1
- Verified that counter.say_hello, counter.increment, counter.get_value, and counter.sum work via Claude chat UI

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Updated the config in `Cargo.toml` of `examples/servers` and `examples/clients`
