### PR TITLE
feat: better http server support

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -129,7 +129,7 @@ tracing-subscriber = { version = "0.3", features = [
 async-trait = "0.1"
 [[test]]
 name = "test_tool_macros"
-required-features = ["server"]
+required-features = ["server", "client"]
 path = "tests/test_tool_macros.rs"
 
 [[test]]

--- a/crates/rmcp/src/handler/client.rs
+++ b/crates/rmcp/src/handler/client.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::Error as McpError,
     model::*,
-    service::{Peer, RequestContext, RoleClient, Service, ServiceRole},
+    service::{RequestContext, RoleClient, Service, ServiceRole},
 };
 
 impl<H: ClientHandler> Service<RoleClient> for H {
@@ -118,47 +118,16 @@ pub trait ClientHandler: Sized + Send + Sync + 'static {
         std::future::ready(())
     }
 
-    fn get_peer(&self) -> Option<Peer<RoleClient>>;
-
-    fn set_peer(&mut self, peer: Peer<RoleClient>);
-
     fn get_info(&self) -> ClientInfo {
         ClientInfo::default()
     }
 }
 
-/// Do nothing, just store the peer.
-impl ClientHandler for Option<Peer<RoleClient>> {
-    fn get_peer(&self) -> Option<Peer<RoleClient>> {
-        self.clone()
-    }
+/// Do nothing, with default client info.
+impl ClientHandler for () {}
 
-    fn set_peer(&mut self, peer: Peer<RoleClient>) {
-        *self = Some(peer);
-    }
-}
-
-/// Do nothing, even store the peer.
-impl ClientHandler for () {
-    fn get_peer(&self) -> Option<Peer<RoleClient>> {
-        None
-    }
-
-    fn set_peer(&mut self, peer: Peer<RoleClient>) {
-        drop(peer);
-    }
-}
-
-/// Do nothing, even store the peer.
+/// Do nothing, with a specific client info.
 impl ClientHandler for ClientInfo {
-    fn get_peer(&self) -> Option<Peer<RoleClient>> {
-        None
-    }
-
-    fn set_peer(&mut self, peer: Peer<RoleClient>) {
-        drop(peer);
-    }
-
     fn get_info(&self) -> ClientInfo {
         self.clone()
     }

--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::Error as McpError,
     model::*,
-    service::{Peer, RequestContext, RoleServer, Service, ServiceRole},
+    service::{RequestContext, RoleServer, Service, ServiceRole},
 };
 
 mod resource;
@@ -108,6 +108,10 @@ pub trait ServerHandler: Sized + Send + Sync + 'static {
         request: InitializeRequestParam,
         context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<InitializeResult, McpError>> + Send + '_ {
+        if context.peer.peer_info().is_none() {
+            context.peer.set_peer_info(request);
+        }
+        let info = self.get_info();
         std::future::ready(Ok(self.get_info()))
     }
     fn complete(
@@ -208,14 +212,6 @@ pub trait ServerHandler: Sized + Send + Sync + 'static {
     }
     fn on_roots_list_changed(&self) -> impl Future<Output = ()> + Send + '_ {
         std::future::ready(())
