### PR TITLE
feat: mark boxed http body as sync (#285)

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/session.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session.rs
@@ -31,7 +31,7 @@ pub trait SessionManager: Send + Sync + 'static {
         id: &SessionId,
         message: ClientJsonRpcMessage,
     ) -> impl Future<
-        Output = Result<impl Stream<Item = ServerSseMessage> + Send + 'static, Self::Error>,
+        Output = Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>,
     > + Send;
     fn accept_message(
         &self,
@@ -42,13 +42,13 @@ pub trait SessionManager: Send + Sync + 'static {
         &self,
         id: &SessionId,
     ) -> impl Future<
-        Output = Result<impl Stream<Item = ServerSseMessage> + Send + 'static, Self::Error>,
+        Output = Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>,
     > + Send;
     fn resume(
         &self,
         id: &SessionId,
         last_event_id: String,
     ) -> impl Future<
-        Output = Result<impl Stream<Item = ServerSseMessage> + Send + 'static, Self::Error>,
+        Output = Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>,
     > + Send;
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
make boxed http body in tower service sync.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
resolve #285

The underlying http body types are already sync, so it would be better to mark them as sync.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
