### PR TITLE
test(context): test context requests 

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -80,6 +80,7 @@ tracing-subscriber = { version = "0.3", features = [
     "std",
     "fmt",
 ] }
+async-trait = "0.1"
 [[test]]
 name = "test_tool_macros"
 required-features = ["server"]
@@ -104,4 +105,9 @@ path = "tests/test_notification.rs"
 name = "test_logging"
 required-features = ["server", "client"]
 path = "tests/test_logging.rs"
+
+[[test]]
+name = "test_message_protocol"
+required-features = ["client"]
+path = "tests/test_message_protocol.rs"
 

--- a/crates/rmcp/src/handler/client.rs
+++ b/crates/rmcp/src/handler/client.rs
@@ -84,6 +84,7 @@ pub trait ClientHandler: Sized + Send + Sync + 'static {
             McpError::method_not_found::<CreateMessageRequestMethod>(),
         ))
     }
+
     fn list_roots(
         &self,
         context: RequestContext<RoleClient>,

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -660,6 +660,16 @@ pub struct SamplingMessage {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum ContextInclusion {
+    #[serde(rename = "allServers")]
+    AllServers,
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "thisServer")]
+    ThisServer,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateMessageRequestParam {
     pub messages: Vec<SamplingMessage>,
@@ -668,7 +678,7 @@ pub struct CreateMessageRequestParam {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub include_context: Option<String>,
+    pub include_context: Option<ContextInclusion>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
     pub max_tokens: u32,

--- a/crates/rmcp/tests/common/handlers.rs
+++ b/crates/rmcp/tests/common/handlers.rs
@@ -1,0 +1,193 @@
+use std::{
+    future::Future,
+    sync::{Arc, Mutex},
+};
+
+use rmcp::{
+    ClientHandler, Error as McpError, RoleClient, RoleServer, ServerHandler,
+    model::*,
+    service::{Peer, RequestContext},
+};
+use serde_json::json;
+use tokio::sync::Notify;
+
+#[derive(Clone)]
+pub struct TestClientHandler {
+    pub peer: Option<Peer<RoleClient>>,
+    pub honor_this_server: bool,
+    pub honor_all_servers: bool,
+    pub receive_signal: Arc<Notify>,
+    pub received_messages: Arc<Mutex<Vec<LoggingMessageNotificationParam>>>,
+}
+
+impl TestClientHandler {
+    #[allow(dead_code)]
+    pub fn new(honor_this_server: bool, honor_all_servers: bool) -> Self {
+        Self {
+            peer: None,
+            honor_this_server,
+            honor_all_servers,
+            receive_signal: Arc::new(Notify::new()),
+            received_messages: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn with_notification(
+        honor_this_server: bool,
+        honor_all_servers: bool,
+        receive_signal: Arc<Notify>,
+        received_messages: Arc<Mutex<Vec<LoggingMessageNotificationParam>>>,
+    ) -> Self {
+        Self {
+            peer: None,
+            honor_this_server,
+            honor_all_servers,
+            receive_signal,
+            received_messages,
+        }
+    }
+}
+
+impl ClientHandler for TestClientHandler {
+    fn get_peer(&self) -> Option<Peer<RoleClient>> {
+        self.peer.clone()
+    }
+
+    fn set_peer(&mut self, peer: Peer<RoleClient>) {
+        self.peer = Some(peer);
+    }
+
+    async fn create_message(
+        &self,
+        params: CreateMessageRequestParam,
+        _context: RequestContext<RoleClient>,
+    ) -> Result<CreateMessageResult, McpError> {
+        // First validate that there's at least one User message
+        if !params.messages.iter().any(|msg| msg.role == Role::User) {
+            return Err(McpError::invalid_request(
+                "Message sequence must contain at least one user message",
+                Some(json!({"messages": params.messages})),
+            ));
+        }
+
+        // Create response based on context inclusion
+        let response = match params.include_context {
+            Some(ContextInclusion::ThisServer) if self.honor_this_server => {
+                "Test response with context: test context"
+            }
+            Some(ContextInclusion::AllServers) if self.honor_all_servers => {
+                "Test response with context: test context"
+            }
+            _ => "Test response without context",
+        };
+
+        Ok(CreateMessageResult {
+            message: SamplingMessage {
+                role: Role::Assistant,
+                content: Content::text(response.to_string()),
+            },
+            model: "test-model".to_string(),
+            stop_reason: Some(CreateMessageResult::STOP_REASON_END_TURN.to_string()),
+        })
+    }
+
+    fn on_logging_message(
+        &self,
+        params: LoggingMessageNotificationParam,
+    ) -> impl Future<Output = ()> + Send + '_ {
+        let receive_signal = self.receive_signal.clone();
+        let received_messages = self.received_messages.clone();
+
+        async move {
+            println!("Client: Received log message: {:?}", params);
+            let mut messages = received_messages.lock().unwrap();
+            messages.push(params);
+            receive_signal.notify_one();
+        }
+    }
+}
+
+pub struct TestServer {}
+
+impl TestServer {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ServerHandler for TestServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_logging().build(),
+            ..Default::default()
+        }
+    }
+
+    fn set_level(
+        &self,
+        request: SetLevelRequestParam,
+        context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<(), McpError>> + Send + '_ {
+        let peer = context.peer;
+        async move {
+            let (data, logger) = match request.level {
+                LoggingLevel::Error => (
+                    serde_json::json!({
+                        "message": "Failed to process request",
+                        "error_code": "E1001",
+                        "error_details": "Connection timeout",
+                        "timestamp": chrono::Utc::now().to_rfc3339(),
+                    }),
+                    Some("error_handler".to_string()),
+                ),
+                LoggingLevel::Debug => (
+                    serde_json::json!({
+                        "message": "Processing request",
+                        "function": "handle_request",
+                        "line": 42,
+                        "context": {
+                            "request_id": "req-123",
+                            "user_id": "user-456"
+                        },
+                        "timestamp": chrono::Utc::now().to_rfc3339(),
+                    }),
+                    Some("debug_logger".to_string()),
+                ),
+                LoggingLevel::Info => (
+                    serde_json::json!({
+                        "message": "System status update",
+                        "status": "healthy",
+                        "metrics": {
+                            "requests_per_second": 150,
+                            "average_latency_ms": 45,
+                            "error_rate": 0.01
+                        },
+                        "timestamp": chrono::Utc::now().to_rfc3339(),
+                    }),
+                    Some("monitoring".to_string()),
+                ),
+                _ => (
+                    serde_json::json!({
+                        "message": format!("Message at level {:?}", request.level),
+                        "timestamp": chrono::Utc::now().to_rfc3339(),
+                    }),
+                    None,
+                ),
+            };
+
+            if let Err(e) = peer
+                .notify_logging_message(LoggingMessageNotificationParam {
+                    level: request.level,
+                    data,
+                    logger,
+                })
+                .await
+            {
+                panic!("Failed to send notification: {}", e);
+            }
+            Ok(())
+        }
+    }
+}

--- a/crates/rmcp/tests/common/mod.rs
+++ b/crates/rmcp/tests/common/mod.rs
@@ -1,1 +1,2 @@
 pub mod calculator;
+pub mod handlers;

--- a/crates/rmcp/tests/test_message_protocol.rs
+++ b/crates/rmcp/tests/test_message_protocol.rs
@@ -1,0 +1,529 @@
+//cargo test --test test_message_protocol --features "client server"
+
+mod common;
+use common::handlers::{TestClientHandler, TestServer};
+use rmcp::{
+    ServiceExt,
+    model::*,
+    service::{RequestContext, Service},
+};
+use tokio_util::sync::CancellationToken;
+
+// Tests start here
+#[tokio::test]
+async fn test_message_roles() {
+    let messages = vec![
+        SamplingMessage {
+            role: Role::User,
+            content: Content::text("user message"),
+        },
+        SamplingMessage {
+            role: Role::Assistant,
+            content: Content::text("assistant message"),
+        },
+    ];
+
+    // Verify all roles can be serialized/deserialized correctly
+    let json = serde_json::to_string(&messages).unwrap();
+    let deserialized: Vec<SamplingMessage> = serde_json::from_str(&json).unwrap();
+    assert_eq!(messages, deserialized);
+}
+
+#[tokio::test]
+async fn test_context_inclusion_integration() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    // Start server
+    let server_handle = tokio::spawn(async move {
+        let server = TestServer::new().serve(server_transport).await?;
+        server.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    // Start client that honors context requests
+    let handler = TestClientHandler::new(true, true);
+    let client = handler.clone().serve(client_transport).await?;
+
+    // Test ThisServer context inclusion
+    let request = ServerRequest::CreateMessageRequest(CreateMessageRequest {
+        method: Default::default(),
+        params: CreateMessageRequestParam {
+            messages: vec![SamplingMessage {
+                role: Role::User,
+                content: Content::text("test message"),
+            }],
+            include_context: Some(ContextInclusion::ThisServer),
+            model_preferences: None,
+            system_prompt: None,
+            temperature: None,
+            max_tokens: 100,
+            stop_sequences: None,
+            metadata: None,
+        },
+    });
+
+    let result = handler
+        .handle_request(
+            request.clone(),
+            RequestContext {
+                peer: client.peer().clone(),
+                ct: CancellationToken::new(),
+                id: NumberOrString::Number(1),
+            },
+        )
+        .await?;
+
+    if let ClientResult::CreateMessageResult(result) = result {
+        let text = result.message.content.as_text().unwrap().text.as_str();
+        assert!(
+            text.contains("test context"),
+            "Response should include context for ThisServer"
+        );
+    } else {
+        panic!("Expected CreateMessageResult");
+    }
+
+    // Test AllServers context inclusion
+    let request = ServerRequest::CreateMessageRequest(CreateMessageRequest {
+        method: Default::default(),
+        params: CreateMessageRequestParam {
+            messages: vec![SamplingMessage {
+                role: Role::User,
+                content: Content::text("test message"),
+            }],
+            include_context: Some(ContextInclusion::AllServers),
+            model_preferences: None,
+            system_prompt: None,
+            temperature: None,
+            max_tokens: 100,
+            stop_sequences: None,
+            metadata: None,
+        },
+    });
+
+    let result = handler
+        .handle_request(
+            request.clone(),
+            RequestContext {
+                peer: client.peer().clone(),
+                ct: CancellationToken::new(),
+                id: NumberOrString::Number(2),
+            },
+        )
+        .await?;
+
+    if let ClientResult::CreateMessageResult(result) = result {
+        let text = result.message.content.as_text().unwrap().text.as_str();
+        assert!(
+            text.contains("test context"),
+            "Response should include context for AllServers"
+        );
+    } else {
+        panic!("Expected CreateMessageResult");
+    }
+
+    // Test No context inclusion
+    let request = ServerRequest::CreateMessageRequest(CreateMessageRequest {
+        method: Default::default(),
+        params: CreateMessageRequestParam {
+            messages: vec![SamplingMessage {
+                role: Role::User,
+                content: Content::text("test message"),
+            }],
+            include_context: Some(ContextInclusion::None),
+            model_preferences: None,
+            system_prompt: None,
+            temperature: None,
+            max_tokens: 100,
+            stop_sequences: None,
+            metadata: None,
+        },
+    });
+
+    let result = handler
+        .handle_request(
+            request.clone(),
+            RequestContext {
+                peer: client.peer().clone(),
+                ct: CancellationToken::new(),
+                id: NumberOrString::Number(3),
+            },
+        )
+        .await?;
+
+    if let ClientResult::CreateMessageResult(result) = result {
+        let text = result.message.content.as_text().unwrap().text.as_str();
+        assert!(
+            !text.contains("test context"),
+            "Response should not include context for None"
+        );
+    } else {
+        panic!("Expected CreateMessageResult");
+    }
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_context_inclusion_ignored_integration() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    // Start server
+    let server_handle = tokio::spawn(async move {
+        let server = TestServer::new().serve(server_transport).await?;
+        server.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    // Start client that ignores context requests
+    let handler = TestClientHandler::new(false, false);
+    let client = handler.clone().serve(client_transport).await?;
+
+    // Test that context requests are ignored
+    let request = ServerRequest::CreateMessageRequest(CreateMessageRequest {
+        method: Default::default(),
+        params: CreateMessageRequestParam {
+            messages: vec![SamplingMessage {
+                role: Role::User,
+                content: Content::text("test message"),
+            }],
+            include_context: Some(ContextInclusion::ThisServer),
+            model_preferences: None,
+            system_prompt: None,
+            temperature: None,
+            max_tokens: 100,
+            stop_sequences: None,
+            metadata: None,
+        },
+    });
+
+    let result = handler
+        .handle_request(
+            request.clone(),
+            RequestContext {
+                peer: client.peer().clone(),
+                ct: CancellationToken::new(),
+                id: NumberOrString::Number(1),
+            },
+        )
+        .await?;
+
+    if let ClientResult::CreateMessageResult(result) = result {
+        let text = result.message.content.as_text().unwrap().text.as_str();
+        assert!(
+            !text.contains("test context"),
+            "Context should be ignored when client chooses not to honor requests"
+        );
+    } else {
+        panic!("Expected CreateMessageResult");
+    }
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_message_sequence_integration() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    // Start server
+    let server_handle = tokio::spawn(async move {
+        let server = TestServer::new().serve(server_transport).await?;
+        server.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    // Start client
+    let handler = TestClientHandler::new(true, true);
+    let client = handler.clone().serve(client_transport).await?;
+
+    let request = ServerRequest::CreateMessageRequest(CreateMessageRequest {
+        method: Default::default(),
+        params: CreateMessageRequestParam {
+            messages: vec![
+                SamplingMessage {
+                    role: Role::User,
+                    content: Content::text("first message"),
+                },
+                SamplingMessage {
+                    role: Role::Assistant,
+                    content: Content::text("second message"),
+                },
+            ],
+            include_context: Some(ContextInclusion::ThisServer),
+            model_preferences: None,
+            system_prompt: None,
+            temperature: None,
+            max_tokens: 100,
+            stop_sequences: None,
+            metadata: None,
+        },
+    });
+
+    let result = handler
+        .handle_request(
+            request.clone(),
+            RequestContext {
+                peer: client.peer().clone(),
+                ct: CancellationToken::new(),
+                id: NumberOrString::Number(1),
+            },
+        )
+        .await?;
+
+    if let ClientResult::CreateMessageResult(result) = result {
+        let text = result.message.content.as_text().unwrap().text.as_str();
+        assert!(
+            text.contains("test context"),
+            "Response should include context when ThisServer is specified"
+        );
+        assert_eq!(result.model, "test-model");
+        assert_eq!(
+            result.stop_reason,
+            Some(CreateMessageResult::STOP_REASON_END_TURN.to_string())
+        );
+    } else {
+        panic!("Expected CreateMessageResult");
+    }
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_message_sequence_validation_integration() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    let server_handle = tokio::spawn(async move {
+        let server = TestServer::new().serve(server_transport).await?;
+        server.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let handler = TestClientHandler::new(true, true);
+    let client = handler.clone().serve(client_transport).await?;
+
+    // Test valid sequence: User -> Assistant -> User
+    let request = ServerRequest::CreateMessageRequest(CreateMessageRequest {
+        method: Default::default(),
+        params: CreateMessageRequestParam {
+            messages: vec![
+                SamplingMessage {
+                    role: Role::User,
+                    content: Content::text("first user message"),
+                },
+                SamplingMessage {
+                    role: Role::Assistant,
+                    content: Content::text("first assistant response"),
+                },
+                SamplingMessage {
+                    role: Role::User,
+                    content: Content::text("second user message"),
+                },
+            ],
+            include_context: None,
+            model_preferences: None,
+            system_prompt: None,
+            temperature: None,
+            max_tokens: 100,
+            stop_sequences: None,
+            metadata: None,
+        },
+    });
+
+    let result = handler
+        .handle_request(
+            request.clone(),
+            RequestContext {
+                peer: client.peer().clone(),
+                ct: CancellationToken::new(),
+                id: NumberOrString::Number(1),
+            },
+        )
+        .await?;
+
+    assert!(matches!(result, ClientResult::CreateMessageResult(_)));
+
+    // Test invalid: No user message
+    let request = ServerRequest::CreateMessageRequest(CreateMessageRequest {
+        method: Default::default(),
+        params: CreateMessageRequestParam {
+            messages: vec![SamplingMessage {
+                role: Role::Assistant,
+                content: Content::text("assistant message"),
+            }],
+            include_context: None,
+            model_preferences: None,
+            system_prompt: None,
+            temperature: None,
+            max_tokens: 100,
+            stop_sequences: None,
+            metadata: None,
+        },
+    });
+
+    let result = handler
+        .handle_request(
+            request.clone(),
+            RequestContext {
+                peer: client.peer().clone(),
+                ct: CancellationToken::new(),
+                id: NumberOrString::Number(2),
+            },
+        )
+        .await;
+
+    assert!(result.is_err());
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_selective_context_handling_integration() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    let server_handle = tokio::spawn(async move {
+        let server = TestServer::new().serve(server_transport).await?;
+        server.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    // Client that only honors ThisServer but ignores AllServers
+    let handler = TestClientHandler::new(true, false);
+    let client = handler.clone().serve(client_transport).await?;
+
+    // Test ThisServer is honored
+    let request = ServerRequest::CreateMessageRequest(CreateMessageRequest {
+        method: Default::default(),
+        params: CreateMessageRequestParam {
+            messages: vec![SamplingMessage {
+                role: Role::User,
+                content: Content::text("test message"),
+            }],
+            include_context: Some(ContextInclusion::ThisServer),
+            model_preferences: None,
+            system_prompt: None,
+            temperature: None,
+            max_tokens: 100,
+            stop_sequences: None,
+            metadata: None,
+        },
+    });
+
+    let result = handler
+        .handle_request(
+            request.clone(),
+            RequestContext {
+                peer: client.peer().clone(),
+                ct: CancellationToken::new(),
+                id: NumberOrString::Number(1),
+            },
+        )
+        .await?;
+
+    if let ClientResult::CreateMessageResult(result) = result {
+        let text = result.message.content.as_text().unwrap().text.as_str();
+        assert!(
+            text.contains("test context"),
+            "ThisServer context request should be honored"
+        );
+    }
+
+    // Test AllServers is ignored
+    let request = ServerRequest::CreateMessageRequest(CreateMessageRequest {
+        method: Default::default(),
+        params: CreateMessageRequestParam {
+            messages: vec![SamplingMessage {
+                role: Role::User,
+                content: Content::text("test message"),
+            }],
+            include_context: Some(ContextInclusion::AllServers),
+            model_preferences: None,
+            system_prompt: None,
+            temperature: None,
+            max_tokens: 100,
+            stop_sequences: None,
+            metadata: None,
+        },
+    });
+
+    let result = handler
+        .handle_request(
+            request.clone(),
+            RequestContext {
+                peer: client.peer().clone(),
+                ct: CancellationToken::new(),
+                id: NumberOrString::Number(2),
+            },
+        )
+        .await?;
+
+    if let ClientResult::CreateMessageResult(result) = result {
+        let text = result.message.content.as_text().unwrap().text.as_str();
+        assert!(
+            !text.contains("test context"),
+            "AllServers context request should be ignored"
+        );
+    }
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_context_inclusion() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+    let server_handle = tokio::spawn(async move {
+        let server = TestServer::new().serve(server_transport).await?;
+        server.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let handler = TestClientHandler::new(true, true);
+    let client = handler.clone().serve(client_transport).await?;
+
+    // Test context handling
+    let request = ServerRequest::CreateMessageRequest(CreateMessageRequest {
+        method: Default::default(),
+        params: CreateMessageRequestParam {
+            messages: vec![SamplingMessage {
+                role: Role::User,
+                content: Content::text("test"),
+            }],
+            include_context: Some(ContextInclusion::ThisServer),
+            model_preferences: None,
+            system_prompt: None,
+            temperature: None,
+            max_tokens: 100,
+            stop_sequences: None,
+            metadata: None,
+        },
+    });
+
+    let result = handler
+        .handle_request(
+            request.clone(),
+            RequestContext {
+                peer: client.peer().clone(),
+                ct: CancellationToken::new(),
+                id: NumberOrString::Number(1),
+            },
+        )
+        .await?;
+
+    if let ClientResult::CreateMessageResult(result) = result {
+        let text = result.message.content.as_text().unwrap().text.as_str();
+        assert!(text.contains("test context"));
+    }
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}


### PR DESCRIPTION
Refactors a client/server implementation for tests, adds tests for context requests from server to client to closely follow spec.

## Motivation and Context
More test coverage

## How Has This Been Tested?
Untested in prod app

## Breaking Changes
users with strings other than `pub enum ContextInclusion` for context may have issue

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

 