### PR TITLE
fix: fix 2 cargo warnings

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -51,7 +51,7 @@ rand = { version = "0.9", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 
 # macro
-rmcp-macros = { version = "0.1", workspace = true, optional = true }
+rmcp-macros = { workspace = true, optional = true }
 
 [features]
 default = ["base64", "macros", "server"]

--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -51,7 +51,7 @@ rand = { version = "0.9", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 
 # macro
-rmcp-macros = { workspace = true, optional = true }
+rmcp-macros = { version = "0.1", workspace = true, optional = true }
 
 [features]
 default = ["base64", "macros", "server"]

--- a/examples/rig-integration/Cargo.toml
+++ b/examples/rig-integration/Cargo.toml
@@ -18,7 +18,7 @@ rmcp = { path = "../../crates/rmcp", features = [
     "client",
     "transport-child-process",
     "transport-sse",
-], no-default-features = true }
+] }
 anyhow = "1.0"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/examples/wasi/Cargo.toml
+++ b/examples/wasi/Cargo.toml
@@ -17,7 +17,7 @@ readme = { workspace = true }
 crate-type = ["cdylib"]
 
 [dependencies]
-wasi = { version = "0.14.2+wasi-0.2.4"}
+wasi = { version = "0.14.2"}
 tokio = { version = "1", features = ["rt", "io-util", "sync", "macros", "time"] }
 rmcp= { path = "../../crates/rmcp", features = ["server", "macros"] }
 serde = { version  = "1", features = ["derive"]}


### PR DESCRIPTION
This fixes three warnings that `cargo test` produced.

## Motivation and Context

Locally and in CI the following warnings were visible:

```
$ cargo test --all-features
warning: /home/runner/work/rust-sdk/rust-sdk/examples/rig-integration/Cargo.toml: unused manifest key: dependencies.rmcp.no-default-features
warning: /home/runner/work/rust-sdk/rust-sdk/crates/rmcp/Cargo.toml: unused manifest key: dependencies.rmcp-macros.version
warning: /home/runner/work/rust-sdk/rust-sdk/examples/wasi/Cargo.toml: version requirement `0.14.2+wasi-0.2.4` for dependency `wasi` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
```

## How Has This Been Tested?

I re-ran all tests and also manually "tested" (built) `rig-integration` via

```sh
$ cd examples/righ-integration

$ cargo build
```

For `rig-integration` I verified that setting `default-features = false` will not be able to build the project, so that's why I removed it. Note that `default-features = false` is interpreted by Cargo while the setting `no-default-features = true` was ignored.

## Breaking Changes

No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
