### PR TITLE
fix: build issue due to missing struct field

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1227,7 +1227,13 @@ pub enum Reference {
 impl Reference {
     /// Create a prompt reference
     pub fn for_prompt(name: impl Into<String>) -> Self {
-        Self::Prompt(PromptReference { name: name.into() })
+        // Not accepting `title` currently as it'll break the API
+        // Until further decision, keep it `None`, modify later
+        // if required, add `title` to the API
+        Self::Prompt(PromptReference {
+            name: name.into(),
+            title: None,
+        })
     }
 
     /// Create a resource reference


### PR DESCRIPTION
Commit 452fe2c broke `Reference::for_prompt` where it missed the field `title` for `struct PromptReference`, which broke the build.

This commit fixes that.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
Fixes build issue.