### PR TITLE
allow using a TokioCommandWrap for TokioChildProcess::new closes #243

### DIFF
--- a/crates/rmcp/src/transport/child_process.rs
+++ b/crates/rmcp/src/transport/child_process.rs
@@ -63,9 +63,7 @@ impl TokioChildProcess {
         let mut command_wrap = command.into();
         command_wrap
             .command_mut()
-            .stdin(std::process::Stdio::piped());
-        command_wrap
-            .command_mut()
+            .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped());
         #[cfg(unix)]
         command_wrap.wrap(process_wrap::tokio::ProcessGroup::leader());

--- a/crates/rmcp/src/transport/child_process.rs
+++ b/crates/rmcp/src/transport/child_process.rs
@@ -59,11 +59,14 @@ impl AsyncRead for TokioChildProcessOut {
 }
 
 impl TokioChildProcess {
-    pub fn new(mut command: tokio::process::Command) -> std::io::Result<Self> {
-        command
-            .stdin(std::process::Stdio::piped())
+    pub fn new(command: impl Into<TokioCommandWrap>) -> std::io::Result<Self> {
+        let mut command_wrap = command.into();
+        command_wrap
+            .command_mut()
+            .stdin(std::process::Stdio::piped());
+        command_wrap
+            .command_mut()
             .stdout(std::process::Stdio::piped());
-        let mut command_wrap = TokioCommandWrap::from(command);
         #[cfg(unix)]
         command_wrap.wrap(process_wrap::tokio::ProcessGroup::leader());
         #[cfg(windows)]


### PR DESCRIPTION


<!-- Provide a brief summary of your changes -->

## Motivation and Context

we need to be able to set KillOnDrop and most importantly CreationFlags for the process spawned - we're now using process-wrap so we need to expose that interface

see https://docs.rs/process-wrap/latest/process_wrap/#killondrop-and-creationflags

## How Has This Been Tested?
I'm working on an app that relies on CreationFlags - so i just tested it on Windows :)

## Breaking Changes
TokioCommandWrap implements From<tokio::process::Command> so this is not a breaking change, but also downstream users have more control over flags such as KillOnDrop and CreationFlags

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
