### PR TITLE
align message endpoint with sse

### DIFF
--- a/crates/rmcp/src/transport/sse.rs
+++ b/crates/rmcp/src/transport/sse.rs
@@ -167,6 +167,12 @@ impl SseClient<reqwest::Error> for ReqwestSseClient {
         let sse_url = self.sse_url.clone();
         let session_id = session_id.to_string();
         Box::pin(async move {
+            // align message endpoint with sse
+            let session_id = if session_id.starts_with("/") {
+                &session_id[1..]
+            } else {
+                &session_id
+            };
             let uri = sse_url.join(&session_id).map_err(SseTransportError::from)?;
             let request_builder = client.post(uri.as_ref()).json(&message);
             request_builder

--- a/crates/rmcp/src/transport/sse_auth.rs
+++ b/crates/rmcp/src/transport/sse_auth.rs
@@ -132,7 +132,12 @@ impl SseClient<reqwest::Error> for AuthorizedSseClient {
                 .get_access_token()
                 .await
                 .map_err(SseTransportError::<reqwest::Error>::from)?;
-
+            // align message endpoint with sse
+            let session_id = if session_id.starts_with("/") {
+                &session_id[1..]
+            } else {
+                &session_id
+            };
             let uri = sse_url.join(&session_id).map_err(SseTransportError::from)?;
             let request_builder = client
                 .post(uri.as_ref())


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
When the MCP server, connected via SSE, returns an endpoint event with a data value that starts with / (e.g., /mcp/message?sessionId=...), the SDK appears to be using this absolute path directly without considering the base URL of the initial SSE connection. This results in the client attempting to access an incorrect URL.

## How Has This Been Tested?

maybe it require a api-gateway server

<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes

Nope

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [✅ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ✅ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ✅ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
