### PR TITLE
fix(readme): missing use declarations, more accurate server instructions

### DIFF
--- a/crates/rmcp/README.md
+++ b/crates/rmcp/README.md
@@ -16,14 +16,8 @@ Creating a server with tools is simple using the `#[tool]` macro:
 
 ```rust, ignore
 use rmcp::{
-    ErrorData as McpError,
-    ServiceExt,
-    model::*,
-    tool,
-    tool_handler,
-    tool_router,
-    transport::stdio,
-    handler::server::router::tool::ToolRouter
+    handler::server::router::tool::ToolRouter, model::*, tool, tool_handler, tool_router,
+    transport::stdio, ErrorData as McpError, ServiceExt,
 };
 use std::future::Future;
 use std::sync::Arc;


### PR DESCRIPTION
The server code in the crates README would not compile with v0.6.0. Also the MCP server description was inaccurate.

Fixes #394

## How Has This Been Tested?
Local cargo build with Rust 1.88.

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [n/a] New and existing tests pass locally
- [n/a] I have added appropriate error handling
- [x] I have added or updated documentation as needed
