### PR TITLE
docs: fix missing README.md codeblock terminator

### DIFF
--- a/crates/rmcp-macros/README.md
+++ b/crates/rmcp-macros/README.md
@@ -98,7 +98,7 @@ impl MyToolHandler {
         }
     }
 }
-
+```
 
 ### tool_handler
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Adds a missing example block terminator for readability.

