### PR TITLE
fix(schemar): Use custom settings without packaging settings

### DIFF
--- a/crates/rmcp/src/handler/server/tool.rs
+++ b/crates/rmcp/src/handler/server/tool.rs
@@ -14,7 +14,13 @@ use crate::{
 };
 /// A shortcut for generating a JSON schema for a type.
 pub fn schema_for_type<T: JsonSchema>() -> JsonObject {
-    let settings = schemars::r#gen::SchemaSettings::openapi3();
+    let mut settings = schemars::r#gen::SchemaSettings::default();
+    settings.option_nullable = true;
+    settings.option_add_null_type = false;
+    settings.definitions_path = "#/components/schemas/".to_owned();
+    settings.meta_schema = None;
+    settings.visitors = Vec::default();
+    settings.inline_subschemas = false;
     let generator = settings.into_generator();
     let schema = generator.into_root_schema_for::<T>();
     let object = serde_json::to_value(schema).expect("failed to serialize schema");


### PR DESCRIPTION
The Shemar configuration of the packaging lacks flexibility and ignores fields that are not defined in the spec file.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