-    }
-
-    fn get_peer(&self) -> Option<Peer<RoleServer>> {
-        None
-    }
-
-    fn set_peer(&mut self, peer: Peer<RoleServer>) {
-        drop(peer);
     }
 
     fn get_info(&self) -> ServerInfo {

--- a/crates/rmcp/src/handler/server/tool.rs
+++ b/crates/rmcp/src/handler/server/tool.rs
@@ -86,6 +86,9 @@ impl<'service, S> ToolCallContext<'service, S> {
     pub fn name(&self) -> &str {
         &self.name
     }
+    pub fn request_context(&self) -> &RequestContext<RoleServer> {
+        &self.request_context
+    }
 }
 
 pub trait FromToolCallContextPart<'a, S>: Sized {
@@ -281,6 +284,39 @@ impl<'a, S> FromToolCallContextPart<'a, S> for JsonObject {
     ) -> Result<(Self, ToolCallContext<'a, S>), crate::Error> {
         let object = context.arguments.take().unwrap_or_default();
         Ok((object, context))
+    }
+}
+
+impl<'a, S> FromToolCallContextPart<'a, S> for crate::model::Extensions {
+    fn from_tool_call_context_part(
+        context: ToolCallContext<'a, S>,
+    ) -> Result<(Self, ToolCallContext<'a, S>), crate::Error> {
+        let extensions = context.request_context.extensions.clone();
+        Ok((extensions, context))
+    }
+}
+
+pub struct Extension<T>(pub T);
+
+impl<'a, S, T> FromToolCallContextPart<'a, S> for Extension<T>
+where
+    T: Send + Sync + 'static + Clone,
+{
+    fn from_tool_call_context_part(
+        context: ToolCallContext<'a, S>,
+    ) -> Result<(Self, ToolCallContext<'a, S>), crate::Error> {
+        let extension = context
+            .request_context
+            .extensions
+            .get::<T>()
+            .cloned()
+            .ok_or_else(|| {
+                crate::Error::invalid_params(
+                    format!("missing extension {}", std::any::type_name::<T>()),
+                    None,
+                )
+            })?;
+        Ok((Extension(extension), context))
     }
 }
 

--- a/crates/rmcp/src/service/client.rs
+++ b/crates/rmcp/src/service/client.rs
@@ -174,7 +174,7 @@ where
             error,
             context: "send initialized notification".into(),
         })?;
-    let (peer, peer_rx) = Peer::new(id_provider, initialize_result);
+    let (peer, peer_rx) = Peer::new(id_provider, Some(initialize_result));
     Ok(serve_inner(service, transport, peer, peer_rx, ct).await)
 }
 

--- a/crates/rmcp/src/service/server.rs
+++ b/crates/rmcp/src/service/server.rs
@@ -156,7 +156,7 @@ where
             ClientJsonRpcMessage::request(request, id),
         )));
     };
