### PR TITLE
test: add comprehensive unit tests for model types

### DIFF
--- a/crates/rmcp/src/error.rs
+++ b/crates/rmcp/src/error.rs
@@ -54,3 +54,75 @@ impl RmcpError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+    use crate::model::{ErrorCode, ErrorData};
+
+    #[test]
+    fn test_error_data_display_without_data() {
+        let error = ErrorData {
+            code: ErrorCode(-32600),
+            message: "Invalid Request".into(),
+            data: None,
+        };
+        assert_eq!(format!("{}", error), "-32600: Invalid Request");
+    }
+
+    #[test]
+    fn test_error_data_display_with_data() {
+        let error = ErrorData {
+            code: ErrorCode(-32600),
+            message: "Invalid Request".into(),
+            data: Some(serde_json::json!({"detail": "missing field"})),
+        };
+        assert_eq!(
+            format!("{}", error),
+            "-32600: Invalid Request({\"detail\":\"missing field\"})"
+        );
+    }
+
+    #[test]
+    fn test_rmcp_error_transport_creation() {
+        struct DummyTransport;
+        let io_error = io::Error::other("connection failed");
+        let error = RmcpError::transport_creation::<DummyTransport>(io_error);
+
+        match error {
+            RmcpError::TransportCreation {
+                into_transport_type_name,
+                into_transport_type_id,
+                ..
+            } => {
+                assert!(into_transport_type_name.contains("DummyTransport"));
+                assert_eq!(
+                    into_transport_type_id,
+                    std::any::TypeId::of::<DummyTransport>()
+                );
+            }
+            _ => panic!("Expected TransportCreation variant"),
+        }
+    }
+
+    #[test]
+    fn test_rmcp_error_display() {
+        struct DummyTransport;
+        let io_error = io::Error::other("connection failed");
+        let error = RmcpError::transport_creation::<DummyTransport>(io_error);
+        let display = format!("{}", error);
+        assert!(display.contains("Transport creation error"));
+    }
+
+    #[test]
+    fn test_error_data_is_std_error() {
+        let error = ErrorData {
+            code: ErrorCode(-32600),
+            message: "Invalid Request".into(),
+            data: None,
+        };
+        let _: &dyn std::error::Error = &error;
+    }
+}

--- a/crates/rmcp/src/model/capabilities.rs
+++ b/crates/rmcp/src/model/capabilities.rs
@@ -343,4 +343,137 @@ mod test {
             })
         );
     }
