### PR TITLE
docs: simplify counter example

### DIFF
--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use rmcp::{
-    Error as McpError, RoleServer, ServerHandler, const_string, model::*, schemars,
-    service::RequestContext, tool,
+    Error as McpError, RoleServer, ServerHandler, model::*, schemars, service::RequestContext, tool,
 };
 use serde_json::json;
 use tokio::sync::Mutex;
@@ -24,10 +23,6 @@ impl Counter {
         Self {
             counter: Arc::new(Mutex::new(0)),
         }
-    }
-
-    fn _create_resource_text(&self, uri: &str, name: &str) -> Resource {
-        RawResource::new(uri, name.to_string()).no_annotation()
     }
 
     #[tool(description = "Increment the counter by 1")]
@@ -81,7 +76,7 @@ impl Counter {
         )]))
     }
 }
-const_string!(Echo = "echo");
+
 #[tool(tool_box)]
 impl ServerHandler for Counter {
     fn get_info(&self) -> ServerInfo {
@@ -102,10 +97,13 @@ impl ServerHandler for Counter {
         _request: Option<PaginatedRequestParam>,
         _: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
+        fn create_resource_text(uri: &str, name: &str) -> Resource {
+            RawResource::new(uri, name.to_string()).no_annotation()
+        }
         Ok(ListResourcesResult {
             resources: vec![
-                self._create_resource_text("str:////Users/to/some/path/", "cwd"),
-                self._create_resource_text("memo://insights", "memo-name"),
+                create_resource_text("str:////Users/to/some/path/", "cwd"),
+                create_resource_text("memo://insights", "memo-name"),
             ],
             next_cursor: None,
         })

--- a/examples/simple-chat-client/Cargo.toml
+++ b/examples/simple-chat-client/Cargo.toml
@@ -17,4 +17,4 @@ rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", features = [
     "client",
     "transport-child-process",
     "transport-sse",
-], no-default-features = true }
+] }


### PR DESCRIPTION
I thought `_create_resource_text` was part of the public API, but noticed that it's only used inside this file. To make that more clear, I moved the function definition closer to the callsite.

## Motivation and Context

It makes the example a bit clearer.

## How Has This Been Tested?

I manually ran the examples.

## Breaking Changes

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
