### PR TITLE
Match the shape of `CallToolResult` schema

### DIFF
--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -304,10 +304,7 @@
       "properties": {
         "content": {
           "description": "The content returned by the tool (text, images, etc.)",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "$ref": "#/definitions/Annotated"
           }
@@ -322,7 +319,10 @@
         "structuredContent": {
           "description": "An optional JSON object that represents the structured result of the tool call"
         }
-      }
+      },
+      "required": [
+        "content"
+      ]
     },
     "CancelledNotificationMethod": {
       "type": "string",

--- a/crates/rmcp/tests/test_structured_output.rs
+++ b/crates/rmcp/tests/test_structured_output.rs
@@ -122,10 +122,10 @@ async fn test_structured_content_in_call_result() {
 
     let result = CallToolResult::structured(structured_data.clone());
 
-    assert!(result.content.is_some());
+    assert!(!result.content.is_empty());
     assert!(result.structured_content.is_some());
 
-    let contents = result.content.unwrap();
+    let contents = result.content;
 
     assert_eq!(contents.len(), 1);
 
@@ -150,10 +150,10 @@ async fn test_structured_error_in_call_result() {
 
     let result = CallToolResult::structured_error(error_data.clone());
 
-    assert!(result.content.is_some());
+    assert!(!result.content.is_empty());
     assert!(result.structured_content.is_some());
 
-    let contents = result.content.unwrap();
+    let contents = result.content;
 
     assert_eq!(contents.len(), 1);
 
@@ -217,10 +217,10 @@ async fn test_structured_return_conversion() {
 
     // Tools which return structured content should also return a serialized version as
     // Content::text for backwards compatibility.
-    assert!(call_result.content.is_some());
+    assert!(!call_result.content.is_empty());
     assert!(call_result.structured_content.is_some());
 
-    let contents = call_result.content.unwrap();
+    let contents = call_result.content;
 
     assert_eq!(contents.len(), 1);
 
@@ -278,5 +278,5 @@ async fn test_output_schema_requires_structured_content() {
 
     // Verify it has structured_content and content
     assert!(call_result.structured_content.is_some());
-    assert!(call_result.content.is_some());
+    assert!(!call_result.content.is_empty());
 }

--- a/crates/rmcp/tests/test_tool_macros.rs
+++ b/crates/rmcp/tests/test_tool_macros.rs
@@ -301,8 +301,7 @@ async fn test_optional_i64_field_with_null_input() -> anyhow::Result<()> {
 
     let result_text = result
         .content
-        .as_ref()
-        .and_then(|contents| contents.first())
+        .first()
         .and_then(|content| content.raw.as_text())
         .map(|text| text.text.as_str())
         .expect("Expected text content");
@@ -330,8 +329,7 @@ async fn test_optional_i64_field_with_null_input() -> anyhow::Result<()> {
 
     let some_result_text = some_result
         .content
-        .as_ref()
-        .and_then(|contents| contents.first())
+        .first()
         .and_then(|content| content.raw.as_text())
         .map(|text| text.text.as_str())
         .expect("Expected text content");

--- a/examples/simple-chat-client/src/chat.rs
+++ b/examples/simple-chat-client/src/chat.rs
@@ -85,8 +85,8 @@ impl ChatSession {
                         if result.is_error.is_some_and(|b| b) {
                             self.messages
                                 .push(Message::user("tool call failed, mcp call error"));
-                        } else if let Some(contents) = &result.content {
-                            contents.iter().for_each(|content| {
+                        } else {
+                            result.content.iter().for_each(|content| {
                                 if let Some(content_text) = content.as_text() {
                                     let json_result = serde_json::from_str::<serde_json::Value>(
                                         &content_text.text,


### PR DESCRIPTION
Adjusts the `content` field to always be present

## Motivation and Context

The MCP schema has the `content` field as mandatory: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/3b3874b4fc010f34ef5b106f044a4867534a9499/schema/2025-06-18/schema.ts#L782

Some of the MCP implementations (I.e, [zed editor](https://github.com/zed-industries/zed/blob/2dbc951058fe0b2325bca2452da330f2bafa34d7/crates/context_server/src/types.rs#L680)) assume (& rightly so) that this field is *always* present.

## How Has This Been Tested?

Running tests

## Breaking Changes

It is essentially a breaking change on the type `CallToolResult`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
