### PR TITLE
David/ignore nonparseable stdout

### DIFF
--- a/crates/rmcp/src/transport/async_rw.rs
+++ b/crates/rmcp/src/transport/async_rw.rs
@@ -302,7 +302,6 @@ impl<T: DeserializeOwned> Decoder for JsonRpcMessageCodec<T> {
                         Ok(Some(item)) => item,
                         Ok(None) => return Ok(None), // Skip non-standard message
                         Err(e) => {
-                            dbg!(e);
                             // Ignore lines that do not parse
                             continue;
                         },

--- a/crates/rmcp/src/transport/async_rw.rs
+++ b/crates/rmcp/src/transport/async_rw.rs
@@ -298,9 +298,14 @@ impl<T: DeserializeOwned> Decoder for JsonRpcMessageCodec<T> {
                     let line = without_carriage_return(line);
 
                     // Use compatibility handling function
-                    let item = match try_parse_with_compatibility(line, "decode")? {
-                        Some(item) => item,
-                        None => return Ok(None), // Skip non-standard message
+                    let item = match try_parse_with_compatibility(line, "decode") {
+                        Ok(Some(item)) => item,
+                        Ok(None) => return Ok(None), // Skip non-standard message
+                        Err(e) => {
+                            dbg!(e);
+                            // Ignore lines that do not parse
+                            continue;
+                        },
                     };
                     return Ok(Some(item));
                 }


### PR DESCRIPTION
Ignore messages that don't parse as a JSONRPC object.

This will fix issues where we fail to start up spec non-compliant servers that write out status logs to stdout instead of stderr.