### PR TITLE
fix(oauth): rfc8414 should judement the response_types

### DIFF
--- a/examples/servers/src/complex_auth_streamhttp.rs
+++ b/examples/servers/src/complex_auth_streamhttp.rs
@@ -529,6 +529,7 @@ async fn oauth_authorization_server() -> impl IntoResponse {
         token_endpoint: format!("http://{}/oauth/token", BIND_ADDRESS),
         scopes_supported: Some(vec!["profile".to_string(), "email".to_string()]),
         registration_endpoint: Some(format!("http://{}/oauth/register", BIND_ADDRESS)),
+        response_types_supported: Some(vec!["code".to_string()]),
         issuer: Some(BIND_ADDRESS.to_string()),
         jwks_uri: Some(format!("http://{}/oauth/jwks", BIND_ADDRESS)),
         additional_fields,


### PR DESCRIPTION
response_types_supported should be judement while try to do 'Authorization Code Flow'

<!-- Provide a brief summary of your changes -->

## Motivation and Context
according to rfc8414

## How Has This Been Tested?
No

## Breaking Changes
auth server should be more standardized.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
