### PR TITLE
feat(SEP-973): add support for icons and websiteUrl across relevant types

### DIFF
--- a/crates/rmcp-macros/src/prompt.rs
+++ b/crates/rmcp-macros/src/prompt.rs
@@ -16,6 +16,8 @@ pub struct PromptAttribute {
     pub description: Option<String>,
     /// Arguments that can be passed to the prompt
     pub arguments: Option<Expr>,
+    /// Optional icons for the prompt
+    pub icons: Option<Expr>,
 }
 
 pub struct ResolvedPromptAttribute {
@@ -23,6 +25,7 @@ pub struct ResolvedPromptAttribute {
     pub title: Option<String>,
     pub description: Option<String>,
     pub arguments: Expr,
+    pub icons: Option<Expr>,
 }
 
 impl ResolvedPromptAttribute {
@@ -32,6 +35,7 @@ impl ResolvedPromptAttribute {
             description,
             arguments,
             title,
+            icons,
         } = self;
         let description = if let Some(description) = description {
             quote! { Some(#description.into()) }
@@ -43,6 +47,11 @@ impl ResolvedPromptAttribute {
         } else {
             quote! { None }
         };
+        let icons = if let Some(icons) = icons {
+            quote! { Some(#icons) }
+        } else {
+            quote! { None }
+        };
         let tokens = quote! {
             pub fn #fn_ident() -> rmcp::model::Prompt {
                 rmcp::model::Prompt {
@@ -50,6 +59,7 @@ impl ResolvedPromptAttribute {
                     description: #description,
                     arguments: #arguments,
                     title: #title,
+                    icons: #icons,
                 }
             }
         };
@@ -98,6 +108,7 @@ pub fn prompt(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream>
         description: description.clone(),
         arguments: arguments.clone(),
         title: attribute.title,
+        icons: attribute.icons,
     };
     let prompt_attr_fn = resolved_prompt_attr.into_fn(prompt_attr_fn_ident.clone())?;
 

--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -75,6 +75,8 @@ pub struct ToolAttribute {
     pub output_schema: Option<Expr>,
     /// Optional additional tool information.
     pub annotations: Option<ToolAnnotationsAttribute>,
+    /// Optional icons for the tool
+    pub icons: Option<Expr>,
 }
 
 pub struct ResolvedToolAttribute {
@@ -84,6 +86,7 @@ pub struct ResolvedToolAttribute {
     pub input_schema: Expr,
     pub output_schema: Option<Expr>,
     pub annotations: Expr,
+    pub icons: Option<Expr>,
 }
 
 impl ResolvedToolAttribute {
@@ -95,6 +98,7 @@ impl ResolvedToolAttribute {
             input_schema,
             output_schema,
             annotations,
+            icons,
         } = self;
         let description = if let Some(description) = description {
             quote! { Some(#description.into()) }
@@ -111,6 +115,11 @@ impl ResolvedToolAttribute {
         } else {
             quote! { None }
         };
+        let icons = if let Some(icons) = icons {
+            quote! { Some(#icons) }
+        } else {
+            quote! { None }
+        };
         let tokens = quote! {
             pub fn #fn_ident() -> rmcp::model::Tool {
                 rmcp::model::Tool {
@@ -120,6 +129,7 @@ impl ResolvedToolAttribute {
                     input_schema: #input_schema,
                     output_schema: #output_schema,
                     annotations: #annotations,
+                    icons: #icons,
                 }
             }
         };
@@ -240,6 +250,7 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
         output_schema: output_schema_expr,
         annotations: annotations_expr,
         title: attribute.title,
+        icons: attribute.icons,
     };
     let tool_attr_fn = resolved_tool_attr.into_fn(tool_attr_fn_ident)?;
     // modify the the input function

--- a/crates/rmcp/src/model/content.rs
+++ b/crates/rmcp/src/model/content.rs
@@ -257,6 +257,7 @@ mod tests {
             description: Some("A test file".to_string()),
             mime_type: Some("text/plain".to_string()),
             size: Some(100),
+            icons: None,
         });
 
         let json = serde_json::to_string(&resource_link).unwrap();

--- a/crates/rmcp/src/model/prompt.rs
+++ b/crates/rmcp/src/model/prompt.rs
@@ -2,7 +2,7 @@ use base64::engine::{Engine, general_purpose::STANDARD as BASE64_STANDARD};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    AnnotateAble, Annotations, RawEmbeddedResource, RawImageContent,
+    AnnotateAble, Annotations, Icon, RawEmbeddedResource, RawImageContent,
     content::{EmbeddedResource, ImageContent},
     resource::ResourceContents,
 };
@@ -22,6 +22,9 @@ pub struct Prompt {
     /// Optional arguments that can be passed to customize the prompt
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<Vec<PromptArgument>>,
+    /// Optional list of icons for the prompt
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<Icon>>,
 }
 
 impl Prompt {
@@ -40,6 +43,7 @@ impl Prompt {
             title: None,
             description: description.map(Into::into),
             arguments,
+            icons: None,
         }
     }
 }

--- a/crates/rmcp/src/model/resource.rs
+++ b/crates/rmcp/src/model/resource.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{Annotated, Meta};
+use super::{Annotated, Icon, Meta};
 
 /// Represents a resource in the extension with metadata
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -26,6 +26,9 @@ pub struct RawResource {
     /// This can be used by Hosts to display file sizes and estimate context window us
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<u32>,
+    /// Optional list of icons for the resource
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<Icon>>,
 }
 
 pub type Resource = Annotated<RawResource>;
@@ -91,6 +94,7 @@ impl RawResource {
             description: None,
             mime_type: None,
             size: None,
+            icons: None,
         }
     }
 }
@@ -110,6 +114,7 @@ mod tests {
             description: Some("Test resource".to_string()),
             mime_type: Some("text/plain".to_string()),
             size: Some(100),
+            icons: None,
         };
 
         let json = serde_json::to_string(&resource).unwrap();

--- a/crates/rmcp/src/model/tool.rs
+++ b/crates/rmcp/src/model/tool.rs
@@ -6,7 +6,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::JsonObject;
+use super::{Icon, JsonObject};
 
 /// A tool that can be used by a model.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -29,6 +29,9 @@ pub struct Tool {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Optional additional tool information.
     pub annotations: Option<ToolAnnotations>,
+    /// Optional list of icons for the tool
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<Icon>>,
 }
 
 /// Additional properties describing a Tool to clients.
@@ -146,6 +149,7 @@ impl Tool {
             input_schema: input_schema.into(),
             output_schema: None,
             annotations: None,
+            icons: None,
         }
     }
 

--- a/crates/rmcp/tests/test_elicitation.rs
+++ b/crates/rmcp/tests/test_elicitation.rs
@@ -893,6 +893,8 @@ async fn test_initialize_request_with_elicitation() {
             name: "test-client".to_string(),
             version: "1.0.0".to_string(),
             title: None,
+            website_url: None,
+            icons: None,
         },
     };
 
@@ -935,6 +937,8 @@ async fn test_capability_checking_logic() {
             name: "test-client".to_string(),
             version: "1.0.0".to_string(),
             title: None,
+            website_url: None,
+            icons: None,
         },
     };
 
@@ -953,9 +957,10 @@ async fn test_capability_checking_logic() {
             name: "test-client".to_string(),
             version: "1.0.0".to_string(),
             title: None,
+            website_url: None,
+            icons: None,
         },
     };
-
     let supports_elicitation = client_without_capability.capabilities.elicitation.is_some();
     assert!(!supports_elicitation);
 }

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
@@ -487,9 +487,45 @@
         "name"
       ]
     },
