### PR TITLE
bugfix: Non-empty paths in OAuth2 Authorization Server Metadata URLs

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -203,7 +203,13 @@ impl AuthorizationManager {
     pub async fn discover_metadata(&self) -> Result<AuthorizationMetadata, AuthError> {
         // according to the specification, the metadata should be located at "/.well-known/oauth-authorization-server"
         let mut discovery_url = self.base_url.clone();
-        discovery_url.set_path("/.well-known/oauth-authorization-server");
+        let path = discovery_url.path();
+        let path_suffix = if path == "/" {
+            ""
+        } else {
+            path
+        };
+        discovery_url.set_path(&format!("/.well-known/oauth-authorization-server{path_suffix}"));
         debug!("discovery url: {:?}", discovery_url);
         let response = self
             .http_client

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -204,12 +204,10 @@ impl AuthorizationManager {
         // according to the specification, the metadata should be located at "/.well-known/oauth-authorization-server"
         let mut discovery_url = self.base_url.clone();
         let path = discovery_url.path();
-        let path_suffix = if path == "/" {
-            ""
-        } else {
-            path
-        };
-        discovery_url.set_path(&format!("/.well-known/oauth-authorization-server{path_suffix}"));
+        let path_suffix = if path == "/" { "" } else { path };
+        discovery_url.set_path(&format!(
+            "/.well-known/oauth-authorization-server{path_suffix}"
+        ));
         debug!("discovery url: {:?}", discovery_url);
         let response = self
             .http_client


### PR DESCRIPTION
When constructing an OAuth2 Authorization Server Metadata URL from the MCP server URL, consider the resource URL path as required in [the RFC](https://datatracker.ietf.org/doc/html/rfc8414#section-3.1).

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This is requiired for MCP servers that use resource-specific authorization servers.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Using the example DCR client.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
N/A