### PR TITLE
chore: try to add oauth2 support

### DIFF
--- a/OAUTH_README.md
+++ b/OAUTH_README.md
@@ -1,0 +1,156 @@
+# Model Context Protocol OAuth Authorization
+
+This document describes the OAuth 2.1 authorization implementation for Model Context Protocol (MCP), following the [MCP 2025-03-26 Authorization Specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/).
+
+## Features
+
+- Full support for OAuth 2.1 authorization flow
+- PKCE support for enhanced security
+- Authorization server metadata discovery
+- Dynamic client registration
+- Automatic token refresh
+- Authorized SSE transport implementation
+
+## Usage Guide
+
+### 1. Enable Features
+
+Enable the auth feature in Cargo.toml:
+
+```toml
+[dependencies]
+rmcp = { version = "0.1", features = ["auth", "transport-sse"] }
+```
+
+### 2. Create Authorization Manager
+
+```rust
+use std::sync::Arc;
+use rmcp::transport::auth::AuthorizationManager;
+
+async fn main() -> anyhow::Result<()> {
+    // Create authorization manager
+    let auth_manager = Arc::new(AuthorizationManager::new("https://api.example.com/mcp").await?);
+    
+    Ok(())
+}
+```
+
+### 3. Create Authorization Session and Get Authorization
+
+```rust
+use rmcp::transport::auth::AuthorizationSession;
+
+async fn get_authorization(auth_manager: Arc<AuthorizationManager>) -> anyhow::Result<()> {
+    // Create authorization session
+    let session = AuthorizationSession::new(
+        auth_manager.clone(),
+        &["mcp"], // Requested scopes
+        "http://localhost:8080/callback", // Redirect URI
+    ).await?;
+    
+    // Get authorization URL and guide user to open it
+    let auth_url = session.get_authorization_url();
+    println!("Please open the following URL in your browser for authorization:\n{}", auth_url);
+    
+    // Handle callback - In real applications, this is typically done in a callback server
+    let auth_code = "Authorization code obtained from browser after user authorization";
+    let credentials = session.handle_callback(auth_code).await?;
+    
+    println!("Authorization successful, access token: {}", credentials.access_token);
+    
+    Ok(())
+}
+```
+
+### 4. Use Authorized SSE Transport
+
+```rust
+use rmcp::{ServiceExt, model::ClientInfo, transport::create_authorized_transport};
+
+async fn connect_with_auth(auth_manager: Arc<AuthorizationManager>) -> anyhow::Result<()> {
+    // Create authorized SSE transport
+    let transport = create_authorized_transport(
+        "https://api.example.com/mcp",
+        auth_manager.clone()
+    ).await?;
+    
+    // Create client
+    let client_service = ClientInfo::default();
+    let client = client_service.serve(transport).await?;
+    
+    // Use client to call APIs
+    let tools = client.peer().list_all_tools().await?;
+    
+    for tool in tools {
+        println!("Tool: {} - {}", tool.name, tool.description);
+    }
+    
+    Ok(())
+}
+```
+
+### 5. Use Authorized HTTP Client
+
+```rust
+use rmcp::transport::auth::AuthorizedHttpClient;
+
+async fn make_authorized_request(auth_manager: Arc<AuthorizationManager>) -> anyhow::Result<()> {
+    // Create authorized HTTP client
+    let client = AuthorizedHttpClient::new(auth_manager, None);
+    
+    // Send authorized request
+    let response = client.get("https://api.example.com/resources").await?;
+    let resources = response.json::<Vec<Resource>>().await?;
+    
+    println!("Number of resources: {}", resources.len());
+    
+    Ok(())
+}
+```
+
+## Complete Example
+
+Please refer to `examples/oauth_client.rs` for a complete usage example.
+
+## Running the Example
+
+```bash
+# Set server URL (optional)
+export MCP_SERVER_URL=https://api.example.com/mcp
+
+# Run example
+cargo run --bin oauth-client
+```
+
+## Authorization Flow Description
+
+1. **Metadata Discovery**: Client attempts to get authorization server metadata from `/.well-known/oauth-authorization-server`
+2. **Client Registration**: If supported, client dynamically registers itself
+3. **Authorization Request**: Build authorization URL with PKCE and guide user to access
+4. **Authorization Code Exchange**: After user authorization, exchange authorization code for access token
+5. **Token Usage**: Use access token for API calls
+6. **Token Refresh**: Automatically use refresh token to get new access token when current one expires
+
+## Security Considerations
+
+- All tokens are securely stored in memory
+- PKCE implementation prevents authorization code interception attacks
+- Automatic token refresh support reduces user intervention
+- Only accepts HTTPS connections or secure local callback URIs
+
+## Troubleshooting
+
+If you encounter authorization issues, check the following:
+
+1. Ensure server supports OAuth 2.1 authorization
+2. Verify callback URI matches server's allowed redirect URIs
+3. Check network connection and firewall settings
+4. Verify server supports metadata discovery or dynamic client registration
+
+## References
+
+- [MCP Authorization Specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/)
+- [OAuth 2.1 Specification Draft](https://oauth.net/2.1/)
+- [RFC 8414: OAuth 2.0 Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414)
+- [RFC 7591: OAuth 2.0 Dynamic Client Registration Protocol](https://datatracker.ietf.org/doc/html/rfc7591) 

--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -23,6 +23,10 @@ tracing = { version = "0.1" }
 tokio-util = { version = "0.7" }
 pin-project-lite = "0.2"
 paste = { version = "1", optional = true }
+
+# oauth2 support
+oauth2 = { version = "4.3", optional = true }
+
 # for auto generate schema
 schemars = { version = "0.8", optional = true }
 
@@ -70,6 +74,8 @@ transport-sse-server = [
 ]
 # transport-ws = ["transport-io", "dep:tokio-tungstenite"]
 tower = ["dep:tower-service"]
+auth = ["dep:oauth2", "dep:reqwest", "dep:url"]
+
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 schemars = { version = "0.8" }

--- a/crates/rmcp/src/transport.rs
+++ b/crates/rmcp/src/transport.rs
@@ -56,6 +56,11 @@ pub mod sse;
 #[cfg(feature = "transport-sse")]
 pub use sse::SseTransport;
 
+#[cfg(all(feature = "transport-sse", feature = "auth"))]
+pub mod sse_auth;
+#[cfg(all(feature = "transport-sse", feature = "auth"))]
+pub use sse_auth::{AuthorizedSseClient, create_authorized_transport};
+
 // #[cfg(feature = "tower")]
 // pub mod tower;
 
@@ -63,6 +68,11 @@ pub use sse::SseTransport;
 pub mod sse_server;
 #[cfg(feature = "transport-sse-server")]
 pub use sse_server::SseServer;
+
+#[cfg(feature = "auth")]
+pub mod auth;
+#[cfg(feature = "auth")]
+pub use auth::{AuthorizationManager, AuthorizationSession, AuthorizedHttpClient, AuthError};
 
 // #[cfg(feature = "transport-ws")]
 // pub mod ws;

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -1,0 +1,428 @@
+use std::sync::Arc;
+use std::time::Duration;
+use futures::future::BoxFuture;
+use oauth2::basic::BasicTokenType;
+use oauth2::{
+    AuthorizationCode, ClientId, ClientSecret, CsrfToken, PkceCodeChallenge, PkceCodeVerifier,
+    RedirectUrl, TokenResponse, Scope, AuthUrl, TokenUrl, RefreshToken, 
+    StandardTokenResponse, TokenType, AccessToken, EmptyExtraTokenFields,
+    basic::BasicClient, reqwest::http_client, RefreshTokenRequest, AuthorizationRequest
+};
+use reqwest::{Client as HttpClient, header::AUTHORIZATION, StatusCode, Url, IntoUrl};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::{Mutex, RwLock};
+use tokio::time::{self, Instant};
+
+/// 错误定义
+#[derive(Debug, Error)]
+pub enum AuthError {
+    #[error("OAuth authorization required")]
+    AuthorizationRequired,
+    
+    #[error("OAuth authorization failed: {0}")]
+    AuthorizationFailed(String),
+    
+    #[error("OAuth token exchange failed: {0}")]
+    TokenExchangeFailed(String),
+    
+    #[error("OAuth token refresh failed: {0}")]
+    TokenRefreshFailed(String),
+    
+    #[error("HTTP error: {0}")]
+    HttpError(#[from] reqwest::Error),
+    
+    #[error("OAuth error: {0}")]
+    OAuthError(String),
+    
+    #[error("Metadata error: {0}")]
+    MetadataError(String),
+    
+    #[error("URL parse error: {0}")]
+    UrlError(#[from] url::ParseError),
+    
+    #[error("No authorization support detected")]
+    NoAuthorizationSupport,
+    
+    #[error("Internal error: {0}")]
+    InternalError(String),
+    
+    #[error("Invalid token type: {0}")]
+    InvalidTokenType(String),
+    
+    #[error("Token expired")]
+    TokenExpired,
+    
+    #[error("Invalid scope: {0}")]
+    InvalidScope(String),
+    
+    #[error("Registration failed: {0}")]
+    RegistrationFailed(String),
+}
+
+/// oauth2 metadata
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AuthorizationMetadata {
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub registration_endpoint: Option<String>,
+    pub issuer: Option<String>,
+    pub jwks_uri: Option<String>,
+    pub scopes_supported: Option<Vec<String>>,
+}
+
+/// oauth2 client config
+#[derive(Debug, Clone)]
+pub struct OAuthClientConfig {
+    pub client_id: String,
+    pub client_secret: Option<String>,
+    pub redirect_uri: String,
+    pub scopes: Vec<String>,
+}
+
+/// oauth2 auth manager
+pub struct AuthorizationManager {
+    http_client: HttpClient,
+    metadata: Option<AuthorizationMetadata>,
+    oauth_client: Option<BasicClient>,
+    credentials: RwLock<Option<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>>>,
+    pkce_verifier: RwLock<Option<PkceCodeVerifier>>,
+    base_url: Url,
+}
+
+impl AuthorizationManager {
+    /// create new auth manager
+    pub async fn new<U: IntoUrl>(base_url: U) -> Result<Self, AuthError> {
+        let base_url = base_url.into_url()?;
+        let http_client = HttpClient::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| AuthError::InternalError(e.to_string()))?;
+            
+        let mut manager = Self {
+            http_client,
+            metadata: None,
+            oauth_client: None,
+            credentials: RwLock::new(None),
+            pkce_verifier: RwLock::new(None),
+            base_url,
+        };
+        
+        // try to discover oauth2 metadata
+        if let Ok(metadata) = manager.discover_metadata().await {
+            manager.metadata = Some(metadata);
+        }
+        
+        Ok(manager)
+    }
+    
+    /// discover oauth2 metadata
+    pub async fn discover_metadata(&self) -> Result<AuthorizationMetadata, AuthError> {
+        // according to the specification, the metadata should be located at "/.well-known/oauth-authorization-server"
+        let mut discovery_url = self.base_url.clone();
+        discovery_url.set_path("/.well-known/oauth-authorization-server");
+        
+        let response = self.http_client
+            .get(discovery_url)
+            .header("MCP-Protocol-Version", "2024-11-05")
+            .send()
+            .await?;
+            
+        if response.status() == StatusCode::OK {
+            let metadata = response.json::<AuthorizationMetadata>().await
+                .map_err(|e| AuthError::MetadataError(format!("Failed to parse metadata: {}", e)))?;
+            Ok(metadata)
+        } else {
+            // fallback to default endpoints
+            let mut auth_base = self.base_url.clone();
+            // discard the path part, only keep scheme, host, port
+            auth_base.set_path("");
+            
+            Ok(AuthorizationMetadata {
+                authorization_endpoint: format!("{}/authorize", auth_base),
+                token_endpoint: format!("{}/token", auth_base),
+                registration_endpoint: Some(format!("{}/register", auth_base)),
+                issuer: None,
+                jwks_uri: None,
+                scopes_supported: None,
+            })
+        }
+    }
+    
+    /// configure oauth2 client with client credentials
+    pub fn configure_client(&mut self, config: OAuthClientConfig) -> Result<(), AuthError> {
+        if self.metadata.is_none() {
+            return Err(AuthError::NoAuthorizationSupport);
+        }
+        
+        let metadata = self.metadata.as_ref().unwrap();
+        
+        let auth_url = AuthUrl::new(metadata.authorization_endpoint.clone())
+            .map_err(|e| AuthError::OAuthError(format!("Invalid authorization URL: {}", e)))?;
+            
+        let token_url = TokenUrl::new(metadata.token_endpoint.clone())
+            .map_err(|e| AuthError::OAuthError(format!("Invalid token URL: {}", e)))?;
+            
+        let client_id = ClientId::new(config.client_id);
+        let redirect_url = RedirectUrl::new(config.redirect_uri)
+            .map_err(|e| AuthError::OAuthError(format!("Invalid redirect URL: {}", e)))?;
+            
+        let mut client_builder = BasicClient::new(client_id.clone(), None, auth_url.clone(), Some(token_url.clone()))
+            .set_redirect_uri(redirect_url.clone());
+            
+        if let Some(secret) = config.client_secret {
+            client_builder = BasicClient::new(client_id, Some(ClientSecret::new(secret)), auth_url, Some(token_url))
+                .set_redirect_uri(redirect_url);
+        }
+        
+        self.oauth_client = Some(client_builder);
+        Ok(())
+    }
+    
+    /// dynamic register oauth2 client
+    pub async fn register_client(&mut self, name: &str, redirect_uri: &str) -> Result<OAuthClientConfig, AuthError> {
+        if self.metadata.is_none() {
+            return Err(AuthError::NoAuthorizationSupport);
+        }
+        
+        let metadata = self.metadata.as_ref().unwrap();
+        let registration_url = metadata.registration_endpoint.as_ref()
+            .ok_or_else(|| AuthError::NoAuthorizationSupport)?;
+            
+        // prepare registration request
+        let registration_request = serde_json::json!({
+            "client_name": name,
+            "redirect_uris": [redirect_uri],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "token_endpoint_auth_method": "none", // public client
+            "response_types": ["code"],
+        });
+        
+        let response = self.http_client
+            .post(registration_url)
+            .json(&registration_request)
+            .send()
+            .await?;
+            
+        if !response.status().is_success() {
+            return Err(AuthError::OAuthError(format!(
+                "Client registration failed: HTTP {}", response.status()
+            )));
+        }
+        
+        #[derive(Deserialize)]
+        struct RegistrationResponse {
+            client_id: String,
+            client_secret: Option<String>,
+        }
+        
+        let reg_response = response.json::<RegistrationResponse>().await
+            .map_err(|e| AuthError::OAuthError(format!("Failed to parse registration response: {}", e)))?;
+            
+        let config = OAuthClientConfig {
+            client_id: reg_response.client_id,
+            client_secret: reg_response.client_secret,
+            redirect_uri: redirect_uri.to_string(),
+            scopes: vec![],
+        };
+        
+        self.configure_client(config.clone())?;
+        Ok(config)
+    }
+    
+    /// generate authorization url
+    pub async fn get_authorization_url(&self, scopes: &[&str]) -> Result<String, AuthError> {
+        let oauth_client = self.oauth_client.as_ref()
+            .ok_or_else(|| AuthError::InternalError("OAuth client not configured".to_string()))?;
+            
+        // generate pkce challenge
+        let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+        
+        // build authorization request
+        let mut auth_request = oauth_client
+            .authorize_url(CsrfToken::new_random)
+            .set_pkce_challenge(pkce_challenge);
+            
+        // add request scopes
+        for scope in scopes {
+            auth_request = auth_request.add_scope(Scope::new(scope.to_string()));
+        }
+        
+        let (auth_url, _csrf_token) = auth_request.url();
+
+        // store pkce verifier for later use
+        *self.pkce_verifier.write().await = Some(pkce_verifier);
+        
+        Ok(auth_url.to_string())
+    }
+    
+    /// exchange authorization code for access token
+    pub async fn exchange_code_for_token(&self, code: &str) -> Result<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>, AuthError> {
+        let oauth_client = self.oauth_client.as_ref()
+            .ok_or_else(|| AuthError::InternalError("OAuth client not configured".to_string()))?;
+            
+        let pkce_verifier = self.pkce_verifier.write().await.take().unwrap();
+        
+        // exchange token
+        let token_result = oauth_client
+            .exchange_code(AuthorizationCode::new(code.to_string()))
+            .set_pkce_verifier(pkce_verifier)
+            .request(http_client)
+            .map_err(|e| AuthError::TokenExchangeFailed(e.to_string()))?;
+            
+        // store credentials
+        *self.credentials.write().await = Some(token_result.clone());
+        
+        Ok(token_result)
+    }
+    
+    /// get access token, if expired, refresh it automatically
+    pub async fn get_access_token(&self) -> Result<String, AuthError> {
+        let credentials = self.credentials.read().await;
+        
+        if let Some(creds) = credentials.as_ref() {
+            // check if the token is expired
+            if let Some(expires_in) = creds.expires_in() {
+                if expires_in <= Duration::from_secs(0) {
+                    // token expired, try to refresh
+                    drop(credentials); // release the lock
+                    let new_creds = self.refresh_token().await?;
+                    return Ok(new_creds.access_token().secret().to_string());
+                }
+            }
+            
+            Ok(creds.access_token().secret().to_string())
+        } else {
+            Err(AuthError::AuthorizationRequired)
+        }
+    }
+    
+    /// refresh access token
+    pub async fn refresh_token(&self) -> Result<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>, AuthError> {
+        let oauth_client = self.oauth_client.as_ref()
+            .ok_or_else(|| AuthError::InternalError("OAuth client not configured".to_string()))?;
+            
+        let current_credentials = self.credentials.read().await.clone()
+            .ok_or_else(|| AuthError::AuthorizationRequired)?;
+            
+        let refresh_token = current_credentials.refresh_token()
+            .ok_or_else(|| AuthError::TokenRefreshFailed("No refresh token available".to_string()))?;
+            
+        // refresh token
+        let token_result = oauth_client
+            .exchange_refresh_token(&RefreshToken::new(refresh_token.secret().to_string()))
+            .request(http_client)
+            .map_err(|e| AuthError::TokenRefreshFailed(e.to_string()))?;
+            
+        
+        // store new credentials
+        *self.credentials.write().await = Some(token_result.clone());
+        
+        Ok(token_result)
+    }
+    
+    /// prepare request, add authorization header
+    pub async fn prepare_request(&self, mut request: reqwest::RequestBuilder) -> Result<reqwest::RequestBuilder, AuthError> {
+        let token = self.get_access_token().await?;
+        Ok(request.header(AUTHORIZATION, format!("Bearer {}", token)))
+    }
+    
+    /// handle response, check if need to re-authorize
+    pub async fn handle_response(&self, response: reqwest::Response) -> Result<reqwest::Response, AuthError> {
+        if response.status() == StatusCode::UNAUTHORIZED {
+            // 401 Unauthorized, need to re-authorize
+            Err(AuthError::AuthorizationRequired)
+        } else {
+            Ok(response)
+        }
+    }
+}
+
+/// oauth2 authorization session, for guiding user to complete the authorization process
+pub struct AuthorizationSession {
+    pub auth_manager: Arc<Mutex<AuthorizationManager>>,
+    pub auth_url: String,
+    pub redirect_uri: String,
+    pub pkce_verifier: PkceCodeVerifier,
+}
+
+impl AuthorizationSession {
+    /// create new authorization session
+    pub async fn new(
+        auth_manager: Arc<Mutex<AuthorizationManager>>, 
+        scopes: &[&str],
+        redirect_uri: &str,
+    ) -> Result<Self, AuthError> {
+        // set redirect uri
+        let config = OAuthClientConfig {
+            client_id: "mcp-client".to_string(), // temporary id, will be updated by dynamic registration
+            client_secret: None,
+            redirect_uri: redirect_uri.to_string(),
+            scopes: scopes.iter().map(|s| s.to_string()).collect(),
+        };
+        
+        // try to dynamic register client
+        let config = match auth_manager.lock().await.register_client("MCP Client", redirect_uri).await {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("Dynamic registration failed: {}", e);
+                // fallback to default config
+                config
+            }
+        };
+        
+        let auth_url= auth_manager.lock().await.get_authorization_url(scopes).await?;
+        let pkce_verifier = auth_manager.lock().await.pkce_verifier.write().await.take().unwrap();
+        Ok(Self {
+            auth_manager,
+            auth_url,
+            redirect_uri: redirect_uri.to_string(),
+            pkce_verifier,
+        })
+    }
+    
+    /// get authorization url
+    pub fn get_authorization_url(&self) -> &str {
+        &self.auth_url
+    }
+    
+    /// handle authorization code callback
+    pub async fn handle_callback(&self, code: &str) -> Result<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>, AuthError> {
+        self.auth_manager.lock().await.exchange_code_for_token(code).await
+    }
+}
+
+/// http client extension, automatically add authorization header
+pub struct AuthorizedHttpClient {
+    auth_manager: Arc<AuthorizationManager>,
+    inner_client: HttpClient,
+}
+
+impl AuthorizedHttpClient {
+    /// create new authorized http client
+    pub fn new(auth_manager: Arc<AuthorizationManager>, client: Option<HttpClient>) -> Self {
+        let inner_client = client.unwrap_or_else(|| HttpClient::new());
+        Self {
+            auth_manager,
+            inner_client,
+        }
+    }
+    
+    /// send authorized request
+    pub async fn request<U: IntoUrl>(&self, method: reqwest::Method, url: U) -> Result<reqwest::RequestBuilder, AuthError> {
+        let request = self.inner_client.request(method, url);
+        self.auth_manager.prepare_request(request).await
+    }
+    
+    /// send get request
+    pub async fn get<U: IntoUrl>(&self, url: U) -> Result<reqwest::Response, AuthError> {
+        let request = self.request(reqwest::Method::GET, url).await?;
+        let response = request.send().await?;
+        self.auth_manager.handle_response(response).await
+    }
+    
+    /// send post request
+    pub async fn post<U: IntoUrl>(&self, url: U) -> Result<reqwest::RequestBuilder, AuthError> {
+        self.request(reqwest::Method::POST, url).await
+    }
+} 

--- a/crates/rmcp/src/transport/sse_auth.rs
+++ b/crates/rmcp/src/transport/sse_auth.rs
@@ -1,0 +1,183 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::{Future, Sink, Stream, StreamExt, future::BoxFuture, stream::BoxStream};
+use futures::sink::SinkExt as FuturesSinkExt;
+use reqwest::{
+    Client as HttpClient, IntoUrl, Url,
+    header::{ACCEPT, AUTHORIZATION, HeaderValue},
+};
+use sse_stream::{Error as SseError, Sse, SseStream};
+use thiserror::Error;
+use tokio::sync::Mutex;
+
+use crate::model::{ClientJsonRpcMessage, ServerJsonRpcMessage};
+use super::auth::{AuthorizationManager, AuthError};
+use super::sse::{SseTransportError, SseClient, SseTransport, SseTransportRetryConfig};
+
+// SSE MIME type
+const MIME_TYPE: &str = "text/event-stream";
+const HEADER_LAST_EVENT_ID: &str = "Last-Event-ID";
+
+/// sse client with oauth2 authorization
+#[derive(Clone)]
+pub struct AuthorizedSseClient {
+    http_client: HttpClient,
+    sse_url: Url,
+    auth_manager: Arc<Mutex<AuthorizationManager>>,
+    retry_config: SseTransportRetryConfig,
+}
+
+impl AuthorizedSseClient {
+    /// create new authorized sse client
+    pub fn new<U>(
+        url: U,
+        auth_manager: Arc<Mutex<AuthorizationManager>>,
+        retry_config: Option<SseTransportRetryConfig>,
+    ) -> Result<Self, SseTransportError<reqwest::Error>>
+    where
+        U: IntoUrl,
+    {
+        let url = url.into_url().map_err(SseTransportError::from)?;
+        Ok(Self {
+            http_client: HttpClient::default(),
+            sse_url: url,
+            auth_manager,
+            retry_config: retry_config.unwrap_or_default(),
+        })
+    }
+
+    /// create authorized sse client with custom http client
+    pub async fn new_with_client<U>(
+        url: U,
+        client: HttpClient,
+        auth_manager: Arc<Mutex<AuthorizationManager>>,
+        retry_config: Option<SseTransportRetryConfig>,
+    ) -> Result<Self, SseTransportError<reqwest::Error>>
+    where
+        U: IntoUrl,
+    {
+        let url = url.into_url().map_err(SseTransportError::from)?;
+        Ok(Self {
+            http_client: client,
+            sse_url: url,
+            auth_manager,
+            retry_config: retry_config.unwrap_or_default(),
+        })
+    }
+
+    /// get access token, support retry
+    async fn get_token_with_retry(&self) -> Result<String, SseTransportError<reqwest::Error>> {
+        let mut retries = 0;
+        let max_retries = self.retry_config.max_times;
+        let base_delay = self.retry_config.min_duration;
+
+        loop {
+            match self.auth_manager.lock().await.get_access_token().await {
+                Ok(token) => return Ok(token),
+                Err(AuthError::AuthorizationRequired) => {
+                    return Err(SseTransportError::Io(std::io::Error::new(std::io::ErrorKind::Other, "Authorization required")));
+                }
+                Err(_e) => {
+                    if retries >= max_retries.unwrap_or(0) {
+                        return Err(SseTransportError::Io(std::io::Error::new(std::io::ErrorKind::Other, "Authorization required")));
+                    }
+                    retries += 1;
+                    // todo: need to optimize
+                    let delay = base_delay.as_millis();
+                    tokio::time::sleep(Duration::from_millis(delay as u64)).await;
+                }
+            }
+        }
+    }
+}
+
+impl SseClient<reqwest::Error> for AuthorizedSseClient {
+    fn connect(&self, last_event_id: Option<String>) -> BoxFuture<'static, Result<BoxStream<'static, Result<Sse, SseError>>, SseTransportError<reqwest::Error>>> {
+        let client = self.http_client.clone();
+        let sse_url = self.sse_url.as_ref().to_string();
+        let last_event_id = last_event_id.clone();
+        let auth_manager = self.auth_manager.clone();
+        
+        let fut = async move {
+            // get access token
+            let token = auth_manager.lock().await.get_access_token().await?;
+                
+            // build request
+            let mut request_builder = client.get(&sse_url)
+                .header(ACCEPT, MIME_TYPE)
+                .header(AUTHORIZATION, format!("Bearer {}", token));
+                
+            if let Some(last_event_id) = last_event_id {
+                request_builder = request_builder.header(HEADER_LAST_EVENT_ID, last_event_id);
+            }
+            
+            let response = request_builder.send().await?;
+            let response = response.error_for_status()?;
+            
+            match response.headers().get(reqwest::header::CONTENT_TYPE) {
+                Some(ct) => {
+                    if !ct.as_bytes().starts_with(MIME_TYPE.as_bytes()) {
+                        return Err(SseTransportError::UnexpectedContentType(Some(ct.clone())));
+                    }
+                }
+                None => {
+                    return Err(SseTransportError::UnexpectedContentType(None));
+                }
+            }
+            
+            let event_stream = SseStream::from_byte_stream(response.bytes_stream()).boxed();
+            Ok(event_stream)
+        };
+        
+        Box::pin(fut)
+    }
+
+    fn post(
+        &self,
+        session_id: &str,
+        message: ClientJsonRpcMessage,
+    ) -> BoxFuture<'static, Result<(), SseTransportError<reqwest::Error>>> {
+        let client = self.http_client.clone();
+        let sse_url = self.sse_url.clone();
+        let session_id = session_id.to_string();
+        let auth_manager = self.auth_manager.clone();
+        
+        Box::pin(async move {
+            // get access token
+            let token = auth_manager.lock().await.get_access_token().await
+                .map_err(|e| SseTransportError::<reqwest::Error>::from(e))?;
+            
+            let uri = sse_url.join(&session_id).map_err(SseTransportError::from)?;
+            let request_builder = client.post(uri.as_ref())
+                .header(AUTHORIZATION, format!("Bearer {}", token))
+                .json(&message);
+                
+            request_builder
+                .send()
+                .await
+                .and_then(|resp| resp.error_for_status())
+                .map_err(SseTransportError::from)
+                .map(drop)
+        })
+    }
+}
+
+impl From<AuthError> for SseTransportError<reqwest::Error> {
+    fn from(err: AuthError) -> Self {
+        SseTransportError::Io(std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))
+    }
+}
+
+/// create authorized sse transport
+pub async fn create_authorized_transport<U>(
+    url: U,
+    auth_manager: Arc<Mutex<AuthorizationManager>>,
+    retry_config: Option<SseTransportRetryConfig>,
+) -> Result<SseTransport<AuthorizedSseClient, reqwest::Error>, SseTransportError<reqwest::Error>>
+where
+    U: IntoUrl,
+{
+    let client = AuthorizedSseClient::new(url, auth_manager, retry_config)?;
+    SseTransport::start_with_client(client).await
+} 

