### PR TITLE
Add Streamable HTTP section in some example configs

### DIFF
--- a/examples/rig-integration/Cargo.toml
+++ b/examples/rig-integration/Cargo.toml
@@ -19,6 +19,7 @@ rmcp = { path = "../../crates/rmcp", features = [
     "reqwest",
     "transport-child-process",
     "transport-sse-client",
+    "transport-streamable-http-client"
 ] }
 anyhow = "1.0"
 serde_json = "1"

--- a/examples/rig-integration/src/config/mcp.rs
+++ b/examples/rig-integration/src/config/mcp.rs
@@ -14,6 +14,9 @@ pub struct McpServerConfig {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "protocol", rename_all = "lowercase")]
 pub enum McpServerTransportConfig {
+    Streamable {
+        url: String,
+    },
     Sse {
         url: String,
     },
@@ -60,6 +63,11 @@ impl McpConfig {
 impl McpServerTransportConfig {
     pub async fn start(&self) -> anyhow::Result<RunningService<RoleClient, ()>> {
         let client = match self {
+            McpServerTransportConfig::Streamable { url } => {
+                let transport =
+                    rmcp::transport::StreamableHttpClientTransport::from_uri(url.to_string());
+                ().serve(transport).await?
+            }
             McpServerTransportConfig::Sse { url } => {
                 let transport = rmcp::transport::SseClientTransport::start(url.to_string()).await?;
                 ().serve(transport).await?

--- a/examples/simple-chat-client/Cargo.toml
+++ b/examples/simple-chat-client/Cargo.toml
@@ -17,6 +17,7 @@ rmcp = { workspace = true, features = [
     "client",
     "transport-child-process",
     "transport-sse-client",
+    "transport-streamable-http-client",
     "reqwest"
 ], no-default-features = true }
 clap = { version = "4.0", features = ["derive"] }

--- a/examples/simple-chat-client/src/config.rs
+++ b/examples/simple-chat-client/src/config.rs
@@ -29,6 +29,9 @@ pub struct McpServerConfig {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "protocol", rename_all = "lowercase")]
 pub enum McpServerTransportConfig {
+    Streamable {
+        url: String,
+    },
     Sse {
         url: String,
     },
@@ -44,6 +47,11 @@ pub enum McpServerTransportConfig {
 impl McpServerTransportConfig {
     pub async fn start(&self) -> Result<RunningService<RoleClient, ()>> {
         let client = match self {
+            McpServerTransportConfig::Streamable { url } => {
+                let transport =
+                    rmcp::transport::StreamableHttpClientTransport::from_uri(url.to_string());
+                ().serve(transport).await?
+            }
             McpServerTransportConfig::Sse { url } => {
                 let transport =
                     rmcp::transport::sse_client::SseClientTransport::start(url.to_owned()).await?;


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Added Streamable HTTP section in RIG handling and Simple Chat Client examples so that an entry with

```
[[mcp.server]]
url="url"
protocol="streamable"
```

will be handled as a Streamable HTTP server

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Based on the docs in https://modelcontextprotocol.io/docs/concepts/transports ,

> SSE as a standalone transport is deprecated as of protocol version 2024-11-05. It has been replaced by Streamable HTTP, which incorporates SSE as an optional streaming mechanism. For backwards compatibility information, see the [backwards compatibility](https://modelcontextprotocol.io/docs/concepts/transports#backwards-compatibility) section below.

So probably best to update the examples as well

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I tested an implementation using this code that I have in [another repo](https://github.com/tyressk/mcp_client)

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
_(Error handling already exists)_
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
