### PR TITLE
fix(oauth): rfc8414 should judement the response_types

### DIFF
--- a/examples/servers/src/complex_auth_sse.rs
+++ b/examples/servers/src/complex_auth_sse.rs
@@ -525,7 +525,7 @@ async fn oauth_authorization_server() -> impl IntoResponse {
         authorization_endpoint: format!("http://{}/oauth/authorize", BIND_ADDRESS),
         token_endpoint: format!("http://{}/oauth/token", BIND_ADDRESS),
         scopes_supported: Some(vec!["profile".to_string(), "email".to_string()]),
-        registration_endpoint: format!("http://{}/oauth/register", BIND_ADDRESS),
+        registration_endpoint: Some(format!("http://{}/oauth/register", BIND_ADDRESS)),
         issuer: Some(BIND_ADDRESS.to_string()),
         jwks_uri: Some(format!("http://{}/oauth/jwks", BIND_ADDRESS)),
         additional_fields,


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
According rfc8414, the response_types_supported should be judement


## Motivation and Context
According rfc8414,

## How Has This Been Tested?
No test

## Breaking Changes
The oauth server should be more standardized  and adapt the rfc8414.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