--- a/examples/clients/Cargo.toml
+++ b/examples/clients/Cargo.toml
@@ -11,7 +11,8 @@ rmcp = { path = "../../crates/rmcp", features = [
     "client",
     "transport-sse",
     "transport-child-process",
-    "tower"
+    "tower",
+    "auth"
 ] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -21,7 +22,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rand = "0.8"
 futures = "0.3"
 anyhow = "1.0"
-
+url = "2.4"
 tower = "0.5"
 
 [[example]]
@@ -40,3 +41,6 @@ path = "src/everything_stdio.rs"
 name = "clients_collection"
 path = "src/collection.rs"
 
+[[example]]
+name = "oauth_client"
+path = "src/oauth_client.rs"

--- a/examples/clients/src/oauth_client.rs
+++ b/examples/clients/src/oauth_client.rs
@@ -1,0 +1,90 @@
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Result;
+use rmcp::{
+    RoleClient, ServiceExt,
+    model::ClientInfo,
+    transport::{
+        auth::{AuthError, AuthorizationManager, AuthorizationSession, AuthorizedHttpClient},
+        create_authorized_transport,
+        sse::SseTransportRetryConfig,
+    },
+};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter},
+    sync::Mutex,
+};
+use url::Url;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // init logger
+    tracing_subscriber::fmt::init();
+
+    // server url
+    let server_url =
+        std::env::var("MCP_SERVER_URL").unwrap_or_else(|_| "http://localhost:3000/mcp".to_string());
+
+    // retry config
+    let retry_config = SseTransportRetryConfig {
+        max_times: Some(3),
+        min_duration: Duration::from_secs(1),
+    };
+
+    // init auth manager
+    let auth_manager = AuthorizationManager::new(&server_url).await?;
+    let auth_manager_arc = Arc::new(Mutex::new(auth_manager));
+
+    // create authorization session
+    let session = AuthorizationSession::new(
+        auth_manager_arc.clone(),
+        &["mcp"],                         // request scopes
+        "http://localhost:8080/callback", // redirect uri
+    )
+    .await?;
+
+    // output authorization url
+    let mut output = BufWriter::new(tokio::io::stdout());
+    output
+        .write_all(b"please open the following URL in your browser:\n")
+        .await?;
+    output
+        .write_all(session.get_authorization_url().as_bytes())
+        .await?;
+    output
+        .write_all(b"\nplease input the authorization code:\n")
+        .await?;
+    output.flush().await?;
+
+    // read authorization code
+    let mut auth_code = String::new();
+    let mut reader = BufReader::new(tokio::io::stdin());
+    reader.read_line(&mut auth_code).await?;
+    let auth_code = auth_code.trim();
+
+    // exchange access token
+    let credentials = session.handle_callback(auth_code).await?;
+    tracing::info!("Successfully obtained access token");
+
+    // create authorized sse transport, use retry config
+    let transport =
+        create_authorized_transport(&server_url, auth_manager_arc, Some(retry_config)).await?;
+
+    // create client
+    let client_service = ClientInfo::default();
+    let client = client_service.serve(transport).await?;
+
+    // test api request
+    let tools = client.peer().list_all_tools().await?;
+    tracing::info!("Available tools: {tools:#?}");
+
+    // get prompt list
+    let prompts = client.peer().list_all_prompts().await?;
+    tracing::info!("Available prompts: {prompts:#?}");
+
+    // get resource list
+    let resources = client.peer().list_all_resources().await?;
+    tracing::info!("Available resources: {resources:#?}");
+
+    Ok(())
+}


### PR DESCRIPTION
add oauth2 client support

## Motivation and Context
oauth2 is in mcp's sepc file

## How Has This Been Tested?
it

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed


