### PR TITLE
Improve error logging in SSE server message handling

### DIFF
--- a/crates/rmcp/src/transport/sse_server.rs
+++ b/crates/rmcp/src/transport/sse_server.rs
@@ -79,6 +79,7 @@ async fn post_event_handler(
             .ok_or(StatusCode::NOT_FOUND)?
             .clone()
     };
+    
     match tx.send(message).await {
         Ok(_) => Ok(StatusCode::ACCEPTED),
         Err(e) => {
@@ -86,7 +87,6 @@ async fn post_event_handler(
             Err(StatusCode::GONE)
         }
     }
-    Ok(StatusCode::ACCEPTED)
 }
 
 async fn sse_handler(

--- a/crates/rmcp/src/transport/sse_server.rs
+++ b/crates/rmcp/src/transport/sse_server.rs
@@ -79,9 +79,12 @@ async fn post_event_handler(
             .ok_or(StatusCode::NOT_FOUND)?
             .clone()
     };
-    if tx.send(message).await.is_err() {
-        tracing::error!("send message error");
-        return Err(StatusCode::GONE);
+    match tx.send(message).await {
+        Ok(_) => Ok(StatusCode::ACCEPTED),
+        Err(e) => {
+            tracing::error!("send message error: {}", e);
+            Err(StatusCode::GONE)
+        }
     }
     Ok(StatusCode::ACCEPTED)
 }


### PR DESCRIPTION
Passes the actual error to error log

## Motivation and Context
Add detailed error information to the tracing::error! call when message sending fails, making it easier to diagnose communication issues between clients and the server.

## How Has This Been Tested?
Tested in a local project, for some reason I can reproduce this error each time I change resources with `npx @modelcontextprotocol/inspector`

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed