### PR TITLE
feat(elicitation) implement SEP-1330 Elicitation Enum Schema Improvements

### DIFF
--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -325,6 +325,11 @@
         }
       }
     },
+    "ArrayTypeConst": {
+      "type": "string",
+      "format": "const",
+      "const": "array"
+    },
     "BooleanSchema": {
       "description": "Schema definition for boolean properties.",
       "type": "object",
@@ -461,6 +466,22 @@
       },
       "required": [
         "values"
+      ]
+    },
+    "ConstTitle": {
+      "description": "Schema definition for enum properties.\n\nRepresent single entry for titled item",
+      "type": "object",
+      "properties": {
+        "const": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "const",
+        "title"
       ]
     },
     "ContextInclusion": {
@@ -724,52 +745,17 @@
       "additionalProperties": false
     },
     "EnumSchema": {
-      "description": "Schema definition for enum properties.\n\nCompliant with MCP 2025-06-18 specification for elicitation schemas.\nEnums must have string type and can optionally include human-readable names.",
-      "type": "object",
-      "properties": {
-        "description": {
-          "description": "Human-readable description",
-          "type": [
-            "string",
-            "null"
-          ]
+      "description": "Compliant with MCP 2025-06-18 specification for elicitation schemas.\nEnums must have string type for values and can optionally include human-readable names.\n\n# Example\n\n```rust\nuse rmcp::model::*;\n\nlet enum_schema = EnumSchema::builder(vec![\"US\".to_string(), \"UK\".to_string()])\n   .multiselect()\n   .min_items(1u64).expect(\"Min items should be correct value\")\n   .max_items(4u64).expect(\"Max items should be correct value\")\n   .description(\"Country code\")\n   .build();\n```",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SingleSelectEnumSchema"
         },
-        "enum": {
-          "description": "Allowed enum values (string values only per MCP spec)",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        {
+          "$ref": "#/definitions/MultiSelectEnumSchema"
         },
-        "enumNames": {
-          "description": "Optional human-readable names for each enum value",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "title": {
-          "description": "Optional title for the schema",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "type": {
-          "description": "Type discriminator (always \"string\" for enums)",
-          "allOf": [
-            {
-              "$ref": "#/definitions/StringTypeConst"
-            }
-          ]
+        {
+          "$ref": "#/definitions/LegacyEnumSchema"
         }
-      },
-      "required": [
-        "type",
-        "enum"
       ]
     },
     "ErrorCode": {
@@ -1109,6 +1095,46 @@
       "format": "const",
       "const": "2.0"
     },
+    "LegacyEnumSchema": {
+      "description": "Legacy enum schema, keep for backward compatibility",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enumNames": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/StringTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "enum"
+      ]
+    },
     "ListPromptsResult": {
       "type": "object",
       "properties": {
@@ -1350,6 +1376,17 @@
         }
       }
     },
+    "MultiSelectEnumSchema": {
+      "description": "Multi-select enum options",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/definitions/TitledMultiSelectEnumSchema"
+        }
+      ]
+    },
     "Notification": {
       "type": "object",
       "properties": {
@@ -1516,8 +1553,16 @@
       "const": "ping"
     },
     "PrimitiveSchema": {
-      "description": "Primitive schema definition for elicitation properties.\n\nAccording to MCP 2025-06-18 specification, elicitation schemas must have\nproperties of primitive types only (string, number, integer, boolean, enum).",
+      "description": "Primitive schema definition for elicitation properties.\n\nAccording to MCP 2025-06-18 specification, elicitation schemas must have\nproperties of primitive types only (string, number, integer, boolean, enum).\n\nNote: Put Enum as the first variant to avoid ambiguity during deserialization.\nThis is due to the fact that EnumSchema can contain StringSchema internally and serde\nuses first match wins strategy when deserializing untagged enums.",
       "anyOf": [
+        {
+          "description": "Enum property (explicit enum schema)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EnumSchema"
+            }
+          ]
+        },
         {
           "description": "String property (with optional enum constraint)",
           "allOf": [
@@ -1547,14 +1592,6 @@
           "allOf": [
             {
               "$ref": "#/definitions/BooleanSchema"
-            }
-          ]
-        },
-        {
-          "description": "Enum property (explicit enum schema)",
-          "allOf": [
-            {
-              "$ref": "#/definitions/EnumSchema"
             }
           ]
         }
@@ -2384,6 +2421,17 @@
         }
       ]
     },
+    "SingleSelectEnumSchema": {
+      "description": "Combined single-select",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/definitions/TitledSingleSelectEnumSchema"
+        }
+      ]
+    },
     "StringFormat": {
       "description": "String format types allowed by the MCP specification.",
       "oneOf": [
@@ -2617,6 +2665,111 @@
         }
       }
     },
+    "TitledItems": {
+      "description": "Items for titled multi-select options",
+      "type": "object",
+      "properties": {
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConstTitle"
+          }
+        }
+      },
+      "required": [
+        "anyOf"
+      ]
+    },
+    "TitledMultiSelectEnumSchema": {
+      "description": "Multi-select titled options",
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "items": {
+          "$ref": "#/definitions/TitledItems"
+        },
+        "maxItems": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/ArrayTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "items"
+      ]
+    },
+    "TitledSingleSelectEnumSchema": {
+      "description": "Titled single-select",
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConstTitle"
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/StringTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "oneOf"
+      ]
+    },
     "Tool": {
       "description": "A tool that can be used by a model.",
       "type": "object",
@@ -2743,6 +2896,115 @@
           ]
         }
       }
+    },
+    "UntitledItems": {
+      "description": "Items for untitled multi-select options",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "$ref": "#/definitions/StringTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "enum"
+      ]
+    },
+    "UntitledMultiSelectEnumSchema": {
+      "description": "Multi-select untitled options",
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "items": {
+          "$ref": "#/definitions/UntitledItems"
+        },
+        "maxItems": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/ArrayTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "items"
+      ]
+    },
+    "UntitledSingleSelectEnumSchema": {
+      "description": "Untitled single-select",
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/StringTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "enum"
+      ]
     }
   }
 }

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -325,6 +325,11 @@
         }
       }
     },
+    "ArrayTypeConst": {
+      "type": "string",
+      "format": "const",
+      "const": "array"
+    },
     "BooleanSchema": {
       "description": "Schema definition for boolean properties.",
       "type": "object",
@@ -461,6 +466,22 @@
       },
       "required": [
         "values"
+      ]
+    },
+    "ConstTitle": {
+      "description": "Schema definition for enum properties.\n\nRepresent single entry for titled item",
+      "type": "object",
+      "properties": {
+        "const": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "const",
+        "title"
       ]
     },
     "ContextInclusion": {
@@ -724,52 +745,17 @@
       "additionalProperties": false
     },
     "EnumSchema": {
-      "description": "Schema definition for enum properties.\n\nCompliant with MCP 2025-06-18 specification for elicitation schemas.\nEnums must have string type and can optionally include human-readable names.",
-      "type": "object",
-      "properties": {
-        "description": {
-          "description": "Human-readable description",
-          "type": [
-            "string",
-            "null"
-          ]
+      "description": "Compliant with MCP 2025-06-18 specification for elicitation schemas.\nEnums must have string type for values and can optionally include human-readable names.\n\n# Example\n\n```rust\nuse rmcp::model::*;\n\nlet enum_schema = EnumSchema::builder(vec![\"US\".to_string(), \"UK\".to_string()])\n   .multiselect()\n   .min_items(1u64).expect(\"Min items should be correct value\")\n   .max_items(4u64).expect(\"Max items should be correct value\")\n   .description(\"Country code\")\n   .build();\n```",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SingleSelectEnumSchema"
         },
-        "enum": {
-          "description": "Allowed enum values (string values only per MCP spec)",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        {
+          "$ref": "#/definitions/MultiSelectEnumSchema"
         },
-        "enumNames": {
-          "description": "Optional human-readable names for each enum value",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "title": {
-          "description": "Optional title for the schema",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "type": {
-          "description": "Type discriminator (always \"string\" for enums)",
-          "allOf": [
-            {
-              "$ref": "#/definitions/StringTypeConst"
-            }
-          ]
+        {
+          "$ref": "#/definitions/LegacyEnumSchema"
         }
-      },
-      "required": [
-        "type",
-        "enum"
       ]
     },
     "ErrorCode": {
@@ -1109,6 +1095,46 @@
       "format": "const",
       "const": "2.0"
     },
+    "LegacyEnumSchema": {
+      "description": "Legacy enum schema, keep for backward compatibility",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enumNames": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/StringTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "enum"
+      ]
+    },
     "ListPromptsResult": {
       "type": "object",
       "properties": {
@@ -1350,6 +1376,17 @@
         }
       }
     },
+    "MultiSelectEnumSchema": {
+      "description": "Multi-select enum options",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/definitions/TitledMultiSelectEnumSchema"
+        }
+      ]
+    },
     "Notification": {
       "type": "object",
       "properties": {
@@ -1516,8 +1553,16 @@
       "const": "ping"
     },
     "PrimitiveSchema": {
-      "description": "Primitive schema definition for elicitation properties.\n\nAccording to MCP 2025-06-18 specification, elicitation schemas must have\nproperties of primitive types only (string, number, integer, boolean, enum).",
+      "description": "Primitive schema definition for elicitation properties.\n\nAccording to MCP 2025-06-18 specification, elicitation schemas must have\nproperties of primitive types only (string, number, integer, boolean, enum).\n\nNote: Put Enum as the first variant to avoid ambiguity during deserialization.\nThis is due to the fact that EnumSchema can contain StringSchema internally and serde\nuses first match wins strategy when deserializing untagged enums.",
       "anyOf": [
+        {
+          "description": "Enum property (explicit enum schema)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EnumSchema"
+            }
+          ]
+        },
         {
           "description": "String property (with optional enum constraint)",
           "allOf": [
@@ -1547,14 +1592,6 @@
           "allOf": [
             {
               "$ref": "#/definitions/BooleanSchema"
-            }
-          ]
-        },
-        {
-          "description": "Enum property (explicit enum schema)",
-          "allOf": [
-            {
-              "$ref": "#/definitions/EnumSchema"
             }
           ]
         }
@@ -2384,6 +2421,17 @@
         }
       ]
     },
