### PR TITLE
feat: Adjust log levels for trace logging

### DIFF
--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -213,7 +213,7 @@ pub trait ServerHandler: Sized + Send + Sync + 'static {
         &self,
         context: NotificationContext<RoleServer>,
     ) -> impl Future<Output = ()> + Send + '_ {
-        tracing::info!("client initialized");
+        tracing::debug!("client initialized");
         std::future::ready(())
     }
     fn on_roots_list_changed(

--- a/crates/rmcp/src/service.rs
+++ b/crates/rmcp/src/service.rs
@@ -557,9 +557,9 @@ where
         tokio::sync::mpsc::channel::<TxJsonRpcMessage<R>>(SINK_PROXY_BUFFER_SIZE);
     let peer_info = peer.peer_info();
     if R::IS_CLIENT {
-        tracing::info!(?peer_info, "Service initialized as client");
+        tracing::debug!(?peer_info, "Service initialized as client");
     } else {
-        tracing::info!(?peer_info, "Service initialized as server");
+        tracing::debug!(?peer_info, "Service initialized as server");
     }
 
     let mut local_responder_pool =
@@ -615,7 +615,7 @@ where
                             Event::PeerMessage(m)
                         } else {
                             // input stream closed
-                            tracing::info!("input stream terminated");
+                            tracing::debug!("input stream terminated");
                             break QuitReason::Closed
                         }
                     }
@@ -642,7 +642,7 @@ where
                         }
                     }
                     _ = serve_loop_ct.cancelled() => {
-                        tracing::info!("task cancelled");
+                        tracing::debug!("task cancelled");
                         break QuitReason::Cancelled
                     }
                 }
@@ -670,7 +670,7 @@ where
                     let _ = responder.send(response);
                     if let Some(param) = cancellation_param {
                         if let Some(responder) = local_responder_pool.remove(&param.request_id) {
-                            tracing::info!(id = %param.request_id, reason = param.reason, "cancelled");
+                            tracing::debug!(id = %param.request_id, reason = param.reason, "cancelled");
                             let _response_result = responder.send(Err(ServiceError::Cancelled {
                                 reason: param.reason.clone(),
                             }));
@@ -782,12 +782,12 @@ where
                     notification,
                     ..
                 })) => {
-                    tracing::info!(?notification, "received notification");
+                    tracing::trace!(?notification, "received notification");
                     // catch cancelled notification
                     let mut notification = match notification.try_into() {
                         Ok::<CancelledNotification, _>(cancelled) => {
                             if let Some(ct) = local_ct_pool.remove(&cancelled.params.request_id) {
-                                tracing::info!(id = %cancelled.params.request_id, reason = cancelled.params.reason, "cancelled");
+                                tracing::debug!(id = %cancelled.params.request_id, reason = cancelled.params.reason, "cancelled");
                                 ct.cancel();
                             }
                             cancelled.into()
@@ -855,7 +855,7 @@ where
         if let Err(e) = sink_close_result {
             tracing::error!(%e, "fail to close sink");
         }
-        tracing::info!(?quit_reason, "serve finished");
+        tracing::debug!(?quit_reason, "serve finished");
         quit_reason
     }.instrument(current_span));
     RunningService {

--- a/crates/rmcp/src/transport/sse_server.rs
+++ b/crates/rmcp/src/transport/sse_server.rs
@@ -88,7 +88,7 @@ async fn sse_handler(
     parts: Parts,
 ) -> Result<Sse<impl Stream<Item = Result<Event, io::Error>>>, Response<String>> {
     let session = session_id();
-    tracing::info!(%session, ?parts, "sse connection");
+    tracing::debug!(%session, ?parts, "sse connection");
     use tokio_stream::{StreamExt, wrappers::ReceiverStream};
     use tokio_util::sync::PollSender;
     let (from_client_tx, from_client_rx) = tokio::sync::mpsc::channel(64);
@@ -246,7 +246,7 @@ impl SseServer {
         let ct = sse_server.config.ct.child_token();
         let server = axum::serve(listener, service).with_graceful_shutdown(async move {
             ct.cancelled().await;
-            tracing::info!("sse server cancelled");
+            tracing::debug!("sse server cancelled");
         });
         tokio::spawn(
             async move {

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -306,10 +306,10 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                     client.delete_session(url, session_id.clone(), None).await;
                 match delete_session_result {
                     Ok(_) => {
-                        tracing::info!(session_id = session_id.as_ref(), "delete session success")
+                        tracing::debug!(session_id = session_id.as_ref(), "delete session success")
                     }
                     Err(StreamableHttpError::SeverDoesNotSupportDeleteSession) => {
-                        tracing::info!(
+                        tracing::debug!(
                             session_id = session_id.as_ref(),
                             "server doesn't support delete session"
                         )

--- a/crates/rmcp/src/transport/streamable_http_server/session/local.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/local.rs
@@ -883,7 +883,7 @@ pub fn create_local_session(
     let (event_tx, event_rx) = tokio::sync::mpsc::channel(config.channel_capacity);
     let (common_tx, _) = tokio::sync::mpsc::channel(config.channel_capacity);
     let common = CachedTx::new_common(common_tx);
-    tracing::info!(session_id = ?id, "create new session");
+    tracing::debug!(session_id = ?id, "create new session");
     let handle = LocalSessionHandle {
         event_tx,
         id: id.clone(),

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -399,7 +399,7 @@ where
                     });
                     Ok(sse_stream_response(
                         ReceiverStream::new(receiver).map(|message| {
-                            tracing::info!(?message);
+                            tracing::trace!(?message);
                             ServerSseMessage {
                                 event_id: None,
                                 message: message.into(),


### PR DESCRIPTION
Reduce log levels on per-connection/request/message events to `trace` from `info`.

I considered using `DEBUG` which is the default level used by Axum for request logging. WDYT?

## Motivation and Context
Emitting per-connection and message logs at INFO level is unexpected, in my experience. Using a finer level allows filtering to be effective without requiring users to set module level configuration.

## How Has This Been Tested?
Locally with my MCP server

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None
