### PR TITLE
docs: give macOS link and clarify missing UI

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@
     ```
     This builds a standard input/output MCP server binary.
 
-2. **Add or update this section in your** `~/.config/claude-desktop/config.toml`
+2. **Add or update this section in your** `~/.config/claude-desktop/config.toml` (Linux) or `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
     ```json
     {
         "mcpServers": {
@@ -18,7 +18,10 @@
     }
     ```
 
-3. **Once Claude Desktop is running, try chatting:**
+3. **Ensure that the MCP UI elements appear in Claude Desktop**
+    The MCP UI elements will only show up in Claude for Desktop if at least one server is properly configured.
+
+4. **Once Claude Desktop is running, try chatting:**
     ```text
     counter.say_hello
     ```


### PR DESCRIPTION
I was following the example in `examples/README.md`, but the instructions didn't match for my system (macOS).

## Motivation and Context

This change will make the instructions clearer for developers on macOS.

## How Has This Been Tested?

Yes the example worked (returned with hello and it was clearly via the MCP) once I modified the right document.

## Breaking Changes

No

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