+    "SingleSelectEnumSchema": {
+      "description": "Combined single-select",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/definitions/TitledSingleSelectEnumSchema"
+        }
+      ]
+    },
     "StringFormat": {
       "description": "String format types allowed by the MCP specification.",
       "oneOf": [
@@ -2617,6 +2665,111 @@
         }
       }
     },
+    "TitledItems": {
+      "description": "Items for titled multi-select options",
+      "type": "object",
+      "properties": {
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConstTitle"
+          }
+        }
+      },
+      "required": [
+        "anyOf"
+      ]
+    },
+    "TitledMultiSelectEnumSchema": {
+      "description": "Multi-select titled options",
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "items": {
+          "$ref": "#/definitions/TitledItems"
+        },
+        "maxItems": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/ArrayTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "items"
+      ]
+    },
+    "TitledSingleSelectEnumSchema": {
+      "description": "Titled single-select",
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConstTitle"
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/StringTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "oneOf"
+      ]
+    },
     "Tool": {
       "description": "A tool that can be used by a model.",
       "type": "object",
@@ -2743,6 +2896,115 @@
           ]
         }
       }
+    },
+    "UntitledItems": {
+      "description": "Items for untitled multi-select options",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "$ref": "#/definitions/StringTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "enum"
+      ]
+    },
+    "UntitledMultiSelectEnumSchema": {
+      "description": "Multi-select untitled options",
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "items": {
+          "$ref": "#/definitions/UntitledItems"
+        },
+        "maxItems": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/ArrayTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "items"
+      ]
+    },
+    "UntitledSingleSelectEnumSchema": {
+      "description": "Untitled single-select",
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/StringTypeConst"
+        }
+      },
+      "required": [
+        "type",
+        "enum"
+      ]
     }
   }
 }

--- a/examples/servers/Cargo.toml
+++ b/examples/servers/Cargo.toml
@@ -105,3 +105,7 @@ path = "src/cimd_auth_streamhttp.rs"
 [[example]]
 name = "servers_calculator_stdio"
 path = "src/calculator_stdio.rs"
+
+[[example]]
+name = "elicitation_enum_select"
+path = "src/elicitation_enum_inference.rs"

--- a/examples/servers/README.md
+++ b/examples/servers/README.md
@@ -45,6 +45,13 @@ A working MCP server demonstrating elicitation for user name collection.
 - JSON Schema validation with schemars
 - Tools: `greet_user` (collects name), `reset_name` (clears stored name)
 
