### PR TITLE
feat: several oauth improvements: support reusing credentials. capture additional fields instead of failing

### DIFF
--- a/examples/servers/src/mcp_oauth_server.rs
+++ b/examples/servers/src/mcp_oauth_server.rs
@@ -525,6 +525,7 @@ async fn oauth_authorization_server() -> impl IntoResponse {
         registration_endpoint: format!("http://{}/oauth/register", BIND_ADDRESS),
         issuer: Some(BIND_ADDRESS.to_string()),
         jwks_uri: Some(format!("http://{}/oauth/jwks", BIND_ADDRESS)),
+        additional_fields: HashMap::new(),
     };
     debug!("metadata: {:?}", metadata);
     (StatusCode::OK, Json(metadata))
@@ -567,9 +568,10 @@ async fn oauth_register(
     // return client information
     let response = ClientRegistrationResponse {
         client_id,
-        client_secret,
+        client_secret: Some(client_secret),
         client_name: req.client_name,
         redirect_uris: req.redirect_uris,
+        additional_fields: HashMap::new(),
     };
 
     (StatusCode::CREATED, Json(response)).into_response()


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
I am writing an application (oneserver.ai) that uses this sdk for connecting to remote servers, and encountered a few issues with the new OAuth work:
- Currently I cannot use reuse OAuth credentials conveniently (must do the whole flow each time)
- I encounter decoding errors on dynamic client registration responses + OAuth metadata discovery due to fields that are not included in the serde struct definitions

This PR fixes both of these:
- OAuthState now has two new methods:
get_credentials: returns client_id and OAuthTokenResponse
set_credentials: sets the client_id and OAuthTokenResponse, and moves the state machine into the Authorized state for use in the transport
- Added an `additional_fields` field to both the AuthorizationMetadata struct and the ClientRegistrationResponse struct which will contain all additional fields available in the response. This lets us safely ignore fields that we don't need for our flow.
- Additionally, client_secret is now an optionally returned value in ClientRegistrationResponse (some implementations of Oauth2 dynamic client registration do not return this value it seems)

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I tested this from within my application oneserver.ai against our hosted hello world remote MCP server at https://mcp.oneserver.ai and it works perfectly :)

You will notice that the current version fails when run against this server, and the new version succeeds.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Will break some implementations that use the ClientRegistrationResponse and AuthorizationMetadata structs, but considering this oauth work is very new, I think this is okay.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
