### PR TITLE
chore: disable unix_socket example on windows

### DIFF
--- a/examples/transport/src/unix_socket.rs
+++ b/examples/transport/src/unix_socket.rs
@@ -1,15 +1,66 @@
-use std::fs;
-
-use common::calculator::Calculator;
-use rmcp::{serve_client, serve_server};
-use tokio::net::{UnixListener, UnixStream};
-
 mod common;
 
-const SOCKET_PATH: &str = "/tmp/rmcp_example.sock";
-
+#[cfg(target_family = "unix")]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    use std::fs;
+
+    use common::calculator::Calculator;
+    use rmcp::{serve_client, serve_server};
+    use tokio::net::{UnixListener, UnixStream};
+
+    const SOCKET_PATH: &str = "/tmp/rmcp_example.sock";
+    async fn server(unix_listener: UnixListener) -> anyhow::Result<()> {
+        while let Ok((stream, addr)) = unix_listener.accept().await {
+            println!("Client connected: {:?}", addr);
+            tokio::spawn(async move {
+                match serve_server(Calculator, stream).await {
+                    Ok(server) => {
+                        println!("Server initialized successfully");
+                        if let Err(e) = server.waiting().await {
+                            println!("Error while server waiting: {}", e);
+                        }
+                    }
+                    Err(e) => println!("Server initialization failed: {}", e),
+                }
+
+                anyhow::Ok(())
+            });
+        }
+        Ok(())
+    }
+
+    async fn client() -> anyhow::Result<()> {
+        println!("Client connecting to {}", SOCKET_PATH);
+        let stream = UnixStream::connect(SOCKET_PATH).await?;
+
+        let client = serve_client((), stream).await?;
+        println!("Client connected and initialized successfully");
+
+        // List available tools
+        let tools = client.peer().list_tools(Default::default()).await?;
+        println!("Available tools: {:?}", tools);
+
+        // Call the sum tool
+        if let Some(sum_tool) = tools.tools.iter().find(|t| t.name.contains("sum")) {
+            println!("Calling sum tool: {}", sum_tool.name);
+            let result = client
+                .peer()
+                .call_tool(rmcp::model::CallToolRequestParam {
+                    name: sum_tool.name.clone(),
+                    arguments: Some(rmcp::object!({
+                        "a": 10,
+                        "b": 20
+                    })),
+                })
+                .await?;
+
+            println!("Result: {:?}", result);
+        }
+
+        Ok(())
+    }
+
     // Remove any existing socket file
     let _ = fs::remove_file(SOCKET_PATH);
     match UnixListener::bind(SOCKET_PATH) {
@@ -30,53 +81,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn server(unix_listener: UnixListener) -> anyhow::Result<()> {
-    while let Ok((stream, addr)) = unix_listener.accept().await {
-        println!("Client connected: {:?}", addr);
-        tokio::spawn(async move {
-            match serve_server(Calculator, stream).await {
-                Ok(server) => {
-                    println!("Server initialized successfully");
-                    if let Err(e) = server.waiting().await {
-                        println!("Error while server waiting: {}", e);
-                    }
-                }
-                Err(e) => println!("Server initialization failed: {}", e),
-            }
-
-            anyhow::Ok(())
-        });
-    }
-    Ok(())
-}
-
-async fn client() -> anyhow::Result<()> {
-    println!("Client connecting to {}", SOCKET_PATH);
-    let stream = UnixStream::connect(SOCKET_PATH).await?;
-
-    let client = serve_client((), stream).await?;
-    println!("Client connected and initialized successfully");
-
-    // List available tools
-    let tools = client.peer().list_tools(Default::default()).await?;
-    println!("Available tools: {:?}", tools);
-
-    // Call the sum tool
-    if let Some(sum_tool) = tools.tools.iter().find(|t| t.name.contains("sum")) {
-        println!("Calling sum tool: {}", sum_tool.name);
-        let result = client
-            .peer()
-            .call_tool(rmcp::model::CallToolRequestParam {
-                name: sum_tool.name.clone(),
-                arguments: Some(rmcp::object!({
-                    "a": 10,
-                    "b": 20
-                })),
-            })
-            .await?;
-
-        println!("Result: {:?}", result);
-    }
-
-    Ok(())
+#[cfg(not(target_family = "unix"))]
+fn main() {
+    println!("Unix socket example is not supported on this platform.");
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Adds conditional compilation (`#[cfg(target_family = "unix")]`) to the example `unix_socket.rs` to prevent build failures on Windows. 
I couldn't find a cleaner solution to exclude this example on Windows.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
 The example fails to compile on Windows due to its dependency on Unix-specific like `UnixStream`

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Verified on Unix: Example compiles and runs as expected.
Verified on Windows: No compilation errors.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

