### PR TITLE
Ignore non-parseable lines on stdout.

### DIFF
--- a/crates/rmcp/src/transport/async_rw.rs
+++ b/crates/rmcp/src/transport/async_rw.rs
@@ -309,9 +309,13 @@ impl<T: DeserializeOwned> Decoder for JsonRpcMessageCodec<T> {
                     let line = without_carriage_return(line);
 
                     // Use compatibility handling function
-                    let item = match try_parse_with_compatibility(line, "decode")? {
-                        Some(item) => item,
-                        None => return Ok(None), // Skip non-standard message
+                    let item = match try_parse_with_compatibility(line, "decode") {
+                        Ok(Some(item)) => item,
+                        Ok(None) => return Ok(None), // Skip non-standard message
+                        Err(e) => {
+                            // Ignore lines that do not parse
+                            continue;
+                        }
                     };
                     return Ok(Some(item));
                 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

As reported in https://github.com/modelcontextprotocol/rust-sdk/issues/412, a non-conforming stdio transport-based server can break this client library by writing non-JSONRPC text to stdout before the initialization handshake.

This changes the `JsonRpcMessageCodec::decode` to ignore lines that don't parse as JSONRPC instead of propagating up an error.

## How Has This Been Tested?

Tested this in Warp, using the `@circleci/mcp-server-circleci` server.  We've had this change live in production (via a fork) for a week now and have not received any reports from users of it causing issues.

## Breaking Changes

No, this does not affect any public APIs, and should strictly improve compatibility with stdio-based MCP servers.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

> [!IMPORTANT]
> I don't love this change.  While it is effective (and was a good quick fix in our fork), it ultimately makes behavioral decisions in parsing code that belong in calling code.
>
> I think the better fix here is to change the signature of `Transport::receive()` to produce `Result<RxJsonRpcMessage<R>, _>` instead of `Option<RxJsonRpcMessage<R>>`, so that we can surface errors to the service layer and let it make decisions.  For example, the service layer might want to ignore _decoding_ errors (and read another message), but handle I/O errors.

Figured I'd start by sending this change as-is in case y'all are ok with it as a quick fix for the problem, and want to make the API change later (given that it would be a semver breaking change).