### PR TITLE
fix(rmcp): allow both content and structured content

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1181,8 +1181,6 @@ pub type RootsListChangedNotification = NotificationNoParam<RootsListChangedNoti
 ///
 /// Contains the content returned by the tool execution and an optional
 /// flag indicating whether the operation resulted in an error.
-///
-/// Note: `content` and `structured_content` are mutually exclusive - exactly one must be provided.
 #[derive(Debug, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -1262,10 +1260,9 @@ impl CallToolResult {
         }
     }
 
-    /// Validate that content and structured_content are mutually exclusive
+    /// Validate that content or structured content is provided
     pub fn validate(&self) -> Result<(), &'static str> {
         match (&self.content, &self.structured_content) {
-            (Some(_), Some(_)) => Err("content and structured_content are mutually exclusive"),
             (None, None) => Err("either content or structured_content must be provided"),
             _ => Ok(()),
         }

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -299,7 +299,7 @@
       }
     },
     "CallToolResult": {
-      "description": "The result of a tool call operation.\n\nContains the content returned by the tool execution and an optional\nflag indicating whether the operation resulted in an error.\n\nNote: `content` and `structured_content` are mutually exclusive - exactly one must be provided.",
+      "description": "The result of a tool call operation.\n\nContains the content returned by the tool execution and an optional\nflag indicating whether the operation resulted in an error.",
       "type": "object",
       "properties": {
         "content": {

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -299,7 +299,7 @@
       }
     },
     "CallToolResult": {
-      "description": "The result of a tool call operation.\n\nContains the content returned by the tool execution and an optional\nflag indicating whether the operation resulted in an error.\n\nNote: `content` and `structured_content` are mutually exclusive - exactly one must be provided.",
+      "description": "The result of a tool call operation.\n\nContains the content returned by the tool execution and an optional\nflag indicating whether the operation resulted in an error.",
       "type": "object",
       "properties": {
         "content": {
@@ -1336,7 +1336,7 @@
         {
           "type": "object",
           "properties": {
-            "mime_type": {
+            "mimeType": {
               "type": [
                 "string",
                 "null"
@@ -1360,7 +1360,7 @@
             "blob": {
               "type": "string"
             },
-            "mime_type": {
+            "mimeType": {
               "type": [
                 "string",
                 "null"

--- a/crates/rmcp/tests/test_structured_output.rs
+++ b/crates/rmcp/tests/test_structured_output.rs
@@ -146,7 +146,7 @@ async fn test_structured_error_in_call_result() {
 
 #[tokio::test]
 async fn test_mutual_exclusivity_validation() {
-    // Test that content and structured_content are mutually exclusive
+    // Test that content and structured_content can both be passed separately
     let content_result = CallToolResult::success(vec![Content::text("Hello")]);
     let structured_result = CallToolResult::structured(json!({"message": "Hello"}));
 
@@ -154,15 +154,15 @@ async fn test_mutual_exclusivity_validation() {
     assert!(content_result.validate().is_ok());
     assert!(structured_result.validate().is_ok());
 
-    // Try to create an invalid result with both fields
-    let invalid_json = json!({
+    // Try to create a result with both fields
+    let json_with_both = json!({
         "content": [{"type": "text", "text": "Hello"}],
         "structuredContent": {"message": "Hello"}
     });
 
-    // The deserialization itself should fail due to validation
-    let deserialized: Result<CallToolResult, _> = serde_json::from_value(invalid_json);
-    assert!(deserialized.is_err());
+    // The deserialization itself should not fail
+    let deserialized: Result<CallToolResult, _> = serde_json::from_value(json_with_both);
+    assert!(deserialized.is_ok());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Small PR with adjustments to https://github.com/modelcontextprotocol/rust-sdk/pull/357 as I won't be able to push to @michaelneale's fork

cc @crepererum @jamadeo 