### PR TITLE
Add _meta to tool definitions

### DIFF
--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -77,6 +77,8 @@ pub struct ToolAttribute {
     pub annotations: Option<ToolAnnotationsAttribute>,
     /// Optional icons for the tool
     pub icons: Option<Expr>,
+    /// Optional metadata for the tool
+    pub meta: Option<Expr>,
 }
 
 pub struct ResolvedToolAttribute {
@@ -87,6 +89,7 @@ pub struct ResolvedToolAttribute {
     pub output_schema: Option<Expr>,
     pub annotations: Expr,
     pub icons: Option<Expr>,
+    pub meta: Option<Expr>,
 }
 
 impl ResolvedToolAttribute {
@@ -99,6 +102,7 @@ impl ResolvedToolAttribute {
             output_schema,
             annotations,
             icons,
+            meta,
         } = self;
         let description = if let Some(description) = description {
             quote! { Some(#description.into()) }
@@ -120,6 +124,11 @@ impl ResolvedToolAttribute {
         } else {
             quote! { None }
         };
+        let meta = if let Some(meta) = meta {
+            quote! { Some(#meta) }
+        } else {
+            quote! { None }
+        };
         let doc_comment = format!("Generated tool metadata function for {name}");
         let doc_attr: syn::Attribute = parse_quote!(#[doc = #doc_comment]);
         let tokens = quote! {
@@ -133,6 +142,7 @@ impl ResolvedToolAttribute {
                     output_schema: #output_schema,
                     annotations: #annotations,
                     icons: #icons,
+                    meta: #meta,
                 }
             }
         };
@@ -264,6 +274,7 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
         annotations: annotations_expr,
         title: attribute.title,
         icons: attribute.icons,
+        meta: attribute.meta,
     };
     let tool_attr_fn = resolved_tool_attr.into_fn(tool_attr_fn_ident)?;
     // modify the the input function

--- a/crates/rmcp/src/model/tool.rs
+++ b/crates/rmcp/src/model/tool.rs
@@ -6,7 +6,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::{Icon, JsonObject};
+use super::{Icon, JsonObject, Meta};
 
 /// A tool that can be used by a model.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -32,6 +32,9 @@ pub struct Tool {
     /// Optional list of icons for the tool
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
+    /// Optional additional metadata for this tool
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 /// Additional properties describing a Tool to clients.
@@ -150,6 +153,7 @@ impl Tool {
             output_schema: None,
             annotations: None,
             icons: None,
+            meta: None,
         }
     }
 

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -2292,6 +2292,14 @@
       "description": "A tool that can be used by a model.",
       "type": "object",
       "properties": {
+        "_meta": {
+          "description": "Optional additional metadata for this tool",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "annotations": {
           "description": "Optional additional tool information.",
           "anyOf": [

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -2292,6 +2292,14 @@
       "description": "A tool that can be used by a model.",
       "type": "object",
       "properties": {
+        "_meta": {
+          "description": "Optional additional metadata for this tool",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "annotations": {
           "description": "Optional additional tool information.",
           "anyOf": [

--- a/examples/servers/src/sampling_stdio.rs
+++ b/examples/servers/src/sampling_stdio.rs
@@ -123,6 +123,7 @@ impl ServerHandler for SamplingDemoServer {
                 output_schema: None,
                 annotations: None,
                 icons: None,
+                meta: None,
             }],
             next_cursor: None,
         })


### PR DESCRIPTION
Adds support for [the _meta field](https://modelcontextprotocol.io/specification/2025-06-18/schema#tool) to Tools.

## Motivation and Contex

Closes #505

## How Has This Been Tested?
Set this field in a local MCP server and verified I could see it in mcp inspector.

## Breaking Changes

Anyone who was constructing a Tool like `Tool { fields, here}` will now need to specify the `meta` field as well.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