+    "Icon": {
+      "description": "A URL pointing to an icon resource or a base64-encoded data URI.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- image/png - PNG images (safe, universal compatibility)\n- image/jpeg (and image/jpg) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- image/svg+xml - SVG images (scalable but requires security precautions)\n- image/webp - WebP images (modern, efficient format)",
+      "type": "object",
+      "properties": {
+        "mimeType": {
+          "description": "Optional override if the server's MIME type is missing or generic",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sizes": {
+          "description": "Size specification (e.g., \"48x48\", \"any\" for SVG, or \"48x48 96x96\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ]
+    },
     "Implementation": {
       "type": "object",
       "properties": {
+        "icons": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
+        },
         "name": {
           "type": "string"
         },
@@ -501,6 +537,12 @@
         },
         "version": {
           "type": "string"
+        },
+        "websiteUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -937,6 +979,16 @@
             "string",
             "null"
           ]
+        },
+        "icons": {
+          "description": "Optional list of icons for the resource",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
         },
         "mimeType": {
           "description": "MIME type of the resource content (\"text\" or \"blob\")",

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "JsonRpcMessage",
-  "description": "Represents any JSON-RPC message that can be sent or received.\n\nThis enum covers all possible message types in the JSON-RPC protocol:\nindividual requests/responses, notifications, batch operations, and errors.\nIt serves as the top-level message container for MCP communication.",
+  "description": "Represents any JSON-RPC message that can be sent or received.\n\nThis enum covers all possible message types in the JSON-RPC protocol:\nindividual requests/responses, notifications, and errors.\nIt serves as the top-level message container for MCP communication.",
   "anyOf": [
     {
       "description": "A single request expecting a response",
@@ -113,7 +113,7 @@
           },
           "allOf": [
             {
-              "$ref": "#/definitions/Annotated2"
+              "$ref": "#/definitions/RawAudioContent"
             }
           ],
           "required": [
@@ -137,31 +137,6 @@
             "type"
           ]
         }
-      ]
-    },
-    "Annotated2": {
-      "type": "object",
-      "properties": {
-        "annotations": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Annotations"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "data": {
-          "type": "string"
-        },
-        "mimeType": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "data",
-        "mimeType"
       ]
     },
     "Annotations": {
@@ -327,6 +302,17 @@
         "argument": {
           "$ref": "#/definitions/ArgumentInfo"
         },
+        "context": {
+          "description": "Optional context containing previously resolved argument values",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CompletionContext"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "ref": {
           "$ref": "#/definitions/Reference"
         }
@@ -335,6 +321,22 @@
         "ref",
         "argument"
       ]