+### Elicitation with Enum Inference config (`elicitation_enum_inference.rs`)
+
+A demonstration of elicitation using enum inference configuration for MCP server.
+- Runs on HTTP with streaming capabilities
+- Uses schemars for elicitation schema generation
+- Shows how to configure enum inference for elicitation prompts
+
 ### Prompt Standard I/O Server (`prompt_stdio.rs`)
 
 A server demonstrating the prompt framework capabilities.

--- a/examples/servers/src/elicitation_enum_inference.rs
+++ b/examples/servers/src/elicitation_enum_inference.rs
@@ -1,0 +1,189 @@
+//! Demonstration how to use enum selection in elicitation forms.
+//!
+//! This example server allows users to select enum values via elicitation forms.
+//! To work with enum inference, it is required to use specific `schemars` attributes and apply some workarounds:
+//! - Use `#[schemars(inline)]` to ensure the enum is inlined in the schema.
+//! - Use `#[schemars(extend("type" = "string"))]` to manually add the required type field, since `schemars` does not provide it for enums.
+//! - Optionally, use `#[schemars(title = "...")]` to provide titles for enum variants.
+//! For more details, see: https://docs.rs/schemars/latest/schemars/
+use std::{
+    fmt::{Display, Formatter},
+    sync::Arc,
+};
+
+use rmcp::{
+    ErrorData as McpError, ServerHandler, elicit_safe,
+    handler::server::router::tool::ToolRouter,
+    model::*,
+    service::{RequestContext, RoleServer},
+    tool, tool_handler, tool_router,
+    transport::{
+        StreamableHttpService, streamable_http_server::session::local::LocalSessionManager,
+    },
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+const BIND_ADDRESS: &str = "127.0.0.1:8000";
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Default)]
+// inline attribute required to work for schema inference in elicitation forms
+#[schemars(inline)]
+// schemars does not provide required type field for enums, so we extend it here
+#[schemars(extend("type" = "string"))]
+enum TitledEnum {
+    #[schemars(title = "Title for the first value")]
+    #[default]
+    FirstValue,
+    #[schemars(title = "Title for the second value")]
+    SecondValue,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+// inline attribute required to work for schema inference in elicitation forms
+#[schemars(inline)]
+enum UntitledEnum {
+    First,
+    Second,
+    Third,
+}
+
+fn default_untitled_multi_select() -> Vec<UntitledEnum> {
+    vec![UntitledEnum::Second, UntitledEnum::Third]
+}
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[schemars(description = "User information")]
+struct SelectEnumForm {
+    pub single_select_untitled: UntitledEnum,
+    #[schemars(
+        title = "Single Select Titled",
+        description = "Description for single select enum",
+        default
+    )]
+    pub single_select_titled: TitledEnum,
+    #[serde(default = "default_untitled_multi_select")]
+    pub multi_select_untitled: Vec<UntitledEnum>,
+    #[schemars(
+        title = "Multi Select Titled",
+        description = "Multi Select Description"
+    )]
+    pub multi_select_titled: Vec<TitledEnum>,
+}
+
+impl Display for SelectEnumForm {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = format!(
+            "Current Selections:\n\
+                Single Select Untitled: {:?}\n\
+                Single Select Titled: {:?}\n\
+            Multi Select Untitled: {:?}\n\
+            Multi Select Titled: {:?}\n",
+            self.single_select_untitled,
+            self.single_select_titled,
+            self.multi_select_untitled,
+            self.multi_select_titled,
+        );
+        write!(f, "{s}")
+    }
+}
+
+elicit_safe!(SelectEnumForm);
+
+#[derive(Clone)]
+struct ElicitationEnumFormServer {
+    selection: Arc<Mutex<SelectEnumForm>>,
+    tool_router: ToolRouter<ElicitationEnumFormServer>,
+}
+
+#[tool_router]
+impl ElicitationEnumFormServer {
+    pub fn new() -> Self {
+        Self {
+            selection: Arc::new(Mutex::new(SelectEnumForm {
+                single_select_untitled: UntitledEnum::First,
+                single_select_titled: TitledEnum::FirstValue,
+                multi_select_untitled: vec![UntitledEnum::Second],
+                multi_select_titled: vec![TitledEnum::SecondValue],
+            })),
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(description = "Get current enum selection form")]
+    async fn get_enum_form(&self) -> Result<CallToolResult, McpError> {
+        let guard = self.selection.lock().await;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{}",
+            *guard
+        ))]))
+    }
+
+    #[tool(description = "Set enum selection via elicitation form")]
+    async fn set_enum_form(
+        &self,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        match context
+            .peer
+            .elicit::<SelectEnumForm>("Please provide your selection".to_string())
+            .await
+        {
+            Ok(Some(form)) => {
+                let mut guard = self.selection.lock().await;
+                *guard = form;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Updated Selection:\n{}",
+                    *guard
+                ))]))
+            }
+            Ok(None) => {
+                return Ok(CallToolResult::success(vec![Content::text(
+                    "Elicitation cancelled by user.",
+                )]));
+            }
+            Err(err) => {
+                return Err(McpError::internal_error(
+                    format!("Elicitation failed: {err}"),
+                    None,
+                ));
+            }
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for ElicitationEnumFormServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation::from_build_env(),
+            instructions: Some(
+                "Simple server demonstrating elicitation for enum selection".to_string(),
+            ),
+            ..Default::default()
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "debug".to_string().into()))
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let service = StreamableHttpService::new(
+        || Ok(ElicitationEnumFormServer::new()),
+        LocalSessionManager::default().into(),
+        Default::default(),
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let tcp_listener = tokio::net::TcpListener::bind(BIND_ADDRESS).await?;
+    let _ = axum::serve(tcp_listener, router)
+        .with_graceful_shutdown(async { tokio::signal::ctrl_c().await.unwrap() })
+        .await;
+    Ok(())
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Implemented https://github.com/modelcontextprotocol/rust-sdk/issues/524 Elicitation Enum Schema Improvements and Standards Compliance.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
SEP-1330: Elicitation Enum Schema Improvements  introduce new schema for enum type for elicitation. This PR implements its specifications: single/multi select options with/without titles.


Details:
- Introduced new model struct to match required schema
- Old response move to Legacy struct
- Added builder to configure enum schema
- New elicitation enum structs support default values required by https://github.com/modelcontextprotocol/rust-sdk/issues/521
- Now it's possible to use next structs for elicitation request with some hacks:
```rust
#[derive(Debug, Serialize, Deserialize, JsonSchema, Default)]
// inline attribute required to work for schema inference in elicitation forms
#[schemars(inline)]
// schemars does not provide required type field for enums, so we extend it here
#[schemars(extend("type" = "string"))]
enum TitledEnum {
    #[schemars(title = "Title for the first value")]
    #[default]
    FirstValue,
    #[schemars(title = "Title for the second value")]
    SecondValue,
}

#[derive(Debug, Serialize, Deserialize, JsonSchema)]
// inline attribute required to work for schema inference in elicitation forms
#[schemars(inline)]
enum UntitledEnum {
    First,
    Second,
    Third,
}

fn default_untitled_multi_select() -> Vec<UntitledEnum> {
    vec![UntitledEnum::Second, UntitledEnum::Third]
}
#[derive(Debug, Serialize, Deserialize, JsonSchema)]
#[schemars(description = "User information")]
struct SelectEnumForm {
    pub single_select_untitled: UntitledEnum,
    #[schemars(
        title = "Single Select Titled",
        description = "Description for single select enum",
        default
    )]
    pub single_select_titled: TitledEnum,
    #[serde(default = "default_untitled_multi_select")]
    pub multi_select_untitled: Vec<UntitledEnum>,
    #[schemars(
        title = "Multi Select Titled",
        description = "Multi Select Description"
    )]
    pub multi_select_titled: Vec<TitledEnum>,
}
```
This code will serialized to specification format.

- Added new example of using enums with elicitations in elicitation_enum_inference.rs

There was another PR https://github.com/modelcontextprotocol/rust-sdk/pull/537 that closed. In this PR is used standard way to parse json schema without modification using attributes of schemars

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tested with mcpinspector. It correctly understands single select option for enum. But does not work with multi-select options.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

- Fields in PrimitiveSchema were reordered: Enum put on the top. This due to overcome deserialization issue of serde. In details: untitled enums and string use both "type":"string" field(with additional fields for enums). Due to library uses untagged representation, for serde first match type will win. In our case if json will contain additional "enum" or "oneOf" fields it will be enum and string otherwise.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Closes https://github.com/modelcontextprotocol/rust-sdk/issues/524
