### PR TITLE
Fix MCP specification compliance: Use mimeType instead of mime_type

### DIFF
--- a/crates/rmcp/src/model/content.rs
+++ b/crates/rmcp/src/model/content.rs
@@ -171,3 +171,40 @@ impl IntoContents for () {
         vec![]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn test_image_content_serialization() {
+        let image_content = RawImageContent {
+            data: "base64data".to_string(),
+            mime_type: "image/png".to_string(),
+        };
+
+        let json = serde_json::to_string(&image_content).unwrap();
+        println!("ImageContent JSON: {}", json);
+
+        // Verify it contains mimeType (camelCase) not mime_type (snake_case)
+        assert!(json.contains("mimeType"));
+        assert!(!json.contains("mime_type"));
+    }
+
+    #[test]
+    fn test_audio_content_serialization() {
+        let audio_content = RawAudioContent {
+            data: "base64audiodata".to_string(),
+            mime_type: "audio/wav".to_string(),
+        };
+
+        let json = serde_json::to_string(&audio_content).unwrap();
+        println!("AudioContent JSON: {}", json);
+
+        // Verify it contains mimeType (camelCase) not mime_type (snake_case)
+        assert!(json.contains("mimeType"));
+        assert!(!json.contains("mime_type"));
+    }
+}

--- a/crates/rmcp/src/model/prompt.rs
+++ b/crates/rmcp/src/model/prompt.rs
@@ -168,3 +168,25 @@ pub struct PromptArgumentTemplate {
     pub description: Option<String>,
     pub required: Option<bool>,
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn test_prompt_message_image_serialization() {
+        let image_content = RawImageContent {
+            data: "base64data".to_string(),
+            mime_type: "image/png".to_string(),
+        };
+
+        let json = serde_json::to_string(&image_content).unwrap();
+        println!("PromptMessage ImageContent JSON: {}", json);
+
+        // Verify it contains mimeType (camelCase) not mime_type (snake_case)
+        assert!(json.contains("mimeType"));
+        assert!(!json.contains("mime_type"));
+    }
+}

--- a/crates/rmcp/src/model/resource.rs
+++ b/crates/rmcp/src/model/resource.rs
@@ -42,15 +42,17 @@ pub struct RawResourceTemplate {
 pub type ResourceTemplate = Annotated<RawResourceTemplate>;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(rename_all = "camelCase", untagged)]
+#[serde(untagged)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ResourceContents {
+    #[serde(rename_all = "camelCase")]
     TextResourceContents {
         uri: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         mime_type: Option<String>,
         text: String,
     },
+    #[serde(rename_all = "camelCase")]
     BlobResourceContents {
         uri: String,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -79,5 +81,46 @@ impl RawResource {
             mime_type: None,
             size: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn test_resource_serialization() {
+        let resource = RawResource {
+            uri: "file:///test.txt".to_string(),
+            name: "test".to_string(),
+            description: Some("Test resource".to_string()),
+            mime_type: Some("text/plain".to_string()),
+            size: Some(100),
+        };
+
+        let json = serde_json::to_string(&resource).unwrap();
+        println!("Serialized JSON: {}", json);
+
+        // Verify it contains mimeType (camelCase) not mime_type (snake_case)
+        assert!(json.contains("mimeType"));
+        assert!(!json.contains("mime_type"));
+    }
+
+    #[test]
+    fn test_resource_contents_serialization() {
+        let text_contents = ResourceContents::TextResourceContents {
+            uri: "file:///test.txt".to_string(),
+            mime_type: Some("text/plain".to_string()),
+            text: "Hello world".to_string(),
+        };
+
+        let json = serde_json::to_string(&text_contents).unwrap();
+        println!("ResourceContents JSON: {}", json);
+
+        // Verify it contains mimeType (camelCase) not mime_type (snake_case)
+        assert!(json.contains("mimeType"));
+        assert!(!json.contains("mime_type"));
     }
 }

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
@@ -1129,7 +1129,7 @@
         {
           "type": "object",
           "properties": {
-            "mime_type": {
+            "mimeType": {
               "type": [
                 "string",
                 "null"
@@ -1153,7 +1153,7 @@
             "blob": {
               "type": "string"
             },
-            "mime_type": {
+            "mimeType": {
               "type": [
                 "string",
                 "null"

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -1333,7 +1333,7 @@
         {
           "type": "object",
           "properties": {
-            "mime_type": {
+            "mimeType": {
               "type": [
                 "string",
                 "null"
@@ -1357,7 +1357,7 @@
             "blob": {
               "type": "string"
             },
-            "mime_type": {
+            "mimeType": {
               "type": [
                 "string",
                 "null"


### PR DESCRIPTION
## Summary

This PR fixes MCP specification compliance by ensuring all resource-related structures use `mimeType` (camelCase) instead of `mime_type` (snake_case) as required by the official MCP specification.

Refer to issue for more info: https://github.com/modelcontextprotocol/rust-sdk/issues/338

## Problem

The MCP specification consistently uses `mimeType` in camelCase for all resource-related interfaces:
- `Resource` interface
- `ResourceTemplate` interface  
- `ResourceContents` interface
- `ImageContent` interface
- `AudioContent` interface

However, the Rust SDK was using `mime_type` (snake_case) in some places, causing serialization mismatches.

## Changes

1. **Fixed ResourceContents enum** - Added `#[serde(rename_all = "camelCase")]` to individual variants to ensure proper JSON serialization
2. **Added comprehensive tests** to verify correct JSON serialization:
   - `test_resource_serialization()` for `RawResource`
   - `test_resource_contents_serialization()` for `ResourceContents`
   - `test_image_content_serialization()` for `RawImageContent`
   - `test_audio_content_serialization()` for `RawAudioContent`
   - `test_prompt_message_image_serialization()` for prompt-related image content

## Testing

All tests pass, including:
- 17 unit tests in the main library
- Multiple integration test suites
- New serialization compliance tests

## Verification

The changes ensure that JSON serialization now produces the correct camelCase field names as required by the MCP specification, while maintaining backward compatibility with existing Rust code that uses snake_case field names internally.