### PR TITLE
Make `Extensions` available from `Context`

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -200,6 +200,15 @@ pub struct Request<M = String, P = JsonObject> {
     pub extensions: Extensions,
 }
 
+impl<M, P> GetExtensions for Request<M, P> {
+    fn extensions(&self) -> &Extensions {
+        &self.extensions
+    }
+    fn extensions_mut(&mut self) -> &mut Extensions {
+        &mut self.extensions
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RequestOptionalParam<M = String, P = JsonObject> {
     pub method: M,
@@ -220,6 +229,14 @@ pub struct RequestNoParam<M = String> {
     pub extensions: Extensions,
 }
 
+impl<M> GetExtensions for RequestNoParam<M> {
+    fn extensions(&self) -> &Extensions {
+        &self.extensions
+    }
+    fn extensions_mut(&mut self) -> &mut Extensions {
+        &mut self.extensions
+    }
+}
 #[derive(Debug, Clone)]
 pub struct Notification<M = String, P = JsonObject> {
     pub method: M,

--- a/crates/rmcp/src/model/meta.rs
+++ b/crates/rmcp/src/model/meta.rs
@@ -13,21 +13,26 @@ pub trait GetMeta {
     fn get_meta(&self) -> &Meta;
 }
 
+pub trait GetExtensions {
+    fn extensions(&self) -> &Extensions;
+    fn extensions_mut(&mut self) -> &mut Extensions;
+}
+
 macro_rules! variant_extension {
     (
         $Enum: ident {
             $($variant: ident)*
         }
     ) => {
-        impl $Enum {
-            pub fn extensions(&self) -> &Extensions {
+        impl GetExtensions for $Enum {
+            fn extensions(&self) -> &Extensions {
                 match self {
                     $(
                         $Enum::$variant(v) => &v.extensions,
                     )*
                 }
             }
-            pub fn extensions_mut(&mut self) -> &mut Extensions {
+            fn extensions_mut(&mut self) -> &mut Extensions {
                 match self {
                     $(
                         $Enum::$variant(v) => &mut v.extensions,

--- a/crates/rmcp/tests/test_message_protocol.rs
+++ b/crates/rmcp/tests/test_message_protocol.rs
@@ -71,6 +71,7 @@ async fn test_context_inclusion_integration() -> anyhow::Result<()> {
                 ct: CancellationToken::new(),
                 id: NumberOrString::Number(1),
                 meta: Default::default(),
+                extensions: Default::default(),
             },
         )
         .await?;
@@ -112,6 +113,7 @@ async fn test_context_inclusion_integration() -> anyhow::Result<()> {
                 ct: CancellationToken::new(),
                 id: NumberOrString::Number(2),
                 meta: Default::default(),
+                extensions: Default::default(),
             },
         )
         .await?;
@@ -153,6 +155,7 @@ async fn test_context_inclusion_integration() -> anyhow::Result<()> {
                 ct: CancellationToken::new(),
                 id: NumberOrString::Number(3),
                 meta: Default::default(),
+                extensions: Default::default(),
             },
         )
         .await?;
@@ -214,6 +217,7 @@ async fn test_context_inclusion_ignored_integration() -> anyhow::Result<()> {
                 ct: CancellationToken::new(),
                 id: NumberOrString::Number(1),
                 meta: Meta::default(),
+                extensions: Default::default(),
             },
         )
         .await?;
@@ -280,6 +284,7 @@ async fn test_message_sequence_integration() -> anyhow::Result<()> {
                 ct: CancellationToken::new(),
                 id: NumberOrString::Number(1),
                 meta: Meta::default(),
+                extensions: Default::default(),
             },
         )
         .await?;
@@ -354,6 +359,7 @@ async fn test_message_sequence_validation_integration() -> anyhow::Result<()> {
                 ct: CancellationToken::new(),
                 id: NumberOrString::Number(1),
                 meta: Meta::default(),
+                extensions: Default::default(),
             },
         )
         .await?;
@@ -387,6 +393,7 @@ async fn test_message_sequence_validation_integration() -> anyhow::Result<()> {
                 ct: CancellationToken::new(),
                 id: NumberOrString::Number(2),
                 meta: Meta::default(),
+                extensions: Default::default(),
             },
         )
         .await;
@@ -439,6 +446,7 @@ async fn test_selective_context_handling_integration() -> anyhow::Result<()> {
                 ct: CancellationToken::new(),
                 id: NumberOrString::Number(1),
                 meta: Meta::default(),
+                extensions: Default::default(),
             },
         )
         .await?;
@@ -478,6 +486,7 @@ async fn test_selective_context_handling_integration() -> anyhow::Result<()> {
                 ct: CancellationToken::new(),
                 id: NumberOrString::Number(2),
                 meta: Meta::default(),
+                extensions: Default::default(),
             },
         )
         .await?;
@@ -534,6 +543,7 @@ async fn test_context_inclusion() -> anyhow::Result<()> {
                 ct: CancellationToken::new(),
                 id: NumberOrString::Number(1),
                 meta: Meta::default(),
+                extensions: Default::default(),
             },
         )
         .await?;


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Expose extensions via context so that handlers can use the data.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Extensions were recently added, but without this change they are not usable by the handlers.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
