### PR TITLE
fix(initialization): accept 204 in addition to 202 on initialize

### DIFF
--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -118,8 +118,12 @@ impl StreamableHttpClient for reqwest::Client {
                 }));
             }
         }
+        let status = response.status();
         let response = response.error_for_status()?;
-        if response.status() == reqwest::StatusCode::ACCEPTED {
+        if matches!(
+            status,
+            reqwest::StatusCode::ACCEPTED | reqwest::StatusCode::NO_CONTENT
+        ) {
             return Ok(StreamableHttpPostResponse::Accepted);
         }
         let content_type = response.headers().get(reqwest::header::CONTENT_TYPE);


### PR DESCRIPTION
## Motivation and Context
Most MCP servers return a 202 in response to `notifications/initialized`. However, it seams like some such as the allflow server from https://github.com/openai/codex/issues/5208 return a 204. Other clients such as claude code and `npx @modelcontextprotocol/inspector` accept 204 so it seems reasonable to do so here.

The [spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization) is ambiguous here from what I can tell. I don't see it explicitly mention that the notification response must be a 202.

## How Has This Been Tested?
Test the failing server from https://github.com/openai/codex/issues/5208. It now works.
<img width="5026" height="304" alt="CleanShot 2025-10-22 at 11 42 03" src="https://github.com/user-attachments/assets/8eb7c393-e182-4785-8b24-d6999d136f6e" />


## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
