### PR TITLE
fix: don't wrap errors in streamable http auth client

### DIFF
--- a/crates/rmcp/src/transport/common/auth/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/auth/streamable_http_client.rs
@@ -6,7 +6,7 @@ impl<C> StreamableHttpClient for AuthClient<C>
 where
     C: StreamableHttpClient + Send + Sync,
 {
-    type Error = StreamableHttpError<C::Error>;
+    type Error = C::Error;
 
     async fn delete_session(
         &self,
@@ -21,7 +21,6 @@ where
         self.http_client
             .delete_session(uri, session_id, auth_token)
             .await
-            .map_err(StreamableHttpError::Client)
     }
 
     async fn get_stream(
@@ -40,7 +39,6 @@ where
         self.http_client
             .get_stream(uri, session_id, last_event_id, auth_token)
             .await
-            .map_err(StreamableHttpError::Client)
     }
 
     async fn post_message(
@@ -59,6 +57,5 @@ where
         self.http_client
             .post_message(uri, message, session_id, auth_token)
             .await
-            .map_err(StreamableHttpError::Client)
     }
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
When using the auth client, the errors are wrapped, and matches like this don't work as expected:
https://github.com/modelcontextprotocol/rust-sdk/blob/4c34b64b7f8dcabf94d52a9c6518c6b49c1f0451/crates/rmcp/src/transport/streamable_http_client.rs#L376-L378

## How Has This Been Tested?
Use an auth client to connect to a server that does not support events from a GET connection. When the server responds 405, this match fails and terminates the connection instead of just dropping the listener.

## Breaking Changes
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