-    let (peer, peer_rx) = Peer::new(id_provider, peer_info.params.clone());
+    let (peer, peer_rx) = Peer::new(id_provider, Some(peer_info.params.clone()));
     let context = RequestContext {
         ct: ct.child_token(),
         id: id.clone(),

--- a/crates/rmcp/src/transport.rs
+++ b/crates/rmcp/src/transport.rs
@@ -57,7 +57,7 @@
 //!
 //! // create transport from std io
 //! async fn io()  -> Result<(), Box<dyn std::error::Error>> {
-//!     let client = None.serve((tokio::io::stdin(), tokio::io::stdout())).await?;
+//!     let client = ().serve((tokio::io::stdin(), tokio::io::stdout())).await?;
 //!     let tools = client.peer().list_tools(Default::default()).await?;
 //!     println!("{:?}", tools);
 //!     Ok(())

--- a/crates/rmcp/tests/common/handlers.rs
+++ b/crates/rmcp/tests/common/handlers.rs
@@ -4,16 +4,14 @@ use std::{
 };
 
 use rmcp::{
-    ClientHandler, Error as McpError, RoleClient, RoleServer, ServerHandler,
-    model::*,
-    service::{Peer, RequestContext},
+    ClientHandler, Error as McpError, RoleClient, RoleServer, ServerHandler, model::*,
+    service::RequestContext,
 };
 use serde_json::json;
 use tokio::sync::Notify;
 
 #[derive(Clone)]
 pub struct TestClientHandler {
-    pub peer: Option<Peer<RoleClient>>,
     pub honor_this_server: bool,
     pub honor_all_servers: bool,
     pub receive_signal: Arc<Notify>,
@@ -24,7 +22,6 @@ impl TestClientHandler {
     #[allow(dead_code)]
     pub fn new(honor_this_server: bool, honor_all_servers: bool) -> Self {
         Self {
-            peer: None,
             honor_this_server,
             honor_all_servers,
             receive_signal: Arc::new(Notify::new()),
@@ -40,7 +37,6 @@ impl TestClientHandler {
         received_messages: Arc<Mutex<Vec<LoggingMessageNotificationParam>>>,
     ) -> Self {
         Self {
-            peer: None,
             honor_this_server,
             honor_all_servers,
             receive_signal,
@@ -50,14 +46,6 @@ impl TestClientHandler {
 }
 
 impl ClientHandler for TestClientHandler {
-    fn get_peer(&self) -> Option<Peer<RoleClient>> {
-        self.peer.clone()
-    }
-
-    fn set_peer(&mut self, peer: Peer<RoleClient>) {
-        self.peer = Some(peer);
-    }
-
     async fn create_message(
         &self,
         params: CreateMessageRequestParam,

--- a/crates/rmcp/tests/test_notification.rs
+++ b/crates/rmcp/tests/test_notification.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rmcp::{
-    ClientHandler, Peer, RoleClient, ServerHandler, ServiceExt,
+    ClientHandler, ServerHandler, ServiceExt,
     model::{
         ResourceUpdatedNotificationParam, ServerCapabilities, ServerInfo, SubscribeRequestParam,
     },
@@ -49,7 +49,6 @@ impl ServerHandler for Server {
 
 pub struct Client {
     receive_signal: Arc<Notify>,
-    peer: Option<Peer<RoleClient>>,
 }
 
 impl ClientHandler for Client {
@@ -57,14 +56,6 @@ impl ClientHandler for Client {
         let uri = params.uri;
         tracing::info!("Resource updated: {}", uri);
         self.receive_signal.notify_one();
-    }
-
-    fn set_peer(&mut self, peer: Peer<RoleClient>) {
-        self.peer.replace(peer);
-    }
-
-    fn get_peer(&self) -> Option<Peer<RoleClient>> {
-        self.peer.clone()
     }
 }
 
@@ -85,7 +76,6 @@ async fn test_server_notification() -> anyhow::Result<()> {
     });
     let receive_signal = Arc::new(Notify::new());
     let client = Client {
-        peer: Default::default(),
         receive_signal: receive_signal.clone(),
     }
     .serve(client_transport)

--- a/crates/rmcp/tests/test_tool_macros.rs
+++ b/crates/rmcp/tests/test_tool_macros.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use rmcp::{
-    ClientHandler, Peer, RoleClient, ServerHandler, ServiceExt,
+    ClientHandler, ServerHandler, ServiceExt,
     handler::server::tool::ToolCallContext,
     model::{CallToolRequestParam, ClientInfo},
     tool,
@@ -242,21 +242,11 @@ fn test_optional_field_schema_generation_via_macro() {
 
 // Define a dummy client handler
 #[derive(Debug, Clone, Default)]
-struct DummyClientHandler {
-    peer: Option<Peer<RoleClient>>,
-}
+struct DummyClientHandler {}
 
 impl ClientHandler for DummyClientHandler {
     fn get_info(&self) -> ClientInfo {
         ClientInfo::default()
-    }
-
-    fn set_peer(&mut self, peer: Peer<RoleClient>) {
-        self.peer = Some(peer);
-    }
-
-    fn get_peer(&self) -> Option<Peer<RoleClient>> {
-        self.peer.clone()
     }
 }
 

--- a/examples/servers/src/axum.rs
+++ b/examples/servers/src/axum.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
 
     let ct = SseServer::serve(BIND_ADDRESS.parse()?)
         .await?
-        .with_service(Counter::new);
+        .with_service_directly(Counter::new);
 
     tokio::signal::ctrl_c().await?;
     ct.cancel();


### PR DESCRIPTION
1. allow user get extensions in tool call. To support #175
2. allow user serve sse service without initialization. To support [this](https://github.com/modelcontextprotocol/rust-sdk/issues/171#issuecomment-2889166130)

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Now the `peer_info` in `Peer` could be uninitialized. This allows users serve a transport without initialization.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
