### PR TITLE
fix(handler): do call handler methods when initialize server.

### DIFF
--- a/crates/rmcp/src/service/client.rs
+++ b/crates/rmcp/src/service/client.rs
@@ -174,7 +174,8 @@ where
         }),
     );
     sink.send(notification).await?;
-    serve_inner(service, (sink, stream), initialize_result, id_provider, ct).await
+    let (peer, peer_rx) = Peer::new(id_provider, initialize_result);
+    serve_inner(service, (sink, stream), peer, peer_rx, ct).await
 }
 
 macro_rules! method {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Call handlers to get the info instead of return the info directly when initializing.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
fix #114

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
