### PR TITLE
Skip notification in initialization handshake

### DIFF
--- a/crates/rmcp/src/service/client.rs
+++ b/crates/rmcp/src/service/client.rs
@@ -75,18 +75,51 @@ where
 }
 
 /// Helper function to expect a response from the stream
-async fn expect_response<T>(
+async fn expect_response<T, S>(
     transport: &mut T,
     context: &str,
+    service: &S,
+    peer: Peer<RoleClient>,
 ) -> Result<(ServerResult, RequestId), ClientInitializeError>
 where
     T: Transport<RoleClient>,
+    S: Service<RoleClient>,
 {
-    let msg = expect_next_message(transport, context).await?;
-
-    match msg {
-        ServerJsonRpcMessage::Response(JsonRpcResponse { id, result, .. }) => Ok((result, id)),
-        _ => Err(ClientInitializeError::ExpectedInitResponse(Some(msg))),
+    let notification_context = NotificationContext {
+        meta: Meta::new(),
+        extensions: Default::default(),
+        peer,
+    };
+    loop {
+        let message = expect_next_message(transport, context).await?;
+        match message {
+            // Expected message to complete the initialization
+            ServerJsonRpcMessage::Response(JsonRpcResponse { id, result, .. }) => {
+                break Ok((result, id));
+            }
+            // Server could send logging messages before handshake
+            ServerJsonRpcMessage::Notification(notification)
+                if matches!(
+                    notification.notification,
+                    ServerNotification::LoggingMessageNotification(_)
+                ) =>
+            {
+                if let Err(error) = service
+                    .handle_notification(notification.notification, notification_context.clone())
+                    .await
+                {
+                    tracing::warn!(?error, "Handle logging before handshake failed.");
+                }
+            }
+            // Server could send pings before handshake
+            ServerJsonRpcMessage::Request(ref request)
+                if matches!(request.request, ServerRequest::PingRequest(_)) =>
+            {
+                tracing::trace!("Received ping request. Ignored.")
+            }
+            // Server SHOULD NOT send any other messages before handshake. We ignore them anyway
+            _ => tracing::warn!(?message, "Received unexpected message"),
+        }
     }
 }
 
@@ -183,7 +216,15 @@ where
             context: "send initialize request".into(),
         })?;
 
-    let (response, response_id) = expect_response(&mut transport, "initialize response").await?;
+    let (peer, peer_rx) = Peer::new(id_provider, None);
+
+    let (response, response_id) = expect_response(
+        &mut transport,
+        "initialize response",
+        &service,
+        peer.clone(),
+    )
+    .await?;
 
     if id != response_id {
         return Err(ClientInitializeError::ConflictInitResponseId(
@@ -195,6 +236,7 @@ where
     let ServerResult::InitializeResult(initialize_result) = response else {
         return Err(ClientInitializeError::ExpectedInitResult(Some(response)));
     };
+    peer.set_peer_info(initialize_result);
 
     // send notification
     let notification = ClientJsonRpcMessage::notification(
@@ -206,7 +248,6 @@ where
     transport.send(notification).await.map_err(|error| {
         ClientInitializeError::transport::<T>(error, "send initialized notification")
     })?;
-    let (peer, peer_rx) = Peer::new(id_provider, Some(initialize_result));
     Ok(serve_inner(service, transport, peer, peer_rx, ct))
 }
 


### PR DESCRIPTION
This allows supporting nonconforming MCP servers by skipping notification in initialization handshake.

Fix #412


## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
Tested with DesktopCommanderMCP. All standard MCP servers continue to work normally.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
