### PR TITLE
fix(examples): Prevent transport from closing due to premature client drop

### DIFF
--- a/examples/simple-chat-client/src/bin/simple_chat.rs
+++ b/examples/simple-chat-client/src/bin/simple_chat.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
             if config.mcp.is_some() {
                 let mcp_clients = config.create_mcp_clients().await?;
 
-                for (name, client) in mcp_clients {
+                for (name, client) in mcp_clients.iter() {
                     println!("load MCP tool: {}", name);
                     let server = client.peer().clone();
                     let tools = get_mcp_tools(server).await?;
@@ -84,6 +84,7 @@ async fn main() -> Result<()> {
                         tool_set.add_tool(tool);
                     }
                 }
+                tool_set.set_clients(mcp_clients);
             }
 
             // create chat session

--- a/examples/simple-chat-client/src/tool.rs
+++ b/examples/simple-chat-client/src/tool.rs
@@ -3,8 +3,9 @@ use std::{collections::HashMap, sync::Arc};
 use anyhow::Result;
 use async_trait::async_trait;
 use rmcp::{
+    RoleClient,
     model::{CallToolRequestParam, CallToolResult, Tool as McpTool},
-    service::ServerSink,
+    service::{RunningService, ServerSink},
 };
 use serde_json::Value;
 
@@ -70,9 +71,14 @@ impl Tool for McpToolAdapter {
 #[derive(Default)]
 pub struct ToolSet {
     tools: HashMap<String, Arc<dyn Tool>>,
+    clients: HashMap<String, RunningService<RoleClient, ()>>,
 }
 
 impl ToolSet {
+    pub fn set_clients(&mut self, clients: HashMap<String, RunningService<RoleClient, ()>>) {
+        self.clients = clients;
+    }
+
     pub fn add_tool<T: Tool + 'static>(&mut self, tool: T) {
         self.tools.insert(tool.name(), Arc::new(tool));
     }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fix: Prevent MCP client from being dropped early, which caused transport to close.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The MCP client was dropped after tool registration, leading to `Transport closed` errors
when calling tools later in the program. This change ensures the client remains alive
by keeping it in scope.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested manually:
- Tools were registered and called inside the same scope: ✅ success
- Tools were called again after the scope: ✅ no more `Transport closed` error

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This bug was tricky because the `client` was dropped silently.
Explicitly storing the clients ensures the transport remains open.