### PR TITLE
fix(model): allow backwards compat as per MCP spec

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1262,10 +1262,9 @@ impl CallToolResult {
         }
     }
 
-    /// Validate that content and structured_content are mutually exclusive
+    /// Validate that content or structured content is provided
     pub fn validate(&self) -> Result<(), &'static str> {
         match (&self.content, &self.structured_content) {
-            (Some(_), Some(_)) => Err("content and structured_content are mutually exclusive"),
             (None, None) => Err("either content or structured_content must be provided"),
             _ => Ok(()),
         }

--- a/crates/rmcp/tests/test_structured_output.rs
+++ b/crates/rmcp/tests/test_structured_output.rs
@@ -2,7 +2,7 @@
 use rmcp::{
     Json, ServerHandler,
     handler::server::{router::tool::ToolRouter, tool::Parameters},
-    model::{CallToolResult, Content, Tool},
+    model::{CallToolResult, Tool},
     tool, tool_handler, tool_router,
 };
 use schemars::JsonSchema;

--- a/crates/rmcp/tests/test_structured_output.rs
+++ b/crates/rmcp/tests/test_structured_output.rs
@@ -145,27 +145,6 @@ async fn test_structured_error_in_call_result() {
 }
 
 #[tokio::test]
-async fn test_mutual_exclusivity_validation() {
-    // Test that content and structured_content are mutually exclusive
-    let content_result = CallToolResult::success(vec![Content::text("Hello")]);
-    let structured_result = CallToolResult::structured(json!({"message": "Hello"}));
-
-    // Verify the validation
-    assert!(content_result.validate().is_ok());
-    assert!(structured_result.validate().is_ok());
-
-    // Try to create an invalid result with both fields
-    let invalid_json = json!({
-        "content": [{"type": "text", "text": "Hello"}],
-        "structuredContent": {"message": "Hello"}
-    });
-
-    // The deserialization itself should fail due to validation
-    let deserialized: Result<CallToolResult, _> = serde_json::from_value(invalid_json);
-    assert!(deserialized.is_err());
-}
-
-#[tokio::test]
 async fn test_structured_return_conversion() {
     // Test that Json<T> converts to CallToolResult with structured_content
     let calc_result = CalculationResult {


### PR DESCRIPTION
This is a very small fix for issue: https://github.com/modelcontextprotocol/rust-sdk/issues/355 

MCP servers (especially in python) will likely fail with 0.4.0 with an error like "Error: Unexpected response type"
this is due to the validation  `content and structured_content are mutually exclusive`, but this is a bit strict. 

## How Has This Been Tested?

Tested with goose and a python based MCP server - it worked with < 0.4.0 and failed with 0.4.0. 
I then tested this patch with the goose agent and exactly the same server it works. 

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
