### PR TITLE
fix: expose TokioChildWrapper::id() in TokioChildProcess and TokioChildProcessOut

### DIFF
--- a/crates/rmcp/src/transport/child_process.rs
+++ b/crates/rmcp/src/transport/child_process.rs
@@ -48,6 +48,13 @@ pin_project_lite::pin_project! {
     }
 }
 
+impl TokioChildProcessOut {
+    /// Get the process ID of the child process.
+    pub fn id(&self) -> Option<u32> {
+        self.child.inner.id()
+    }
+}
+
 impl AsyncRead for TokioChildProcessOut {
     fn poll_read(
         self: std::pin::Pin<&mut Self>,
@@ -75,6 +82,11 @@ impl TokioChildProcess {
             child_stdin,
             child_stdout,
         })
+    }
+
+    /// Get the process ID of the child process.
+    pub fn id(&self) -> Option<u32> {
+        self.child.inner.id()
     }
 
     pub fn split(self) -> (TokioChildProcessOut, ChildStdin) {


### PR DESCRIPTION
Adds `TokioChildWrapper::id()`.  

## Motivation and Context
Lets you track the spawned process.

## How Has This Been Tested?
I tested it in the app I'm developing.

## Breaking Changes
No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
