### PR TITLE
fix: generate default schema for tools with no params

### DIFF
--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -199,9 +199,12 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
                 rmcp::handler::server::common::cached_schema_for_type::<#params_ty>()
             })?
         } else {
-            // if not found, use a simple empty JSON object
+            // if not found, use a default empty JSON schema object
             syn::parse2::<Expr>(quote! {
-                std::sync::Arc::new(serde_json::Map::new())
+                std::sync::Arc::new(serde_json::json!({
+                    "type": "object",
+                    "properties": {}
+                }).as_object().unwrap().clone())
             })?
         }
     };

--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -200,6 +200,7 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
             })?
         } else {
             // if not found, use a default empty JSON schema object
+            // TODO: should be updated according to the new specifications
             syn::parse2::<Expr>(quote! {
                 std::sync::Arc::new(serde_json::json!({
                     "type": "object",

--- a/crates/rmcp/tests/test_tool_macros.rs
+++ b/crates/rmcp/tests/test_tool_macros.rs
@@ -121,8 +121,14 @@ async fn test_tool_macros() {
 async fn test_tool_macros_with_empty_param() {
     let _attr = Server::empty_param_tool_attr();
     println!("{_attr:?}");
-    assert!(_attr.input_schema.get("type").is_none());
-    assert!(_attr.input_schema.get("properties").is_none());
+    assert_eq!(
+        _attr.input_schema.get("type"),
+        Some(&serde_json::Value::String("object".to_string()))
+    );
+    assert_eq!(
+        _attr.input_schema.get("properties"),
+        Some(&serde_json::Value::Object(serde_json::Map::new()))
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
closes https://github.com/modelcontextprotocol/rust-sdk/issues/445

provide empty object json schema when there is no params for a tool, following https://github.com/modelcontextprotocol/typescript-sdk/blob/c94ba4b43cd305e39d88985c73d6b9bc1153da84/src/server/mcp.ts#L1202-L1205

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
