### PR TITLE
fix: allow SSE server router to be nested

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -151,6 +151,7 @@ path = "tests/test_tool_macros.rs"
 [[test]]
 name = "test_with_python"
 required-features = [
+    "reqwest",
     "server",
     "client",
     "transport-sse-server",

--- a/crates/rmcp/src/transport/sse_server.rs
+++ b/crates/rmcp/src/transport/sse_server.rs
@@ -1,10 +1,15 @@
 use std::{collections::HashMap, io, net::SocketAddr, sync::Arc, time::Duration};
 
-use axum::{Json, Router, extract::{Query, State}, http::{StatusCode, request::Parts}, response::{
-    Response,
-    sse::{Event, KeepAlive, Sse},
-}, routing::{get, post}, Extension};
-use axum::extract::NestedPath;
+use axum::{
+    Extension, Json, Router,
+    extract::{NestedPath, Query, State},
+    http::{StatusCode, request::Parts},
+    response::{
+        Response,
+        sse::{Event, KeepAlive, Sse},
+    },
+    routing::{get, post},
+};
 use futures::{Sink, SinkExt, Stream};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::{CancellationToken, PollSender};

--- a/crates/rmcp/tests/test_with_python.rs
+++ b/crates/rmcp/tests/test_with_python.rs
@@ -1,15 +1,18 @@
+use axum::Router;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 use rmcp::{
     ServiceExt,
-    transport::{ConfigureCommandExt, SseServer, TokioChildProcess},
+    transport::{
+        ConfigureCommandExt, SseServer, TokioChildProcess,
+        sse_server::SseServerConfig
+    },
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 mod common;
 use common::calculator::Calculator;
 
-const BIND_ADDRESS: &str = "127.0.0.1:8000";
-
-#[tokio::test]
-async fn test_with_python_client() -> anyhow::Result<()> {
+async fn init() -> anyhow::Result<()> {
     let _ = tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -23,6 +26,14 @@ async fn test_with_python_client() -> anyhow::Result<()> {
         .spawn()?
         .wait()
         .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_with_python_client() -> anyhow::Result<()> {
+    init().await?;
+
+    const BIND_ADDRESS: &str = "127.0.0.1:8000";
 
     let ct = SseServer::serve(BIND_ADDRESS.parse()?)
         .await?
@@ -31,6 +42,7 @@ async fn test_with_python_client() -> anyhow::Result<()> {
     let status = tokio::process::Command::new("uv")
         .arg("run")
         .arg("tests/test_with_python/client.py")
+        .arg(format!("http://{BIND_ADDRESS}/sse"))
         .spawn()?
         .wait()
         .await?;
@@ -39,21 +51,64 @@ async fn test_with_python_client() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Test the SSE server in a nested Axum router.
+#[tokio::test]
+async fn test_nested_with_python_client() -> anyhow::Result<()> {
+    init().await?;
+
+    const BIND_ADDRESS: &str = "127.0.0.1:8001";
+
+    // Create an SSE router
+    let sse_config = SseServerConfig {
+        bind: BIND_ADDRESS.parse()?,
+        sse_path: "/sse".to_string(),
+        post_path: "/message".to_string(),
+        ct: CancellationToken::new(),
+        sse_keep_alive: None,
+    };
+
+    let listener = tokio::net::TcpListener::bind(&sse_config.bind).await?;
+
+    let (sse_server, sse_router) = SseServer::new(sse_config);
+    let ct = sse_server.with_service(Calculator::default);
+
+    let main_router = Router::new()
+        .nest("/nested", sse_router);
+
+    let server_ct = ct.clone();
+    let server = axum::serve(listener, main_router)
+        .with_graceful_shutdown(async move {
+            server_ct.cancelled().await;
+            tracing::info!("sse server cancelled");
+        });
+
+    tokio::spawn(
+        async move {
+            let _ = server.await;
+            tracing::info!("sse server shutting down");
+        }
+    );
+
+    // Spawn the process with timeout, as failure to access the '/message' URL
+    // causes the client to never exit.
+    let status = timeout(
+        tokio::time::Duration::from_secs(5),
+        tokio::process::Command::new("uv")
+            .arg("run")
+            .arg("tests/test_with_python/client.py")
+            .arg(format!("http://{BIND_ADDRESS}/nested/sse"))
+            .spawn()?
+            .wait()
+    ).await?;
+    assert!(status?.success());
+    ct.cancel();
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_with_python_server() -> anyhow::Result<()> {
-    let _ = tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "debug".to_string().into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .try_init();
-    tokio::process::Command::new("uv")
-        .args(["pip", "install", "-r", "pyproject.toml"])
-        .current_dir("tests/test_with_python")
-        .spawn()?
-        .wait()
-        .await?;
+    init().await?;
+
     let transport = TokioChildProcess::new(tokio::process::Command::new("uv").configure(|cmd| {
         cmd.arg("run").arg("tests/test_with_python/server.py");
     }))?;

--- a/crates/rmcp/tests/test_with_python/client.py
+++ b/crates/rmcp/tests/test_with_python/client.py
@@ -1,10 +1,10 @@
 from mcp import ClientSession, StdioServerParameters, types
 from mcp.client.sse import sse_client
-
-
+import sys
 
 async def run():
-    async with sse_client("http://localhost:8000/sse") as (read, write):
+    url = sys.argv[1]
+    async with sse_client(url) as (read, write):
         async with ClientSession(
             read, write
         ) as session:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Allows the SSE server router to be nested.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The SSE server router was providing the `post_path` provided in the server configuration, assuming it was mounted at the root of the server. This prevented the SSE router to be nested in a larger Axum routing tree (as indicated by the comment on `SseServer::new()`.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Test added in `test_with_python`. I slightly refactored the other tests in that file to extract the initialization part.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
