### PR TITLE
Fix: generic ServerHandler 

### DIFF
--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -258,7 +258,7 @@ pub(crate) fn tool_impl_item(attr: TokenStream, mut input: ItemImpl) -> syn::Res
                 input.items.push(parse_quote! {
                     async fn list_tools(
                         &self,
-                        request: rmcp::model::PaginatedRequestParam,
+                        request: Option<rmcp::model::PaginatedRequestParam>,
                         context: rmcp::service::RequestContext<rmcp::RoleServer>,
                     ) -> Result<rmcp::model::ListToolsResult, rmcp::Error> {
                         self.list_tools_inner(request, context).await
@@ -316,7 +316,7 @@ pub(crate) fn tool_impl_item(attr: TokenStream, mut input: ItemImpl) -> syn::Res
             input.items.push(parse_quote! {
                 async fn list_tools_inner(
                     &self,
-                    _: rmcp::model::PaginatedRequestParam,
+                    _: Option<rmcp::model::PaginatedRequestParam>,
                     _: rmcp::service::RequestContext<rmcp::RoleServer>,
                 ) -> Result<rmcp::model::ListToolsResult, rmcp::Error> {
                     Ok(rmcp::model::ListToolsResult {

--- a/crates/rmcp/tests/test_tool_macros.rs
+++ b/crates/rmcp/tests/test_tool_macros.rs
@@ -83,6 +83,8 @@ impl<DS: DataService> GenericServer<DS> {
         self.data_service.get_data()
     }
 }
+#[tool(tool_box)]
+impl<DS: DataService> ServerHandler for GenericServer<DS> {}
 
 #[tokio::test]
 async fn test_tool_macros() {


### PR DESCRIPTION
The `list_tools` function now accepts `Option<PaginatedRequestParam>` but the macro wasn't updated for generic servers. This pr fixes the error and adds the implementation to the test to avoid future regressions.

```rust
#[tool(tool_box)]
impl<DS: DataService> ServerHandler for GenericServer<DS> {}

/// error:


error[E0053]: method `list_tools` has an incompatible type for trait
  --> crates/rmcp/tests/test_tool_macros.rs:86:1
   |
86 | #[tool(tool_box)]
   | ^^^^^^^^^^^^^^^^^ expected `Option<PaginatedRequestParam>`, found `PaginatedRequestParam`
   |
   = note: expected signature `fn(&GenericServer<_>, std::option::Option<PaginatedRequestParam>, RequestContext<_>) -> _`
              found signature `fn(&GenericServer<_>, PaginatedRequestParam, RequestContext<_>) -> _`
   = note: this error originates in the attribute macro `tool` (in Nightly builds, run with -Z macro-backtrace for more info)
help: change the parameter type to match the trait
   |
86 | std::option::Option<PaginatedRequestParam>


```