+    },
+    "CompletionContext": {
+      "description": "Context for completion requests providing previously resolved arguments.\n\nThis enables context-aware completion where subsequent argument completions\ncan take into account the values of previously resolved arguments.",
+      "type": "object",
+      "properties": {
+        "arguments": {
+          "description": "Previously resolved argument values that can inform completion suggestions",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
     },
     "CreateElicitationResult": {
       "description": "The result returned by a client in response to an elicitation request.\n\nContains the user's decision (accept/decline/cancel) and optionally their input data\nif they chose to accept the request.",
@@ -485,14 +487,62 @@
         "name"
       ]
     },
+    "Icon": {
+      "description": "A URL pointing to an icon resource or a base64-encoded data URI.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- image/png - PNG images (safe, universal compatibility)\n- image/jpeg (and image/jpg) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- image/svg+xml - SVG images (scalable but requires security precautions)\n- image/webp - WebP images (modern, efficient format)",
+      "type": "object",
+      "properties": {
+        "mimeType": {
+          "description": "Optional override if the server's MIME type is missing or generic",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sizes": {
+          "description": "Size specification (e.g., \"48x48\", \"any\" for SVG, or \"48x48 96x96\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ]
+    },
     "Implementation": {
       "type": "object",
       "properties": {
+        "icons": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
+        },
         "name": {
           "type": "string"
         },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "version": {
           "type": "string"
+        },
+        "websiteUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -845,6 +895,12 @@
       "properties": {
         "name": {
           "type": "string"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -854,6 +910,21 @@
     "ProtocolVersion": {
       "description": "Represents the MCP protocol version used for communication.\n\nThis ensures compatibility between clients and servers by specifying\nwhich version of the Model Context Protocol is being used.",
       "type": "string"
+    },
+    "RawAudioContent": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        },
+        "mimeType": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType"
+      ]
     },
     "RawEmbeddedResource": {
       "type": "object",
@@ -909,6 +980,16 @@
             "null"
           ]
         },
+        "icons": {
+          "description": "Optional list of icons for the resource",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
+        },
         "mimeType": {
           "description": "MIME type of the resource content (\"text\" or \"blob\")",
           "type": [
@@ -928,6 +1009,13 @@
           ],
           "format": "uint32",
           "minimum": 0
+        },
+        "title": {
+          "description": "Human-readable title of the resource",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "uri": {
           "description": "URI representing the resource location (e.g., \"file:///path/to/file\" or \"str:///content\")",

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -189,6 +189,16 @@
             "null"
           ]
         },
+        "icons": {
+          "description": "Optional list of icons for the resource",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
+        },
         "mimeType": {
           "description": "MIME type of the resource content (\"text\" or \"blob\")",
           "type": [
@@ -608,9 +618,45 @@
         "messages"
       ]
     },
+    "Icon": {
+      "description": "A URL pointing to an icon resource or a base64-encoded data URI.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- image/png - PNG images (safe, universal compatibility)\n- image/jpeg (and image/jpg) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- image/svg+xml - SVG images (scalable but requires security precautions)\n- image/webp - WebP images (modern, efficient format)",
+      "type": "object",
+      "properties": {
+        "mimeType": {
+          "description": "Optional override if the server's MIME type is missing or generic",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sizes": {
+          "description": "Size specification (e.g., \"48x48\", \"any\" for SVG, or \"48x48 96x96\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ]
+    },
     "Implementation": {
       "type": "object",
       "properties": {
+        "icons": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
+        },
         "name": {
           "type": "string"
         },
@@ -622,6 +668,12 @@
         },
         "version": {
           "type": "string"
+        },
+        "websiteUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -1136,6 +1188,16 @@
             "null"
           ]
         },
+        "icons": {
+          "description": "Optional list of icons for the prompt",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
+        },
         "name": {
           "description": "The name of the prompt",
           "type": "string"
@@ -1314,6 +1376,16 @@
                 "null"
               ]
             },
+            "icons": {
+              "description": "Optional list of icons for the resource",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/Icon"
+              }
+            },
             "mimeType": {
               "description": "MIME type of the resource content (\"text\" or \"blob\")",
               "type": [
@@ -1449,6 +1521,16 @@
             "string",
             "null"
           ]
+        },
+        "icons": {
+          "description": "Optional list of icons for the resource",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
         },
         "mimeType": {
           "description": "MIME type of the resource content (\"text\" or \"blob\")",
@@ -1836,6 +1918,16 @@
             "string",
             "null"
           ]
