### PR TITLE
fix: explicitly added client_id as an extra parameter causes bad token requests

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -432,7 +432,6 @@ impl AuthorizationManager {
         // exchange token
         let token_result = oauth_client
             .exchange_code(AuthorizationCode::new(code.to_string()))
-            .add_extra_param("client_id", oauth_client.client_id().to_string())
             .set_pkce_verifier(pkce_verifier)
             .request_async(&http_client)
             .await


### PR DESCRIPTION
Fix https://github.com/modelcontextprotocol/rust-sdk/issues/321 by omitting the addition of an extra client_id parameter.

## Motivation and Context

Adding an extra client_id parameter to token endpoint request duplicates the client_id parameter, which the server then rejects with 400 Bad Request.

## How Has This Been Tested?

I tested the fix using a customized example MCP client against a test MCP server that supports DCR.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

None.