### PR TITLE
feat(macros): support macros in doc attributes for tool macro

### DIFF
--- a/crates/rmcp-macros/src/common.rs
+++ b/crates/rmcp-macros/src/common.rs
@@ -9,7 +9,7 @@ pub fn none_expr() -> syn::Result<Expr> {
 }
 
 /// Extract documentation from doc attributes
-pub fn extract_doc_line(existing_docs: Option<String>, attr: &Attribute) -> Option<String> {
+pub fn extract_doc_line(existing_docs: Option<Expr>, attr: &Attribute) -> Option<Expr> {
     if !attr.path().is_ident("doc") {
         return None;
     }
@@ -18,23 +18,32 @@ pub fn extract_doc_line(existing_docs: Option<String>, attr: &Attribute) -> Opti
         return None;
     };
 
-    let syn::Expr::Lit(expr_lit) = &name_value.value else {
-        return None;
-    };
-
-    let syn::Lit::Str(lit_str) = &expr_lit.lit else {
-        return None;
-    };
-
-    let content = lit_str.value().trim().to_string();
-    match (existing_docs, content) {
-        (Some(mut existing_docs), content) if !content.is_empty() => {
-            existing_docs.push('\n');
-            existing_docs.push_str(&content);
-            Some(existing_docs)
+    let value = &name_value.value;
+    let this_expr: Option<Expr> = match value {
+        // Preserve macros such as `include_str!(...)`
+        syn::Expr::Macro(_) => Some(value.clone()),
+        syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(lit_str),
+            ..
+        }) => {
+            let content = lit_str.value().trim().to_string();
+            if content.is_empty() {
+                return existing_docs;
+            }
+            Some(Expr::Lit(syn::ExprLit {
+                attrs: Vec::new(),
+                lit: syn::Lit::Str(syn::LitStr::new(&content, lit_str.span())),
+            }))
         }
-        (Some(existing_docs), _) => Some(existing_docs),
-        (None, content) if !content.is_empty() => Some(content),
+        _ => return None,
+    };
+
+    match (existing_docs, this_expr) {
+        (Some(existing), Some(this)) => {
+            syn::parse2::<Expr>(quote! { concat!(#existing, "\n", #this) }).ok()
+        }
+        (Some(existing), None) => Some(existing),
+        (None, Some(this)) => Some(this),
         _ => None,
     }
 }

--- a/crates/rmcp-macros/src/prompt.rs
+++ b/crates/rmcp-macros/src/prompt.rs
@@ -1,5 +1,5 @@
 use darling::{FromMeta, ast::NestedMeta};
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{Expr, Ident, ImplItemFn, ReturnType};
 
@@ -23,7 +23,7 @@ pub struct PromptAttribute {
 pub struct ResolvedPromptAttribute {
     pub name: String,
     pub title: Option<String>,
-    pub description: Option<String>,
+    pub description: Option<Expr>,
     pub arguments: Expr,
     pub icons: Option<Expr>,
 }
@@ -100,6 +100,12 @@ pub fn prompt(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream>
     let name = attribute.name.unwrap_or_else(|| fn_ident.to_string());
     let description = attribute
         .description
+        .map(|s| {
+            Expr::Lit(syn::ExprLit {
+                attrs: Vec::new(),
+                lit: syn::Lit::Str(syn::LitStr::new(&s, Span::call_site())),
+            })
+        })
         .or_else(|| fn_item.attrs.iter().fold(None, extract_doc_line));
     let arguments = arguments_expr;
 
@@ -197,6 +203,24 @@ mod test {
         let result_str = result.to_string();
         assert!(result_str.contains("This is a test prompt description"));
         assert!(result_str.contains("with multiple lines"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_doc_include_description() -> syn::Result<()> {
+        let attr = quote! {}; // No explicit description
+        let input = quote! {
+            #[doc = include_str!("some/test/data/doc.txt")]
+            fn test_prompt_included(&self) -> Result<String> {
+                Ok("Test".to_string())
+            }
+        };
+        let result = prompt(attr, input)?;
+
+        // The generated tokens should preserve the include_str! invocation
+        let result_str = result.to_string();
+        assert!(result_str.contains("include_str"));
 
         Ok(())
     }

--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -1,7 +1,7 @@
 use darling::{FromMeta, ast::NestedMeta};
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, format_ident, quote};
-use syn::{Expr, Ident, ImplItemFn, ReturnType, parse_quote};
+use syn::{Expr, Ident, ImplItemFn, LitStr, ReturnType, parse_quote};
 
 use crate::common::{extract_doc_line, none_expr};
 
@@ -82,7 +82,7 @@ pub struct ToolAttribute {
 pub struct ResolvedToolAttribute {
     pub name: String,
     pub title: Option<String>,
-    pub description: Option<String>,
+    pub description: Option<Expr>,
     pub input_schema: Expr,
     pub output_schema: Option<Expr>,
     pub annotations: Expr,
@@ -244,11 +244,19 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
         }
     });
 
+    let description_expr = attribute
+        .description
+        .map(|s| {
+            let lit = LitStr::new(&s, Span::call_site());
+            Expr::Lit(syn::ExprLit {
+                attrs: Vec::new(),
+                lit: syn::Lit::Str(lit),
+            })
+        })
+        .or_else(|| fn_item.attrs.iter().fold(None, extract_doc_line));
     let resolved_tool_attr = ResolvedToolAttribute {
         name: attribute.name.unwrap_or_else(|| fn_ident.to_string()),
-        description: attribute
-            .description
-            .or_else(|| fn_item.attrs.iter().fold(None, extract_doc_line)),
+        description: description_expr,
         input_schema: input_schema_expr,
         output_schema: output_schema_expr,
         annotations: annotations_expr,
@@ -350,6 +358,24 @@ mod test {
         // The output should contain the explicit description
         let result_str = result.to_string();
         assert!(result_str.contains("Explicit description has priority"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_doc_include_description() -> syn::Result<()> {
+        let attr = quote! {}; // No explicit description
+        let input = quote! {
+            #[doc = include_str!("some/test/data/doc.txt")]
+            fn test_function(&self) -> Result<(), Error> {
+                Ok(())
+            }
+        };
+        let result = tool(attr, input)?;
+
+        // The macro should preserve include_str! in the generated tokens so we at least
+        // see the include_str invocation in the generated function source.
+        let result_str = result.to_string();
+        assert!(result_str.contains("include_str"));
         Ok(())
     }
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add support for macros in doc attributes parsed by the tool macro.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Currently the `#[tool]` macro only supports literal strings for `#[doc]` attributes, and some codebases use external docs, .e.g, `#[doc = include_str!(...)]`.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Test cases have been added.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
