### PR TITLE
fix: generate simple {} schema for tools with no parameters

### DIFF
--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -176,9 +176,9 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
                 rmcp::handler::server::common::cached_schema_for_type::<#params_ty>()
             })?
         } else {
-            // if not found, use the default EmptyObject schema
+            // if not found, use a simple empty JSON object
             syn::parse2::<Expr>(quote! {
-                rmcp::handler::server::common::cached_schema_for_type::<rmcp::model::EmptyObject>()
+                std::sync::Arc::new(serde_json::Map::new())
             })?
         }
     };

--- a/crates/rmcp/tests/test_tool_macros.rs
+++ b/crates/rmcp/tests/test_tool_macros.rs
@@ -110,7 +110,7 @@ async fn test_tool_macros() {
 async fn test_tool_macros_with_empty_param() {
     let _attr = Server::empty_param_tool_attr();
     println!("{_attr:?}");
-    assert_eq!(_attr.input_schema.get("type").unwrap(), "object");
+    assert!(_attr.input_schema.get("type").is_none());
     assert!(_attr.input_schema.get("properties").is_none());
 }
 


### PR DESCRIPTION
fixes #303

## Motivation and Context

This fix resolves the OpenAI compatibility issue reported in Issue #303.

### Before

```json
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "type": "object",
    "title": "EmptyObject",
    "description": "This is commonly used for representing empty objects in MCP messages..."
}
```

### After

```json
{}
```

## How Has This Been Tested?

Updated existing test `test_tool_macros_with_empty_param` to validate the new behavior

## Breaking Changes

None. This is a backward-compatible fix:
- Tools with parameters continue to generate proper complex schemas
- Only affects the schema generation for tools with no parameters

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
