### PR TITLE
test(server): test js and py resources and tools

### DIFF
--- a/crates/rmcp/tests/test_with_js.rs
+++ b/crates/rmcp/tests/test_with_js.rs
@@ -60,8 +60,14 @@ async fn test_with_js_server() -> anyhow::Result<()> {
     let client = ().serve(transport).await?;
     let resources = client.list_all_resources().await?;
     tracing::info!("{:#?}", resources);
+    assert!(resources.len() == 1);
+    assert_eq!(resources[0].name, "greeting");
+    assert_eq!(resources[0].uri, "test://static");
+
     let tools = client.list_all_tools().await?;
     tracing::info!("{:#?}", tools);
+    assert!(tools.len() == 1);
+    assert_eq!(tools[0].name, "add");
 
     client.cancel().await?;
     Ok(())

--- a/crates/rmcp/tests/test_with_js/server.js
+++ b/crates/rmcp/tests/test_with_js/server.js
@@ -7,6 +7,19 @@ const server = new McpServer({
   version: "1.0.0"
 });
 
+// Add a static greeting resource
+server.resource(
+  "greeting",
+  "test://static",
+  async (uri) => ({
+    contents: [{
+      uri: uri.href,
+      text: `Hello!`
+    }]
+  })
+);
+
+// Add a dynamic greeting resource
 server.resource(
   "greeting",
   new ResourceTemplate("greeting://{name}", { list: undefined }),

--- a/crates/rmcp/tests/test_with_python.rs
+++ b/crates/rmcp/tests/test_with_python.rs
@@ -62,9 +62,16 @@ async fn test_with_python_server() -> anyhow::Result<()> {
 
     let client = ().serve(transport).await?;
     let resources = client.list_all_resources().await?;
-    tracing::info!("{:#?}", resources);
+    tracing::info!("resources: {:#?}", resources);
+    assert!(resources.len() == 1);
+    assert_eq!(resources[0].name, "greeting://static");
+
     let tools = client.list_all_tools().await?;
-    tracing::info!("{:#?}", tools);
+    tracing::info!("tools: {:#?}", tools);
+    assert!(tools.len() == 1);
+    let tool = tools.first().unwrap();
+    assert_eq!(tool.name, "add");
+
     client.cancel().await?;
     Ok(())
 }

--- a/crates/rmcp/tests/test_with_python/server.py
+++ b/crates/rmcp/tests/test_with_python/server.py
@@ -8,11 +8,18 @@ def add(a: int, b: int) -> int:
     return a + b
 
 
+# Add a static greeting resource
+@mcp.resource("greeting://static")
+def get_greeting() -> str:
+    """Get a personalized greeting"""
+    return f"Hello!"
+
+
 # Add a dynamic greeting resource
 @mcp.resource("greeting://{name}")
 def get_greeting(name: str) -> str:
     """Get a personalized greeting"""
-    return f"Hello, {name}!"
+    return f"Hello {name}!"
 
 
 


### PR DESCRIPTION
Add tests to ensure that JS and Python resources and tools are correctly read.

I confirmed with `npx @modelcontextprotocol/inspector uv "run crates/rmcp/tests/test_with_
python/server.py"` that also in that inspector only static resources are returned.

## Motivation and Context

Better test coverage. Related to  https://github.com/modelcontextprotocol/rust-sdk/issues/49

## How Has This Been Tested?

I ran the tests.

## Breaking Changes

No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

