### PR TITLE
fix: close oneshot transport on error

### DIFF
--- a/crates/rmcp/src/transport.rs
+++ b/crates/rmcp/src/transport.rs
@@ -221,7 +221,8 @@ where
         item: TxJsonRpcMessage<R>,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
         let sender = self.sender.clone();
-        let terminate = matches!(item, TxJsonRpcMessage::<R>::Response(_));
+        let terminate = matches!(item, TxJsonRpcMessage::<R>::Response(_))
+            || matches!(item, TxJsonRpcMessage::<R>::Error(_));
         let signal = self.finished_signal.clone();
         async move {
             sender.send(item).await?;


### PR DESCRIPTION
Close the `OneshotTransport` on error.

## Motivation and Context
While building an MCP tool and using the `OneshotTransport`, if the call to a tool returns an `rmcp::ErrorData` the transport remains open indefinitely. On failure, the `OneshotTransport` should also issue the terminate call, the same way it does it for a successful response.

## How Has This Been Tested?
Testing the change locally did return an error response with the correct shape.

```
{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"Forcing an error response from tool"}}
```

## Breaking Changes
I don't believe this is a breaking change

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling (didn't change any error handling)
- [ ] I have added or updated documentation as needed (not sure it applies)

## Additional context
Very minor fix for a behavior that was not expected when returning an `Err` from a tool
