### PR TITLE
fix(macros): Allow `#[tool]` to work even if Future is not in scope

### DIFF
--- a/crates/rmcp-macros/src/prompt.rs
+++ b/crates/rmcp-macros/src/prompt.rs
@@ -108,10 +108,10 @@ pub fn prompt(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream>
             }
             match &fn_item.sig.output {
                 syn::ReturnType::Default => {
-                    quote! { -> futures::future::BoxFuture<#lt, ()> }
+                    quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = ()> + Send + #lt>> }
                 }
                 syn::ReturnType::Type(_, ty) => {
-                    quote! { -> futures::future::BoxFuture<#lt, #ty> }
+                    quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = #ty> + Send + #lt>> }
                 }
             }
         })?;

--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -234,7 +234,7 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
     // modify the the input function
     if fn_item.sig.asyncness.is_some() {
         // 1. remove asyncness from sig
-        // 2. make return type: `std::pin::Pin<Box<dyn Future<Output = #ReturnType> + Send + '_>>`
+        // 2. make return type: `std::pin::Pin<Box<dyn std::future::Future<Output = #ReturnType> + Send + '_>>`
         // 3. make body: { Box::pin(async move { #body }) }
         let new_output = syn::parse2::<ReturnType>({
             let mut lt = quote! { 'static };
@@ -249,10 +249,10 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
             }
             match &fn_item.sig.output {
                 syn::ReturnType::Default => {
-                    quote! { -> futures::future::BoxFuture<#lt, ()> }
+                    quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = ()> + Send + #lt>> }
                 }
                 syn::ReturnType::Type(_, ty) => {
-                    quote! { -> futures::future::BoxFuture<#lt, #ty> }
+                    quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = #ty> + Send + #lt>> }
                 }
             }
         })?;


### PR DESCRIPTION


<!-- Provide a brief summary of your changes -->
This changes the expansion of `#[tool]` to emit `std::future::Future` instead of `Future`.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This is a pretty small papercut, but if you use `#[tool]` on an async function then it requires that `Future` be imported.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
`cargo check --all-targets` passes

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
