### PR TITLE
Return auth errors

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -18,6 +18,11 @@ use crate::{
 
 type BoxedSseStream = BoxStream<'static, Result<Sse, SseError>>;
 
+#[derive(Debug)]
+pub struct AuthRequiredError {
+    pub www_authenticate_header: String,
+}
+
 #[derive(Error, Debug)]
 pub enum StreamableHttpError<E: std::error::Error + Send + Sync + 'static> {
     #[error("SSE error: {0}")]
@@ -48,6 +53,8 @@ pub enum StreamableHttpError<E: std::error::Error + Send + Sync + 'static> {
     #[cfg_attr(docsrs, doc(cfg(feature = "auth")))]
     #[error("Auth error: {0}")]
     Auth(#[from] crate::transport::auth::AuthError),
+    #[error("Auth required")]
+    AuthRequired(AuthRequiredError),
 }
 
 #[derive(Debug, Clone, Error)]
@@ -274,8 +281,7 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
             responder,
             message: initialize_request,
         } = context.recv_from_handler().await?;
-        let _ = responder.send(Ok(()));
-        let (message, session_id) = self
+        let (message, session_id) = match self
             .client
             .post_message(
                 config.uri.clone(),
@@ -284,12 +290,22 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                 self.config.auth_header,
             )
             .await
-            .map_err(WorkerQuitReason::fatal_context("send initialize request"))?
-            .expect_initialized::<C::Error>()
-            .await
-            .map_err(WorkerQuitReason::fatal_context(
-                "process initialize response",
-            ))?;
+        {
+            Ok(res) => {
+                let _ = responder.send(Ok(()));
+                res.expect_initialized::<C::Error>().await.map_err(
+                    WorkerQuitReason::fatal_context("process initialize response"),
+                )?
+            }
+            Err(err) => {
+                let msg = format!("{:?}", err);
+                let _ = responder.send(Err(err));
+                return Err(WorkerQuitReason::fatal(
+                    StreamableHttpError::TransportChannelClosed,
+                    msg,
+                ));
+            }
+        };
         let session_id: Option<Arc<str>> = if let Some(session_id) = session_id {
             Some(session_id.into())
         } else {


### PR DESCRIPTION
When streamable HTTP servers return 401s, surface them to the client.

## Motivation and Context
This is necessary for clients to determine whether oauth is needed.

## How Has This Been Tested?
Tested with https://github.com/block/goose

## Breaking Changes
It adds a new error variant to StreamableHttpError

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
