### PR TITLE
fix: resolve the server 406 error in API calls

### DIFF
--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -88,8 +88,7 @@ impl StreamableHttpClient for reqwest::Client {
     ) -> Result<StreamableHttpPostResponse, StreamableHttpError<Self::Error>> {
         let mut request = self
             .post(uri.as_ref())
-            .header(ACCEPT, EVENT_STREAM_MIME_TYPE)
-            .header(ACCEPT, JSON_MIME_TYPE);
+            .header(ACCEPT, [EVENT_STREAM_MIME_TYPE, JSON_MIME_TYPE].join(", "));
         if let Some(auth_header) = auth_token {
             request = request.bearer_auth(auth_header);
         }


### PR DESCRIPTION
## Motivation and Context

- ​​Problem​​: When using the typescript-sdk's StreamableHttp server (from src/examples/server/simpleStreamableHttp.ts), requests from rust-sdk clients would return 406 errors, making the service unusable for these clients.
​​- Root Cause​​: The server's Accept header validation was too strict, rejecting valid requests from certain SDK implementations.
​​- Solution​​: By merging and properly handling Accept headers, we maintain compatibility across different SDK implementations while preserving the expected behavior.

## How Has This Been Tested?

- Modified the typescript-sdk and verified using the rust-sdk client example (examples/clients/src/streamable_http.rs)
- Confirmed that:
  - 406 errors no longer occur for valid requests
  - Standard JSON requests (Accept: application/json) continue to work as expected
  - The service remains stable with different Accept header variations

## Breaking Changes
No breaking changes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

> issue:

<img width="908" alt="image" src="https://github.com/user-attachments/assets/f68b6d68-30c3-4b14-9dd6-49d5d30d52ff" />

> after repair:

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/c4ce9de1-a5e7-41d9-85c3-03c800d634e9" />