+        },
+        "icons": {
+          "description": "Optional list of icons for the tool",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
         },
         "inputSchema": {
           "description": "A JSON Schema object defining the expected parameters for the tool",

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "JsonRpcMessage",
-  "description": "Represents any JSON-RPC message that can be sent or received.\n\nThis enum covers all possible message types in the JSON-RPC protocol:\nindividual requests/responses, notifications, batch operations, and errors.\nIt serves as the top-level message container for MCP communication.",
+  "description": "Represents any JSON-RPC message that can be sent or received.\n\nThis enum covers all possible message types in the JSON-RPC protocol:\nindividual requests/responses, notifications, and errors.\nIt serves as the top-level message container for MCP communication.",
   "anyOf": [
     {
       "description": "A single request expecting a response",
@@ -113,7 +113,7 @@
           },
           "allOf": [
             {
-              "$ref": "#/definitions/Annotated2"
+              "$ref": "#/definitions/RawAudioContent"
             }
           ],
           "required": [
@@ -142,31 +142,6 @@
     "Annotated2": {
       "type": "object",
       "properties": {
-        "annotations": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Annotations"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "data": {
-          "type": "string"
-        },
-        "mimeType": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "data",
-        "mimeType"
-      ]
-    },
-    "Annotated3": {
-      "type": "object",
-      "properties": {
         "_meta": {
           "description": "Optional protocol-level metadata for this content block",
           "type": [
@@ -193,7 +168,7 @@
         "resource"
       ]
     },
-    "Annotated4": {
+    "Annotated3": {
       "description": "Represents a resource in the extension with metadata",
       "type": "object",
       "properties": {
@@ -213,6 +188,16 @@
             "string",
             "null"
           ]
+        },
+        "icons": {
+          "description": "Optional list of icons for the resource",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
         },
         "mimeType": {
           "description": "MIME type of the resource content (\"text\" or \"blob\")",
@@ -234,6 +219,13 @@
           "format": "uint32",
           "minimum": 0
         },
+        "title": {
+          "description": "Human-readable title of the resource",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "uri": {
           "description": "URI representing the resource location (e.g., \"file:///path/to/file\" or \"str:///content\")",
           "type": "string"
@@ -244,7 +236,7 @@
         "name"
       ]
     },
-    "Annotated5": {
+    "Annotated4": {
       "type": "object",
       "properties": {
         "annotations": {
@@ -271,6 +263,12 @@
         },
         "name": {
           "type": "string"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "uriTemplate": {
           "type": "string"
@@ -620,14 +618,62 @@
         "messages"
       ]
     },
+    "Icon": {
+      "description": "A URL pointing to an icon resource or a base64-encoded data URI.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- image/png - PNG images (safe, universal compatibility)\n- image/jpeg (and image/jpg) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- image/svg+xml - SVG images (scalable but requires security precautions)\n- image/webp - WebP images (modern, efficient format)",
+      "type": "object",
+      "properties": {
+        "mimeType": {
+          "description": "Optional override if the server's MIME type is missing or generic",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sizes": {
+          "description": "Size specification (e.g., \"48x48\", \"any\" for SVG, or \"48x48 96x96\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ]
+    },
     "Implementation": {
       "type": "object",
       "properties": {
+        "icons": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
+        },
         "name": {
           "type": "string"
         },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "version": {
           "type": "string"
+        },
+        "websiteUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -815,7 +861,7 @@
         "resourceTemplates": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Annotated5"
+            "$ref": "#/definitions/Annotated4"
           }
         }
       },
@@ -835,7 +881,7 @@
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Annotated4"
+            "$ref": "#/definitions/Annotated3"
           }
         }
       },
@@ -1142,9 +1188,25 @@
             "null"
           ]
         },
+        "icons": {
+          "description": "Optional list of icons for the prompt",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
+        },
         "name": {
           "description": "The name of the prompt",
           "type": "string"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -1170,6 +1232,13 @@
           "description": "Whether this argument is required",
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "A human-readable title for the argument",
+          "type": [
+            "string",
             "null"
           ]
         }
@@ -1274,7 +1343,7 @@
           "type": "object",
           "properties": {
             "resource": {
-              "$ref": "#/definitions/Annotated3"
+              "$ref": "#/definitions/Annotated2"
             },
             "type": {
               "type": "string",
@@ -1307,6 +1376,16 @@
                 "null"
               ]
             },
+            "icons": {
+              "description": "Optional list of icons for the resource",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/Icon"
+              }
+            },
             "mimeType": {
               "description": "MIME type of the resource content (\"text\" or \"blob\")",
               "type": [
@@ -1326,6 +1405,13 @@
               ],
               "format": "uint32",
               "minimum": 0
+            },
+            "title": {
+              "description": "Human-readable title of the resource",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "type": {
               "type": "string",
@@ -1366,6 +1452,21 @@
     "ProtocolVersion": {
       "description": "Represents the MCP protocol version used for communication.\n\nThis ensures compatibility between clients and servers by specifying\nwhich version of the Model Context Protocol is being used.",
       "type": "string"
+    },
+    "RawAudioContent": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        },
+        "mimeType": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType"
+      ]
     },
     "RawEmbeddedResource": {
       "type": "object",
@@ -1421,6 +1522,16 @@
             "null"
           ]
         },
