### PR TITLE
Fix SSE Transport Memory Leak

### DIFF
--- a/crates/rmcp/src/transport/sse_server.rs
+++ b/crates/rmcp/src/transport/sse_server.rs
@@ -89,6 +89,8 @@ async fn sse_handler(
     use tokio_util::sync::PollSender;
     let (from_client_tx, from_client_rx) = tokio::sync::mpsc::channel(64);
     let (to_client_tx, to_client_rx) = tokio::sync::mpsc::channel(64);
+    let to_client_tx_clone = to_client_tx.clone();
+
     app.txs
         .write()
         .await
@@ -123,6 +125,19 @@ async fn sse_handler(
             Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e)),
         }
     }));
+
+    tokio::spawn(async move {
+        // Wait for connection closure
+        to_client_tx_clone.closed().await;
+
+        // Clean up session
+        let session_id = session.clone();
+        let tx_store = app.txs.clone();
+        let mut txs = tx_store.write().await;
+        txs.remove(&session_id);
+        tracing::debug!(%session_id, "Closed session and cleaned up resources");
+    });
+
     Ok(Sse::new(stream).keep_alive(KeepAlive::new().interval(ping_interval)))
 }
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
When running the SSE transport in production, we noticed a massive memory leak. We have a Kubernetes health check process that was hitting the SSE endpoint periodically and then just disconnecting which was causing the memory leak. Digging in to the current implementation, there is no disconnection handling in the case of an abrupt disconnection, so this PR adds some cleanup when the connection drops.

## Motivation and Context
Removes a memory leak in the case that a client disconnects abruptly.

## How Has This Been Tested?
You can replicate the memory leak by simply making a GET request to the SSE endpoint and then disconnecting many times to see memory grow quite rapidly. I applied this fix to our production environment and the instance memory usage has been steady since.

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
There were two errors that were failing on main already, so these changes have not added any new errors.
