### PR TITLE
feat: keep internal error in worker's quit reason

### DIFF
--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -36,7 +36,7 @@ impl StreamableHttpClient for reqwest::Client {
         }
         let response = request_builder.send().await?;
         if response.status() == reqwest::StatusCode::METHOD_NOT_ALLOWED {
-            return Err(StreamableHttpError::SeverDoesNotSupportSse);
+            return Err(StreamableHttpError::ServerDoesNotSupportSse);
         }
         let response = response.error_for_status()?;
         match response.headers().get(reqwest::header::CONTENT_TYPE) {

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -269,7 +269,7 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
     async fn run(
         self,
         mut context: super::worker::WorkerContext<Self>,
-    ) -> Result<(), WorkerQuitReason> {
+    ) -> Result<(), WorkerQuitReason<Self::Error>> {
         let channel_buffer_capacity = self.config.channel_buffer_capacity;
         let (sse_worker_tx, mut sse_worker_rx) =
             tokio::sync::mpsc::channel::<ServerJsonRpcMessage>(channel_buffer_capacity);
@@ -286,7 +286,7 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
             .post_message(config.uri.clone(), initialize_request, None, None)
             .await
             .map_err(WorkerQuitReason::fatal_context("send initialize request"))?
-            .expect_initialized::<Self::Error>()
+            .expect_initialized::<C::Error>()
             .await
             .map_err(WorkerQuitReason::fatal_context(
                 "process initialize response",
@@ -346,7 +346,7 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
             .map_err(WorkerQuitReason::fatal_context(
                 "send initialized notification",
             ))?
-            .expect_accepted::<Self::Error>()
+            .expect_accepted::<C::Error>()
             .map_err(WorkerQuitReason::fatal_context(
                 "process initialized notification response",
             ))?;

--- a/crates/rmcp/src/transport/worker.rs
+++ b/crates/rmcp/src/transport/worker.rs
@@ -7,12 +7,12 @@ use super::{IntoTransport, Transport};
 use crate::service::{RxJsonRpcMessage, ServiceRole, TxJsonRpcMessage};
 
 #[derive(Debug, thiserror::Error)]
-pub enum WorkerQuitReason {
+pub enum WorkerQuitReason<E> {
     #[error("Join error {0}")]
     Join(#[from] tokio::task::JoinError),
     #[error("Transport fatal {error}, when {context}")]
     Fatal {
-        error: Box<dyn std::error::Error + Send>,
+        error: E,
         context: Cow<'static, str>,
     },
     #[error("Transport canncelled")]
@@ -23,21 +23,16 @@ pub enum WorkerQuitReason {
     HandlerTerminated,
 }
 
-impl WorkerQuitReason {
-    pub fn fatal(
-        error: impl std::error::Error + Send + 'static,
-        context: impl Into<Cow<'static, str>>,
- ) -> Self {
+impl<E: std::error::Error + Send + 'static> WorkerQuitReason<E> {
+    pub fn fatal(error: E, context: impl Into<Cow<'static, str>>) -> Self {
         Self::Fatal {
-            error: Box::new(error),
+            error,
             context: context.into(),
         }
     }
-    pub fn fatal_context<E: std::error::Error + Send + 'static>(
-        context: impl Into<Cow<'static, str>>,
-    ) -> impl FnOnce(E) -> Self {
+    pub fn fatal_context(context: impl Into<Cow<'static, str>>) -> impl FnOnce(E) -> Self {
         |e| Self::Fatal {
-            error: Box::new(e),
+            error: e,
             context: context.into(),
         }
     }
@@ -51,7 +46,7 @@ pub trait Worker: Sized + Send + 'static {
     fn run(
         self,
         context: WorkerContext<Self>,
-    ) -> impl Future<Output = Result<(), WorkerQuitReason>> + Send;
+    ) -> impl Future<Output = Result<(), WorkerQuitReason<Self::Error>>> + Send;
     fn config(&self) -> WorkerConfig {
         WorkerConfig::default()
     }
@@ -65,7 +60,7 @@ pub struct WorkerSendRequest<W: Worker> {
 pub struct WorkerTransport<W: Worker> {
     rx: tokio::sync::mpsc::Receiver<RxJsonRpcMessage<W::Role>>,
     send_service: tokio::sync::mpsc::Sender<WorkerSendRequest<W>>,
-    join_handle: Option<tokio::task::JoinHandle<Result<(), WorkerQuitReason>>>,
+    join_handle: Option<tokio::task::JoinHandle<Result<(), WorkerQuitReason<W::Error>>>>,
     _drop_guard: tokio_util::sync::DropGuard,
     ct: CancellationToken,
 }
@@ -162,14 +157,16 @@ impl<W: Worker> WorkerContext<W> {
     pub async fn send_to_handler(
         &mut self,
         item: RxJsonRpcMessage<W::Role>,
-    ) -> Result<(), WorkerQuitReason> {
+    ) -> Result<(), WorkerQuitReason<W::Error>> {
         self.to_handler_tx
             .send(item)
             .await
             .map_err(|_| WorkerQuitReason::HandlerTerminated)
     }
 
-    pub async fn recv_from_handler(&mut self) -> Result<WorkerSendRequest<W>, WorkerQuitReason> {
+    pub async fn recv_from_handler(
+        &mut self,
+    ) -> Result<WorkerSendRequest<W>, WorkerQuitReason<W::Error>> {
         self.from_handler_rx
             .recv()
             .await


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
fix #345
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
1. Change the error type for local session worker.
2. Change the type defination of worker's `QuitReason`
3. Fix some typo of `StreamableHttpError`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
