### PR TITLE
Add Terminator to Built with rmcp section

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ See [oauth_support](docs/OAUTH_SUPPORT.md) for details.
 - [containerd-mcp-server](https://github.com/jokemanfire/mcp-containerd) - A containerd-based MCP server implementation
 - [rmcp-openapi-server](https://gitlab.com/lx-industries/rmcp-openapi/-/tree/main/crates/rmcp-openapi-server) - High-performance MCP server that exposes OpenAPI definition endpoints as MCP tools
 - [nvim-mcp](https://github.com/linw1995/nvim-mcp) - A MCP server to interact with Neovim
+- [terminator](https://github.com/mediar-ai/terminator) - AI-powered desktop automation MCP server with cross-platform support and >95% success rate
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Added Terminator to the list of projects built with rmcp in the README

## Description
This PR adds [Terminator](https://github.com/mediar-ai/terminator) to the "Built with `rmcp`" section of the README. Terminator is an AI-powered desktop automation MCP server with cross-platform support and high success rates.

## Test plan
- [x] Verified the link is correct
- [x] Confirmed the description accurately represents the project
- [x] Maintained consistent formatting with other entries

🤖 Generated with [Claude Code](https://claude.ai/code)