+
+    #[test]
+    fn test_prompts_capability_default() {
+        let cap = PromptsCapability::default();
+        assert_eq!(cap.list_changed, None);
+    }
+
+    #[test]
+    fn test_resources_capability_default() {
+        let cap = ResourcesCapability::default();
+        assert_eq!(cap.subscribe, None);
+        assert_eq!(cap.list_changed, None);
+    }
+
+    #[test]
+    fn test_tools_capability_default() {
+        let cap = ToolsCapability::default();
+        assert_eq!(cap.list_changed, None);
+    }
+
+    #[test]
+    fn test_roots_capabilities_default() {
+        let cap = RootsCapabilities::default();
+        assert_eq!(cap.list_changed, None);
+    }
+
+    #[test]
+    fn test_elicitation_capability_default() {
+        let cap = ElicitationCapability::default();
+        assert_eq!(cap.schema_validation, None);
+    }
+
+    #[test]
+    fn test_server_capabilities_builder_build() {
+        let builder = ServerCapabilities::builder()
+            .enable_logging()
+            .enable_prompts();
+        let caps: ServerCapabilities = builder.build();
+        assert!(caps.logging.is_some());
+        assert!(caps.prompts.is_some());
+    }
+
+    #[test]
+    fn test_server_capabilities_prompts_list_changed() {
+        let caps = ServerCapabilities::builder()
+            .enable_prompts()
+            .enable_prompts_list_changed()
+            .build();
+        assert_eq!(caps.prompts.as_ref().unwrap().list_changed, Some(true));
+    }
+
+    #[test]
+    fn test_server_capabilities_resources_list_changed() {
+        let caps = ServerCapabilities::builder()
+            .enable_resources()
+            .enable_resources_list_changed()
+            .build();
+        assert_eq!(caps.resources.as_ref().unwrap().list_changed, Some(true));
+    }
+
+    #[test]
+    fn test_server_capabilities_resources_subscribe() {
+        let caps = ServerCapabilities::builder()
+            .enable_resources()
+            .enable_resources_subscribe()
+            .build();
+        assert_eq!(caps.resources.as_ref().unwrap().subscribe, Some(true));
+    }
+
+    #[test]
+    fn test_server_capabilities_completions() {
+        let caps = ServerCapabilities::builder().enable_completions().build();
+        assert!(caps.completions.is_some());
+    }
+
+    #[test]
+    fn test_client_capabilities_default() {
+        let caps = ClientCapabilities::default();
+        assert_eq!(caps.experimental, None);
+        assert_eq!(caps.roots, None);
+        assert_eq!(caps.sampling, None);
+    }
+
+    #[test]
+    fn test_client_capabilities_builder_from() {
+        let builder = ClientCapabilities::builder().enable_experimental();
+        let caps: ClientCapabilities = builder.into();
+        assert!(caps.experimental.is_some());
+    }
+
+    #[test]
+    fn test_server_capabilities_enable_with() {
+        let mut exp_caps = ExperimentalCapabilities::default();
+        exp_caps.insert("feature1".to_string(), JsonObject::default());
+
+        let caps = ServerCapabilities::builder()
+            .enable_experimental_with(exp_caps.clone())
+            .build();
+        assert_eq!(caps.experimental, Some(exp_caps));
+    }
+
+    #[test]
+    fn test_client_capabilities_elicitation() {
+        let caps = ClientCapabilities::builder().enable_elicitation().build();
+        assert!(caps.elicitation.is_some());
+    }
+
+    #[test]
+    #[cfg(feature = "elicitation")]
+    fn test_client_capabilities_elicitation_schema_validation() {
+        let caps = ClientCapabilities::builder()
+            .enable_elicitation()
+            .enable_elicitation_schema_validation()
+            .build();
+        assert_eq!(
+            caps.elicitation.as_ref().unwrap().schema_validation,
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn test_server_capabilities_clone() {
+        let caps1 = ServerCapabilities::builder().enable_logging().build();
+        let caps2 = caps1.clone();
+        assert_eq!(caps1, caps2);
+    }
+
+    #[test]
+    fn test_client_capabilities_clone() {
+        let caps1 = ClientCapabilities::builder().enable_roots().build();
+        let caps2 = caps1.clone();
+        assert_eq!(caps1, caps2);
+    }
 }

--- a/crates/rmcp/src/model/meta.rs
+++ b/crates/rmcp/src/model/meta.rs
@@ -186,3 +186,162 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_meta_new() {
+        let meta = Meta::new();
+        assert!(meta.0.is_empty());
+    }
+
+    #[test]
+    fn test_meta_default() {
+        let meta = Meta::default();
+        assert!(meta.0.is_empty());
+    }
+
+    #[test]
+    fn test_meta_static_empty() {
+        let meta = Meta::static_empty();
+        assert!(meta.0.is_empty());
+    }
+
+    #[test]
+    fn test_meta_set_and_get_progress_token_string() {
+        let mut meta = Meta::new();
+        let token = ProgressToken(NumberOrString::String("token123".into()));
+        meta.set_progress_token(token.clone());
+        assert_eq!(meta.get_progress_token(), Some(token));
+    }
+
+    #[test]
+    fn test_meta_set_and_get_progress_token_number() {
+        let mut meta = Meta::new();
+        let token = ProgressToken(NumberOrString::Number(42));
+        meta.set_progress_token(token.clone());
+        assert_eq!(meta.get_progress_token(), Some(token));
+    }
+
+    #[test]
+    fn test_meta_get_progress_token_none() {
+        let meta = Meta::new();
+        assert_eq!(meta.get_progress_token(), None);
+    }
+
+    #[test]
+    fn test_meta_extend() {
+        let mut meta1 = Meta::new();
+        meta1
+            .0
+            .insert("key1".to_string(), Value::String("value1".to_string()));
+
+        let mut meta2 = Meta::new();
+        meta2
+            .0
+            .insert("key2".to_string(), Value::String("value2".to_string()));
+
+        meta1.extend(meta2);
+        assert_eq!(meta1.0.len(), 2);
+        assert_eq!(
+            meta1.0.get("key1"),
+            Some(&Value::String("value1".to_string()))
+        );
+        assert_eq!(
+            meta1.0.get("key2"),
+            Some(&Value::String("value2".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_meta_deref() {
+        let mut meta = Meta::new();
+        meta.0
+            .insert("key".to_string(), Value::String("value".to_string()));
+        assert_eq!(meta.get("key"), Some(&Value::String("value".to_string())));
+    }
+
+    #[test]
+    fn test_meta_deref_mut() {
+        let mut meta = Meta::new();
+        meta.insert("key".to_string(), Value::String("value".to_string()));
+        assert_eq!(meta.0.get("key"), Some(&Value::String("value".to_string())));
+    }
+
+    #[test]
+    fn test_meta_clone() {
+        let mut meta = Meta::new();
+        meta.0
+            .insert("key".to_string(), Value::String("value".to_string()));
+        let cloned = meta.clone();
+        assert_eq!(cloned.0, meta.0);
+    }
+
+    #[test]
+    fn test_meta_partial_eq() {
+        let mut meta1 = Meta::new();
+        meta1
+            .0
+            .insert("key".to_string(), Value::String("value".to_string()));
+        let mut meta2 = Meta::new();
+        meta2
+            .0
+            .insert("key".to_string(), Value::String("value".to_string()));
+        assert_eq!(meta1, meta2);
+    }
+
+    #[test]
+    fn test_progress_token_string_variant() {
+        let token = ProgressToken(NumberOrString::String("test".into()));
+        let mut meta = Meta::new();
+        meta.set_progress_token(token.clone());
+        assert_eq!(meta.get_progress_token(), Some(token));
+    }
+
+    #[test]
+    fn test_progress_token_number_variant() {
+        let token = ProgressToken(NumberOrString::Number(100));
+        let mut meta = Meta::new();
+        meta.set_progress_token(token.clone());
+        assert_eq!(meta.get_progress_token(), Some(token));
+    }
+
+    #[test]
+    fn test_meta_extend_overwrites() {
+        let mut meta1 = Meta::new();
+        meta1
+            .0
+            .insert("key".to_string(), Value::String("value1".to_string()));
+
+        let mut meta2 = Meta::new();
+        meta2
+            .0
+            .insert("key".to_string(), Value::String("value2".to_string()));
+
+        meta1.extend(meta2);
+        assert_eq!(
+            meta1.0.get("key"),
+            Some(&Value::String("value2".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_meta_with_multiple_fields() {
+        let mut meta = Meta::new();
+        meta.0
+            .insert("field1".to_string(), Value::String("value1".to_string()));
+        meta.0
+            .insert("field2".to_string(), Value::Number(42.into()));
+        meta.0.insert("field3".to_string(), Value::Bool(true));
+
+        assert_eq!(meta.0.len(), 3);
+        assert_eq!(
+            meta.0.get("field1"),
+            Some(&Value::String("value1".to_string()))
+        );
+        assert_eq!(meta.0.get("field2"), Some(&Value::Number(42.into())));
+        assert_eq!(meta.0.get("field3"), Some(&Value::Bool(true)));
+    }
+}

--- a/crates/rmcp/src/model/resource.rs
+++ b/crates/rmcp/src/model/resource.rs
@@ -141,4 +141,283 @@ mod tests {
         assert!(json.contains("mimeType"));
         assert!(!json.contains("mime_type"));
     }
+
+    #[test]
+    fn test_raw_resource_new() {
+        let resource = RawResource::new("file:///test.txt", "test");
+        assert_eq!(resource.uri, "file:///test.txt");
+        assert_eq!(resource.name, "test");
+        assert_eq!(resource.title, None);
+        assert_eq!(resource.description, None);
+        assert_eq!(resource.mime_type, None);
+        assert_eq!(resource.size, None);
+    }
+
+    #[test]
+    fn test_resource_contents_text() {
+        let contents = ResourceContents::text("Hello", "file:///test.txt");
+        match contents {
+            ResourceContents::TextResourceContents {
+                text,
+                uri,
+                mime_type,
+                ..
+            } => {
+                assert_eq!(text, "Hello");
+                assert_eq!(uri, "file:///test.txt");
+                assert_eq!(mime_type, Some("text".to_string()));
+            }
+            _ => panic!("Expected TextResourceContents"),
+        }
+    }
+
+    #[test]
+    fn test_resource_contents_blob() {
+        let blob_contents = ResourceContents::BlobResourceContents {
+            uri: "file:///binary.dat".to_string(),
+            mime_type: Some("application/octet-stream".to_string()),
+            blob: "base64data".to_string(),
+            meta: None,
+        };
+        let json = serde_json::to_string(&blob_contents).unwrap();
+        assert!(json.contains("blob"));
+        assert!(json.contains("mimeType"));
+    }
+
+    #[test]
+    fn test_resource_template() {
+        let template = RawResourceTemplate {
+            uri_template: "file:///{path}".to_string(),
+            name: "template".to_string(),
+            title: Some("Template".to_string()),
+            description: Some("A template".to_string()),
+            mime_type: Some("text/plain".to_string()),
+        };
+        let json = serde_json::to_string(&template).unwrap();
+        assert!(json.contains("uriTemplate"));
+    }
+
+    #[test]
+    fn test_resource_with_size() {
+        let resource = RawResource {
+            uri: "file:///large.txt".to_string(),
+            name: "large".to_string(),
+            title: None,
+            description: None,
+            mime_type: None,
+            size: Some(1024),
+            icons: None,
+        };
+        assert_eq!(resource.size, Some(1024));
+    }
+
+    #[test]
+    fn test_resource_clone() {
+        let resource1 = RawResource::new("file:///test.txt", "test");
+        let resource2 = resource1.clone();
+        assert_eq!(resource1, resource2);
+    }
+
+    #[test]
+    fn test_resource_contents_with_meta() {
+        let mut meta = Meta::new();
+        meta.insert("key".to_string(), serde_json::json!("value"));
+
+        let contents = ResourceContents::TextResourceContents {
+            uri: "file:///test.txt".to_string(),
+            mime_type: Some("text/plain".to_string()),
+            text: "content".to_string(),
+            meta: Some(meta),
+        };
+
+        let json = serde_json::to_value(&contents).unwrap();
+        assert_eq!(json["_meta"]["key"], "value");
+    }
+
+    #[test]
+    fn test_raw_resource_with_all_fields() {
+        let icon = Icon {
+            src: "icon.png".to_string(),
+            mime_type: Some("image/png".to_string()),
+            sizes: None,
+        };
+        let resource = RawResource {
+            uri: "file:///test.txt".to_string(),
+            name: "test".to_string(),
+            title: Some("Test Resource".to_string()),
+            description: Some("A test resource".to_string()),
+            mime_type: Some("text/plain".to_string()),
+            size: Some(100),
+            icons: Some(vec![icon]),
+        };
+        assert_eq!(resource.uri, "file:///test.txt");
+        assert_eq!(resource.title, Some("Test Resource".to_string()));
+        assert_eq!(resource.size, Some(100));
+        assert_eq!(resource.icons.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_raw_resource_template_serialization() {
+        let template = RawResourceTemplate {
+            uri_template: "file:///{path}".to_string(),
+            name: "template".to_string(),
+            title: None,
+            description: None,
+            mime_type: None,
+        };
+        let json = serde_json::to_string(&template).unwrap();
+        assert!(json.contains("uriTemplate"));
+        assert!(json.contains("template"));
+    }
+
+    #[test]
+    fn test_raw_resource_template_with_all_fields() {
+        let template = RawResourceTemplate {
+            uri_template: "file:///{path}".to_string(),
+            name: "template".to_string(),
+            title: Some("Template".to_string()),
+            description: Some("A template".to_string()),
+            mime_type: Some("text/plain".to_string()),
+        };
+        assert_eq!(template.title, Some("Template".to_string()));
+        assert_eq!(template.description, Some("A template".to_string()));
+    }
+
+    #[test]
+    fn test_resource_contents_text_with_none_mime() {
+        let contents = ResourceContents::TextResourceContents {
+            uri: "file:///test.txt".to_string(),
+            mime_type: None,
+            text: "content".to_string(),
+            meta: None,
+        };
+        match contents {
+            ResourceContents::TextResourceContents { mime_type, .. } => {
+                assert_eq!(mime_type, None);
+            }
+            _ => panic!("Expected TextResourceContents"),
+        }
+    }
+
+    #[test]
+    fn test_resource_contents_blob_with_meta() {
+        let mut meta = Meta::new();
+        meta.insert("key".to_string(), serde_json::json!("value"));
+
+        let contents = ResourceContents::BlobResourceContents {
+            uri: "file:///binary.dat".to_string(),
+            mime_type: Some("application/octet-stream".to_string()),
+            blob: "blobdata".to_string(),
+            meta: Some(meta),
+        };
+
+        let json = serde_json::to_value(&contents).unwrap();
+        assert_eq!(json["_meta"]["key"], "value");
+    }
+
+    #[test]
+    fn test_resource_with_different_uris() {
+        let file_resource = RawResource::new("file:///path/to/file.txt", "file");
+        let http_resource = RawResource::new("http://example.com/resource", "http");
+        let custom_resource = RawResource::new("custom://resource/id", "custom");
+
+        assert_eq!(file_resource.uri, "file:///path/to/file.txt");
+        assert_eq!(http_resource.uri, "http://example.com/resource");
+        assert_eq!(custom_resource.uri, "custom://resource/id");
+    }
+
+    #[test]
+    fn test_resource_size_affects_equality() {
+        let resource1 = RawResource {
+            uri: "file:///test.txt".to_string(),
+            name: "test".to_string(),
+            title: None,
+            description: None,
+            mime_type: None,
+            size: Some(100),
+            icons: None,
+        };
+
+        let resource2 = RawResource {
+            uri: "file:///test.txt".to_string(),
+            name: "test".to_string(),
+            title: None,
+            description: None,
+            mime_type: None,
+            size: Some(200),
+            icons: None,
+        };
+
+        assert_ne!(resource1, resource2);
+    }
+
+    #[test]
+    fn test_resource_contents_text_sets_mime_type() {
+        let contents = ResourceContents::text("content", "file:///test.txt");
+        match contents {
+            ResourceContents::TextResourceContents { mime_type, .. } => {
+                assert_eq!(mime_type, Some("text".to_string()));
+            }
+            _ => panic!("Expected TextResourceContents"),
+        }
+    }
+
+    #[test]
+    fn test_resource_template_with_variable_substitution_pattern() {
+        let template = RawResourceTemplate {
+            uri_template: "file:///{user}/documents/{filename}".to_string(),
+            name: "user_document".to_string(),
+            title: Some("User Document".to_string()),
+            description: Some("Access user documents by name".to_string()),
+            mime_type: None,
+        };
+
+        assert!(template.uri_template.contains("{user}"));
+        assert!(template.uri_template.contains("{filename}"));
+    }
+
+    #[test]
+    fn test_resource_deserialization() {
+        let json = r#"{
+            "uri": "file:///test.txt",
+            "name": "test",
+            "mimeType": "text/plain"
+        }"#;
+        let resource: RawResource = serde_json::from_str(json).unwrap();
+        assert_eq!(resource.uri, "file:///test.txt");
+        assert_eq!(resource.name, "test");
+        assert_eq!(resource.mime_type, Some("text/plain".to_string()));
+    }
+
+    #[test]
+    fn test_resource_contents_deserialization_text() {
+        let json = r#"{
+            "uri": "file:///test.txt",
+            "text": "content",
+            "mimeType": "text/plain"
+        }"#;
+        let contents: ResourceContents = serde_json::from_str(json).unwrap();
+        match contents {
+            ResourceContents::TextResourceContents { text, .. } => {
+                assert_eq!(text, "content");
+            }
+            _ => panic!("Expected TextResourceContents"),
+        }
+    }
+
+    #[test]
+    fn test_resource_contents_deserialization_blob() {
+        let json = r#"{
+            "uri": "file:///binary.dat",
+            "blob": "blobdata",
+            "mimeType": "application/octet-stream"
+        }"#;
+        let contents: ResourceContents = serde_json::from_str(json).unwrap();
+        match contents {
+            ResourceContents::BlobResourceContents { blob, .. } => {
+                assert_eq!(blob, "blobdata");
+            }
+            _ => panic!("Expected BlobResourceContents"),
+        }
+    }
 }

--- a/crates/rmcp/src/model/tool.rs
+++ b/crates/rmcp/src/model/tool.rs
@@ -177,3 +177,355 @@ impl Tool {
         Value::Object(self.input_schema.as_ref().clone())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_tool_annotations_new() {
+        let annotations = ToolAnnotations::new();
+        assert_eq!(annotations.title, None);
+        assert_eq!(annotations.read_only_hint, None);
+        assert_eq!(annotations.destructive_hint, None);
+        assert_eq!(annotations.idempotent_hint, None);
+        assert_eq!(annotations.open_world_hint, None);
+    }
+
+    #[test]
+    fn test_tool_annotations_with_title() {
+        let annotations = ToolAnnotations::with_title("Test Tool");
+        assert_eq!(annotations.title, Some("Test Tool".to_string()));
+    }
+
+    #[test]
+    fn test_tool_annotations_read_only() {
+        let annotations = ToolAnnotations::new().read_only(true);
+        assert_eq!(annotations.read_only_hint, Some(true));
+    }
+
+    #[test]
+    fn test_tool_annotations_destructive() {
+        let annotations = ToolAnnotations::new().destructive(false);
+        assert_eq!(annotations.destructive_hint, Some(false));
+    }
+
+    #[test]
+    fn test_tool_annotations_idempotent() {
+        let annotations = ToolAnnotations::new().idempotent(true);
+        assert_eq!(annotations.idempotent_hint, Some(true));
+    }
+
+    #[test]
+    fn test_tool_annotations_open_world() {
+        let annotations = ToolAnnotations::new().open_world(false);
+        assert_eq!(annotations.open_world_hint, Some(false));
+    }
+
+    #[test]
+    fn test_tool_annotations_is_destructive_default() {
+        let annotations = ToolAnnotations::new();
+        assert!(annotations.is_destructive());
+    }
+
+    #[test]
+    fn test_tool_annotations_is_destructive_explicit() {
+        let annotations = ToolAnnotations::new().destructive(false);
+        assert!(!annotations.is_destructive());
+    }
+
+    #[test]
+    fn test_tool_annotations_is_idempotent_default() {
+        let annotations = ToolAnnotations::new();
+        assert!(!annotations.is_idempotent());
+    }
+
+    #[test]
+    fn test_tool_annotations_is_idempotent_explicit() {
+        let annotations = ToolAnnotations::new().idempotent(true);
+        assert!(annotations.is_idempotent());
+    }
+
+    #[test]
+    fn test_tool_annotations_chaining() {
+        let annotations = ToolAnnotations::with_title("Test")
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(false);
+
+        assert_eq!(annotations.title, Some("Test".to_string()));
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.destructive_hint, Some(false));
+        assert_eq!(annotations.idempotent_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
+    }
+
+    #[test]
+    fn test_tool_new() {
+        let schema = Arc::new(json!({"type": "object"}).as_object().unwrap().clone());
+        let tool = Tool::new("test_tool", "A test tool", schema);
+
+        assert_eq!(tool.name, "test_tool");
+        assert_eq!(tool.description, Some(Cow::Borrowed("A test tool")));
+        assert_eq!(tool.title, None);
+        assert_eq!(tool.annotations, None);
+        assert_eq!(tool.icons, None);
+    }
+
+    #[test]
+    fn test_tool_annotate() {
+        let schema = Arc::new(json!({"type": "object"}).as_object().unwrap().clone());
+        let tool = Tool::new("test_tool", "desc", schema);
+        let annotations = ToolAnnotations::with_title("Test Title");
+        let annotated_tool = tool.annotate(annotations);
+
+        assert!(annotated_tool.annotations.is_some());
+        assert_eq!(
+            annotated_tool.annotations.unwrap().title,
+            Some("Test Title".to_string())
+        );
+    }
+
+    #[test]
+    fn test_tool_schema_as_json_value() {
+        let schema_obj = json!({"type": "object", "properties": {}})
+            .as_object()
+            .unwrap()
+            .clone();
+        let schema = Arc::new(schema_obj);
+        let tool = Tool::new("test_tool", "desc", schema);
+
+        let json_value = tool.schema_as_json_value();
+        assert!(json_value.is_object());
+        assert_eq!(json_value["type"], "object");
+    }
+
+    #[test]
+    fn test_tool_annotations_default() {
+        let annotations = ToolAnnotations::default();
+        assert_eq!(annotations.title, None);
+        assert_eq!(annotations.read_only_hint, None);
+    }
+
+    #[test]
+    fn test_tool_with_title() {
+        let schema = Arc::new(json!({"type": "object"}).as_object().unwrap().clone());
+        let tool = Tool {
+            name: "test_tool".into(),
+            title: Some("Test Tool".to_string()),
+            description: Some("desc".into()),
+            input_schema: schema,
+            output_schema: None,
+            annotations: None,
+            icons: None,
+        };
+        assert_eq!(tool.title, Some("Test Tool".to_string()));
+    }
+
+    #[test]
+    fn test_tool_with_icons() {
+        let schema = Arc::new(json!({"type": "object"}).as_object().unwrap().clone());
+        let icon = Icon {
+            src: "icon.png".to_string(),
+            mime_type: Some("image/png".to_string()),
+            sizes: None,
+        };
+        let tool = Tool {
+            name: "test_tool".into(),
+            title: None,
+            description: Some("desc".into()),
+            input_schema: schema,
+            output_schema: None,
+            annotations: None,
+            icons: Some(vec![icon]),
+        };
+        assert_eq!(tool.icons.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_tool_with_output_schema() {
+        let schema = Arc::new(json!({"type": "object"}).as_object().unwrap().clone());
+        let output_schema = Arc::new(json!({"type": "string"}).as_object().unwrap().clone());
+        let tool = Tool {
+            name: "test_tool".into(),
+            title: None,
+            description: Some("desc".into()),
+            input_schema: schema,
+            output_schema: Some(output_schema.clone()),
+            annotations: None,
+            icons: None,
+        };
+        assert!(tool.output_schema.is_some());
+    }
+
+    #[test]
+    fn test_tool_with_different_schemas_not_equal() {
+        let schema1 = Arc::new(
+            json!({"type": "object", "properties": {"a": {"type": "string"}}})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+        let schema2 = Arc::new(
+            json!({"type": "object", "properties": {"b": {"type": "number"}}})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+
+        let tool1 = Tool::new("test_tool", "desc", schema1);
+        let tool2 = Tool::new("test_tool", "desc", schema2);
+
+        assert_ne!(tool1, tool2);
+    }
+
+    #[test]
+    fn test_tool_annotations_with_all_hints() {
+        let annotations = ToolAnnotations::new()
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(false);
+
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.destructive_hint, Some(false));
+        assert_eq!(annotations.idempotent_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
+    }
+
+    #[test]
+    fn test_tool_annotations_destructive_defaults_to_true() {
+        let annotations1 = ToolAnnotations::new();
+        let annotations2 = ToolAnnotations::new().destructive(true);
+
+        assert!(annotations1.is_destructive());
+        assert!(annotations2.is_destructive());
+    }
+
+    #[test]
+    fn test_tool_annotations_idempotent_defaults_to_false() {
+        let annotations1 = ToolAnnotations::new();
+        let annotations2 = ToolAnnotations::new().idempotent(false);
+
+        assert!(!annotations1.is_idempotent());
+        assert!(!annotations2.is_idempotent());
+    }
+
+    #[test]
+    fn test_tool_annotations_contradictory_hints() {
+        // A tool can be both read-only and destructive (contradictory but allowed)
+        let annotations = ToolAnnotations::new().read_only(true).destructive(true);
+
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.destructive_hint, Some(true));
+    }
+
+    #[test]
+    fn test_tool_serialization() {
+        let schema = Arc::new(
+            json!({"type": "object", "properties": {}})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+        let tool = Tool::new("test_tool", "A test tool", schema);
+        let json = serde_json::to_string(&tool).unwrap();
+        assert!(json.contains("test_tool"));
+        assert!(json.contains("A test tool"));
+    }
+
+    #[test]
+    fn test_tool_deserialization() {
+        let json = r#"{
+            "name": "test_tool",
+            "description": "A test tool",
+            "inputSchema": {"type": "object"}
+        }"#;
+        let tool: Tool = serde_json::from_str(json).unwrap();
+        assert_eq!(tool.name, "test_tool");
+        assert_eq!(tool.description, Some(Cow::Borrowed("A test tool")));
+    }
+
+    #[test]
+    fn test_tool_with_annotations_serialization() {
+        let schema = Arc::new(json!({"type": "object"}).as_object().unwrap().clone());
+        let tool =
+            Tool::new("test_tool", "desc", schema).annotate(ToolAnnotations::new().read_only(true));
+        let json = serde_json::to_value(&tool).unwrap();
+        assert_eq!(json["annotations"]["readOnlyHint"], true);
+    }
+
+    #[test]
+    fn test_tool_annotations_serialization() {
+        let annotations = ToolAnnotations::with_title("Test")
+            .read_only(true)
+            .destructive(false);
+        let json = serde_json::to_string(&annotations).unwrap();
+        assert!(json.contains("Test"));
+        assert!(json.contains("readOnlyHint"));
+    }
+
+    #[test]
+    fn test_tool_name_cow_borrowed() {
+        let schema = Arc::new(json!({"type": "object"}).as_object().unwrap().clone());
+        let tool = Tool::new("static_name", "desc", schema);
+        assert_eq!(tool.name, "static_name");
+    }
+
+    #[test]
+    fn test_tool_name_cow_owned() {
+        let schema = Arc::new(json!({"type": "object"}).as_object().unwrap().clone());
+        let name = String::from("dynamic_name");
+        let tool = Tool::new(name, "desc", schema);
+        assert_eq!(tool.name, "dynamic_name");
+    }
+
+    #[test]
+    fn test_tool_annotations_is_idempotent_when_destructive() {
+        let annotations = ToolAnnotations::new().destructive(true).idempotent(false);
+        assert!(!annotations.is_idempotent());
+    }
+
+    #[test]
+    fn test_tool_schema_as_json_value_complex() {
+        let schema_obj = json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "number"}
+            },
+            "required": ["name"]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let schema = Arc::new(schema_obj);
+        let tool = Tool::new("test_tool", "desc", schema);
+
+        let json_value = tool.schema_as_json_value();
+        assert_eq!(json_value["type"], "object");
+        assert!(json_value["properties"]["name"].is_object());
+        assert!(json_value["required"].is_array());
+    }
+
+    #[test]
+    fn test_tool_annotations_different_titles_not_equal() {
+        let annotations1 = ToolAnnotations::with_title("Title1");
+        let annotations2 = ToolAnnotations::with_title("Title2");
+        assert_ne!(annotations1, annotations2);
+    }
+
+    #[test]
+    fn test_tool_without_annotations_vs_with_annotations() {
+        let schema = Arc::new(json!({"type": "object"}).as_object().unwrap().clone());
+        let tool_without = Tool::new("test_tool", "desc", schema.clone());
+        let tool_with = Tool::new("test_tool", "desc", schema).annotate(ToolAnnotations::new());
+
+        assert!(tool_without.annotations.is_none());
+        assert!(tool_with.annotations.is_some());
+        assert_ne!(tool_without, tool_with);
+    }
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add 112+ non-async unit tests across model modules to increase coverage:
- content.rs: 34 tests for RawContent variants, type discrimination, meta preservation
- prompt.rs: 24 tests for Prompt, PromptArgument, role handling, meta behavior
- resource.rs: 21 tests for Resource, ResourceTemplate, URI schemes, equality
- tool.rs: 33 tests for Tool, ToolAnnotations, schema handling, default behaviors

## Motivation and Context
Better coverage.

## How Has This Been Tested?
Yes. All unit tests pass.

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
