### PR TITLE
enhancement: more friendly interface to get service error

### DIFF
--- a/crates/rmcp/src/handler/client.rs
+++ b/crates/rmcp/src/handler/client.rs
@@ -53,14 +53,6 @@ impl<H: ClientHandler> Service<RoleClient> for H {
         Ok(())
     }
 
-    fn get_peer(&self) -> Option<Peer<RoleClient>> {
-        self.get_peer()
-    }
-
-    fn set_peer(&mut self, peer: Peer<RoleClient>) {
-        self.set_peer(peer);
-    }
-
     fn get_info(&self) -> <RoleClient as ServiceRole>::Info {
         self.get_info()
     }

--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -89,14 +89,6 @@ impl<H: ServerHandler> Service<RoleServer> for H {
         Ok(())
     }
 
-    fn get_peer(&self) -> Option<Peer<RoleServer>> {
-        self.get_peer()
-    }
-
-    fn set_peer(&mut self, peer: Peer<RoleServer>) {
-        self.set_peer(peer);
-    }
-
     fn get_info(&self) -> <RoleServer as ServiceRole>::Info {
         self.get_info()
     }

--- a/crates/rmcp/src/service/tower.rs
+++ b/crates/rmcp/src/service/tower.rs
@@ -2,12 +2,11 @@ use std::{future::poll_fn, marker::PhantomData};
 
 use tower_service::Service as TowerService;
 
-use crate::service::{Peer, RequestContext, Service, ServiceRole};
+use crate::service::{RequestContext, Service, ServiceRole};
 
 pub struct TowerHandler<S, R: ServiceRole> {
     pub service: S,
     pub info: R::Info,
-    pub peer: Option<Peer<R>>,
     role: PhantomData<R>,
 }
 
@@ -17,7 +16,6 @@ impl<S, R: ServiceRole> TowerHandler<S, R> {
             service,
             role: PhantomData,
             info,
-            peer: None,
         }
     }
 }
@@ -46,14 +44,6 @@ where
         _notification: R::PeerNot,
     ) -> impl Future<Output = Result<(), crate::Error>> + Send + '_ {
         std::future::ready(Ok(()))
-    }
-
-    fn get_peer(&self) -> Option<Peer<R>> {
-        self.peer.clone()
-    }
-
-    fn set_peer(&mut self, peer: Peer<R>) {
-        self.peer = Some(peer);
     }
 
     fn get_info(&self) -> R::Info {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
1. remove unused `get_info` and `set_info`.
2. make it more clear when user get an error after called method on peer.
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
explained in #188, and also aims to solve #177
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Removed `get_info` and `set_info`. And explained in #188 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