+        "icons": {
+          "description": "Optional list of icons for the resource",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
+        },
         "mimeType": {
           "description": "MIME type of the resource content (\"text\" or \"blob\")",
           "type": [
@@ -1440,6 +1551,13 @@
           ],
           "format": "uint32",
           "minimum": 0
+        },
+        "title": {
+          "description": "Human-readable title of the resource",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "uri": {
           "description": "URI representing the resource location (e.g., \"file:///path/to/file\" or \"str:///content\")",
@@ -1801,6 +1919,16 @@
             "null"
           ]
         },
+        "icons": {
+          "description": "Optional list of icons for the tool",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Icon"
+          }
+        },
         "inputSchema": {
           "description": "A JSON Schema object defining the expected parameters for the tool",
           "type": "object",
@@ -1817,6 +1945,13 @@
             "null"
           ],
           "additionalProperties": true
+        },
+        "title": {
+          "description": "A human-readable title for the tool",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [

--- a/examples/clients/src/sse.rs
+++ b/examples/clients/src/sse.rs
@@ -24,6 +24,8 @@ async fn main() -> Result<()> {
             name: "test sse client".to_string(),
             title: None,
             version: "0.0.1".to_string(),
+            website_url: None,
+            icons: None,
         },
     };
     let client = client_info.serve(transport).await.inspect_err(|e| {

--- a/examples/clients/src/streamable_http.rs
+++ b/examples/clients/src/streamable_http.rs
@@ -24,6 +24,8 @@ async fn main() -> Result<()> {
             name: "test sse client".to_string(),
             title: None,
             version: "0.0.1".to_string(),
+            website_url: None,
+            icons: None,
         },
     };
     let client = client_info.serve(transport).await.inspect_err(|e| {

--- a/examples/servers/src/sampling_stdio.rs
+++ b/examples/servers/src/sampling_stdio.rs
@@ -122,6 +122,7 @@ impl ServerHandler for SamplingDemoServer {
                 ),
                 output_schema: None,
                 annotations: None,
+                icons: None,
             }],
             next_cursor: None,
         })


### PR DESCRIPTION
## Motivation and Context
Implementing support for SEP-973 as requested in https://github.com/modelcontextprotocol/rust-sdk/issues/417

Adds

* Icons for server implementations (multiple sizes supported)
* Icons for individual resources, tools, and prompts
* Website URLs for documentation linking

## How Has This Been Tested?

- [X] Unit testing

Will also

- [ ] Test in Goose
- [x] Verify all additions have been made and tested

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed
