### PR TITLE
fix(server): schemars compilation errors

### DIFF
--- a/crates/rmcp/src/handler/server/tool.rs
+++ b/crates/rmcp/src/handler/server/tool.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 /// A shortcut for generating a JSON schema for a type.
 pub fn schema_for_type<T: JsonSchema>() -> JsonObject {
-    let schema = schemars::SchemaGenerator::default().into_root_schema_for::<T>();
+    let schema = schemars::r#gen::SchemaGenerator::default().into_root_schema_for::<T>();
     let object = serde_json::to_value(schema).expect("failed to serialize schema");
     match object {
         serde_json::Value::Object(object) => object,


### PR DESCRIPTION
I think the issue is caused because rust 2024 added "gen" as reserved keyword.
So explicitly calling `::r#gen::SchemaGenerator` works.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Fixes: #103
