### PR TITLE
Don't treat non-success HTTP codes as transport errors

### DIFF
--- a/crates/rmcp/src/transport/common/reqwest/sse_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/sse_client.rs
@@ -33,7 +33,6 @@ impl SseClient for reqwest::Client {
         request_builder
             .send()
             .await
-            .and_then(|resp| resp.error_for_status())
             .map_err(SseTransportError::from)
             .map(drop)
     }

--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -118,7 +118,6 @@ impl StreamableHttpClient for reqwest::Client {
                 }));
             }
         }
-        let response = response.error_for_status()?;
         if response.status() == reqwest::StatusCode::ACCEPTED {
             return Ok(StreamableHttpPostResponse::Accepted);
         }


### PR DESCRIPTION
The spec states that:

> If the server cannot accept the input, it MUST return an HTTP error
> status code (e.g., 400 Bad Request).
> The HTTP response body MAY comprise a JSON-RPC error response that has no id.

But the rust-sdk treated any POST responses with non successful status as an error.

Before this patch, trying to call list_resources on a server that does return HTTP 400 with JSON-RPC error:

```
TransportSend(
    DynamicTransportError {
        transport_name: "rmcp::transport::worker::WorkerTransport<rmcp::transport::streamable_http_client::StreamableHttpClientWorker<reqwest::async_impl::client::Client>>",
        transport_type_id: TypeId(0xf7bacf3cf3889d471ead32d7a3cc8155),
        error: Client(
            reqwest::Error {
                kind: Status(
                    400,
                    None,
                ),
                url: "http://localhost:4000/mcp",
            },
        ),
    },
)
```

After this patch:

```
McpError(
    ErrorData {
        code: ErrorCode(
            -32601,
        ),
        message: "Method not found",
        data: Some(
            Object {
                "name": String("resources/list"),
            },
        ),
    },
)
```

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Clients should be able to see the error the server sends. The code already checks for JSON content type, I assume the error_for_status for included by accident.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tests still seem to pass, but I did not add a new one. For testing, I created a demo client, but someone with more knowledge of the code should add a proper test case.

```rust
use anyhow::Result;
use rmcp::{
    ServiceExt,
    model::{ClientCapabilities, ClientInfo, Implementation},
    transport::StreamableHttpClientTransport,
};
use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};

#[tokio::main]
async fn main() -> Result<()> {
    tracing_subscriber::registry()
        .with(
            tracing_subscriber::EnvFilter::try_from_default_env()
                .unwrap_or_else(|_| format!("debug,{}=debug", env!("CARGO_CRATE_NAME")).into()),
        )
        .with(tracing_subscriber::fmt::layer())
        .init();

    let transport = StreamableHttpClientTransport::from_uri("http://localhost:4000/mcp");
    let client_info = ClientInfo {
        protocol_version: Default::default(),
        capabilities: ClientCapabilities::default(),
        client_info: Implementation {
            name: "test unknown method client".to_string(),
            title: None,
            version: "0.0.1".to_string(),
            website_url: None,
            icons: None,
        },
    };

    let client = client_info.serve(transport).await.inspect_err(|e| {
        tracing::error!("client error during connection: {:?}", e);
    })?;

    let server_info = client.peer_info();
    tracing::info!("Connected to server: {server_info:#?}");

    tracing::info!("Calling list_resources (which the server doesn't support)...");
    match client.list_resources(Default::default()).await {
        Ok(result) => {
            tracing::info!("Success: {result:#?}");
        }
        Err(e) => {
            tracing::error!("Error calling list_resources: {e:#?}");
        }
    }

    client.cancel().await?;
    Ok(())
}
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

Could be seen as a breaking change if people relied on getting the transport error.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
