### PR TITLE
fix: fix resource leak when `RunningService` is dropped.

### DIFF
--- a/examples/servers/src/generic_service.rs
+++ b/examples/servers/src/generic_service.rs
@@ -13,6 +13,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let io = (tokio::io::stdin(), tokio::io::stdout());
 
-    serve_server(generic_service, io).await?;
+    serve_server(generic_service, io).await?.waiting().await?;
     Ok(())
 }


### PR DESCRIPTION
## Motivation and Context

We found in our service that when we were creating clients, they were not cleaning up their resources when they were dropped. Clients keeping their connections open when dropped does not follow the principle of least astonishment and ended up leaking resource. Where possible users can call `cancel` on their `RunningService`, but it is possible for an early exit ( eg by returning an error with `?`) to lead to resource leaks.

These changes add a `drop` implementation to `RunningService` so that when a service is dropped it cleans up its resources.

## Breaking Changes

This is a breaking change, as the change returns the error returned by `waiting` and `cancel` to `ServiceError`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

(python tests are not passing, probably due to local dev env)
