### PR TITLE
fix: transport-streamable-http-server depends on transport-worker.

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -129,6 +129,7 @@ transport-sse-server = [
 transport-streamable-http-server = [
   "transport-streamable-http-server-session",
   "server-side-http",
+  "transport-worker",
 ]
 transport-streamable-http-server-session = [
   "transport-async-rw",


### PR DESCRIPTION
Fixes `transport-streamable-http-server` feature which requires `transport-worker` feature.

## Motivation and Context

When adding rmcp with the `transport-streamable-http-server` feature, `cargo build` fails with the following error:

```
error[E0432]: unresolved imports `crate::transport::WorkerTransport`, `crate::transport::worker`
  --> /home/user/rust-sdk/crates/rmcp/src/transport/streamable_http_server/session/local.rs:25:9
   |
25 |         WorkerTransport,
   |         ^^^^^^^^^^^^^^^ no `WorkerTransport` in `transport`
26 |         common::server_side_http::{SessionId, session_id},
27 |         worker::{Worker, WorkerContext, WorkerQuitReason, WorkerSendRequest},
   |         ^^^^^^ could not find `worker` in `transport`
   |
note: found an item that was configured out
  --> /home/user/rust-sdk/crates/rmcp/src/transport.rs:82:17
   |
82 | pub use worker::WorkerTransport;
   |                 ^^^^^^^^^^^^^^^
note: the item is gated behind the `transport-worker` feature
  --> /home/user/rust-sdk/crates/rmcp/src/transport.rs:80:7
   |
80 | #[cfg(feature = "transport-worker")]
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: found an item that was configured out
  --> /home/user/rust-sdk/crates/rmcp/src/transport.rs:79:9
   |
79 | pub mod worker;
   |         ^^^^^^
note: the item is gated behind the `transport-worker` feature
  --> /home/user/rust-sdk/crates/rmcp/src/transport.rs:77:7
   |
77 | #[cfg(feature = "transport-worker")]
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0433]: failed to resolve: could not find `worker` in `transport`
   --> /home/user/rust-sdk/crates/rmcp/src/transport/streamable_http_server/session/local.rs:720:43
    |
720 |     fn config(&self) -> crate::transport::worker::WorkerConfig {
    |                                           ^^^^^^ could not find `worker` in `transport`
    |
note: found an item that was configured out
   --> /home/user/rust-sdk/crates/rmcp/src/transport.rs:79:9
    |
79  | pub mod worker;
    |         ^^^^^^
note: the item is gated behind the `transport-worker` feature
   --> /home/user/rust-sdk/crates/rmcp/src/transport.rs:77:7
    |
77  | #[cfg(feature = "transport-worker")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0433]: failed to resolve: could not find `worker` in `transport`
   --> /home/user/rust-sdk/crates/rmcp/src/transport/streamable_http_server/session/local.rs:721:27
    |
721 |         crate::transport::worker::WorkerConfig {
    |                           ^^^^^^ could not find `worker` in `transport`
    |
note: found an item that was configured out
   --> /home/user/rust-sdk/crates/rmcp/src/transport.rs:79:9
    |
79  | pub mod worker;
    |         ^^^^^^
note: the item is gated behind the `transport-worker` feature
   --> /home/user/rust-sdk/crates/rmcp/src/transport.rs:77:7
    |
77  | #[cfg(feature = "transport-worker")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## How Has This Been Tested?

`cargo build` with the same `transport-streamable-http-server` feature succeeds with this change.

## Breaking Changes
No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
