### PR TITLE
fix: Cargo.toml cleanup

### DIFF
--- a/examples/clients/Cargo.toml
+++ b/examples/clients/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-rmcp = { path = "../../crates/rmcp", features = [
+rmcp = { workspace = true, features = [
     "client",
     "transport-sse-client",
     "reqwest",

--- a/examples/rig-integration/Cargo.toml
+++ b/examples/rig-integration/Cargo.toml
@@ -10,11 +10,12 @@ keywords = { workspace = true }
 homepage = { workspace = true }
 categories = { workspace = true }
 readme = { workspace = true }
+publish = false
 
 [dependencies]
 rig-core = "0.13.0"
 tokio = { version = "1", features = ["full"] }
-rmcp = { path = "../../crates/rmcp", features = [
+rmcp = { workspace = true, features = [
     "client",
     "reqwest",
     "transport-child-process",

--- a/examples/servers/Cargo.toml
+++ b/examples/servers/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-rmcp = { path = "../../crates/rmcp", features = [
+rmcp = { workspace = true, features = [
     "server",
     "transport-sse-server",
     "transport-io",

--- a/examples/simple-chat-client/Cargo.toml
+++ b/examples/simple-chat-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "simple-chat-client"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/examples/transport/Cargo.toml
+++ b/examples/transport/Cargo.toml
@@ -10,12 +10,13 @@ keywords = { workspace = true }
 homepage = { workspace = true }
 categories = { workspace = true }
 readme = { workspace = true }
+publish = false
 
 [package.metadata.docs.rs]
 all-features = true
 
 [dependencies]
-rmcp = { path = "../../crates/rmcp", features = ["server", "client"] }
+rmcp = { workspace = true, features = ["server", "client"] }
 tokio = { version = "1", features = [
     "macros",
     "rt",

--- a/examples/wasi/Cargo.toml
+++ b/examples/wasi/Cargo.toml
@@ -10,6 +10,7 @@ keywords = { workspace = true }
 homepage = { workspace = true }
 categories = { workspace = true }
 readme = { workspace = true }
+publish = false
 
 [lib]
 crate-type = ["cdylib"]
@@ -17,7 +18,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasi = { version = "0.14.2"}
 tokio = { version = "1", features = ["rt", "io-util", "sync", "macros", "time"] }
-rmcp= { path = "../../crates/rmcp", features = ["server", "macros"] }
+rmcp = { workspace = true, features = ["server", "macros"] }
 serde = { version  = "1", features = ["derive"]}
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",


### PR DESCRIPTION
Address failing build for `release-plz` integration by correcting / updating `Cargo.toml`s to not publish examples and use workspace across the board for depending on `rmcp`

Original error:

```
    failed to publish rig-integration:     Updating crates.io index
    error: all dependencies must have a version specified when publishing.
    dependency `rmcp` does not specify a version
    Note: The published dependency will use the version from crates.io,
    the `path` specification will be removed from the dependency declaration.
```

https://github.com/modelcontextprotocol/rust-sdk/actions/runs/16030293757/job/45228856027