### PR TITLE
fix(oauth): pass bearer token to all streamable http requests

### DIFF
--- a/crates/rmcp/CHANGELOG.md
+++ b/crates/rmcp/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- *(oauth)* support suffixed and preffixed well-knonw paths ([#459](https://github.com/modelcontextprotocol/rust-sdk/pull/459))
+- *(oauth)* support suffixed and prefixed well-known paths ([#459](https://github.com/modelcontextprotocol/rust-sdk/pull/459))
 - generate default schema for tools with no params ([#446](https://github.com/modelcontextprotocol/rust-sdk/pull/446))
 
 ### Other


### PR DESCRIPTION
## Motivation and Context
The auth token wasn't passed to all endpoints which causes 401s in some MCP servers such as GitHub's.

I also clarified that the auth header should be just the bearer token rather than the full header value.
It is possible that some clients were passing in the wrong value here (like [Codex](https://github.com/openai/codex/pull/4846/files#diff-a5cbb78ce0e77a518a6f71ec9fba1984cfcb81ed6fb43019d1e8672a150d6823L140))
**Please confirm that this is the expected behavior.**


## How Has This Been Tested?
I was able to repro the GitHub MCP 401 and confirm that it works after this change

Codex:
<img width="3724" height="562" alt="CleanShot 2025-10-06 at 17 36 17" src="https://github.com/user-attachments/assets/3d95edec-2e32-460d-a2e8-ed34d28f7bc6" />

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

I wrote the core code by hand (it also matches #464) but codex wrote the tests.

Fixes #464
