### PR TITLE
feat: allow failable service creation in streamable HTTP tower service

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -318,7 +318,9 @@ where
                     .create_session()
                     .await
                     .map_err(internal_error_response("create session"))?;
-                let service = self.get_service().map_err(internal_error_response("get service"))?;
+                let service = self
+                    .get_service()
+                    .map_err(internal_error_response("get service"))?;
                 // spawn a task to serve the session
                 tokio::spawn({
                     let session_manager = self.session_manager.clone();
@@ -372,7 +374,9 @@ where
                 Ok(response)
             }
         } else {
-            let service = self.get_service().map_err(internal_error_response("get service"))?;
+            let service = self
+                .get_service()
+                .map_err(internal_error_response("get service"))?;
             match message {
                 ClientJsonRpcMessage::Request(request) => {
                     let (transport, receiver) =

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -47,7 +47,7 @@ impl Default for StreamableHttpServerConfig {
 pub struct StreamableHttpService<S, M = super::session::local::LocalSessionManager> {
     pub config: StreamableHttpServerConfig,
     session_manager: Arc<M>,
-    service_factory: Arc<dyn Fn() -> S + Send + Sync>,
+    service_factory: Arc<dyn Fn() -> Result<S, std::io::Error> + Send + Sync>,
 }
 
 impl<S, M> Clone for StreamableHttpService<S, M> {
@@ -92,7 +92,7 @@ where
     M: SessionManager,
 {
     pub fn new(
-        service_factory: impl Fn() -> S + Send + Sync + 'static,
+        service_factory: impl Fn() -> Result<S, std::io::Error> + Send + Sync + 'static,
         session_manager: Arc<M>,
         config: StreamableHttpServerConfig,
     ) -> Self {
@@ -102,7 +102,7 @@ where
             service_factory: Arc::new(service_factory),
         }
     }
-    fn get_service(&self) -> S {
+    fn get_service(&self) -> Result<S, std::io::Error> {
         (self.service_factory)()
     }
     pub async fn handle<B>(&self, request: Request<B>) -> Response<UnsyncBoxBody<Bytes, Infallible>>
@@ -318,7 +318,7 @@ where
                     .create_session()
                     .await
                     .map_err(internal_error_response("create session"))?;
-                let service = self.get_service();
+                let service = self.get_service().map_err(internal_error_response("get service"))?;
                 // spawn a task to serve the session
                 tokio::spawn({
                     let session_manager = self.session_manager.clone();
@@ -372,7 +372,7 @@ where
                 Ok(response)
             }
         } else {
-            let service = self.get_service();
+            let service = self.get_service().map_err(internal_error_response("get service"))?;
             match message {
                 ClientJsonRpcMessage::Request(request) => {
                     let (transport, receiver) =

--- a/crates/rmcp/tests/test_with_js.rs
+++ b/crates/rmcp/tests/test_with_js.rs
@@ -96,7 +96,7 @@ async fn test_with_js_streamable_http_client() -> anyhow::Result<()> {
 
     let service: StreamableHttpService<Calculator, LocalSessionManager> =
         StreamableHttpService::new(
-            Calculator::default,
+            || Ok(Calculator),
             Default::default(),
             StreamableHttpServerConfig {
                 stateful_mode: true,

--- a/examples/servers/src/counter_hyper_streamable_http.rs
+++ b/examples/servers/src/counter_hyper_streamable_http.rs
@@ -12,7 +12,7 @@ use rmcp::transport::streamable_http_server::{
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let service = TowerToHyperService::new(StreamableHttpService::new(
-        Counter::new,
+        || Ok(Counter::new()),
         LocalSessionManager::default().into(),
         Default::default(),
     ));

--- a/examples/servers/src/counter_streamhttp.rs
+++ b/examples/servers/src/counter_streamhttp.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let service = StreamableHttpService::new(
-        Counter::new,
+        || Ok(Counter::new()),
         LocalSessionManager::default().into(),
         Default::default(),
     );


### PR DESCRIPTION
## Motivation and Context
In our setup we need to lookup some info that may fail before we serve the request.


## How Has This Been Tested?
Manually tested

## Breaking Changes
Yes, minor change in signature

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
