### PR TITLE
fix: exclude WASI example from workspace to avoid linker errors 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/rmcp", "crates/rmcp-macros", "examples/*"]
-exclude = ["examples/wasi"]
+default-members = ["crates/rmcp", "crates/rmcp-macros"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/examples/wasi/Cargo.toml
+++ b/examples/wasi/Cargo.toml
@@ -1,18 +1,15 @@
 [package]
 name = "wasi-mcp-example"
-edition = "2024"
-version = "0.8.5"
-authors = ["4t145 <u4t145@163.com>"]
-license = "MIT"
-repository = "https://github.com/modelcontextprotocol/rust-sdk/"
-description = "Rust SDK for Model Context Protocol"
-keywords = ["mcp", "sdk", "tokio", "modelcontextprotocol"]
-homepage = "https://github.com/modelcontextprotocol/rust-sdk"
-categories = [
-    "network-programming",
-    "asynchronous",
-]
-readme = "README.md"
+edition = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = { workspace = true }
+keywords = { workspace = true }
+homepage = { workspace = true }
+categories = { workspace = true }
+readme = { workspace = true }
 publish = false
 
 [lib]
@@ -21,7 +18,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasi = { version = "0.14.2"}
 tokio = { version = "1", features = ["rt", "io-util", "sync", "macros", "time"] }
-rmcp = { version = "0.8.5", path = "../../crates/rmcp", features = ["server", "macros"] }
+rmcp = { workspace = true, features = ["server", "macros"] }
 serde = { version  = "1", features = ["derive"]}
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",


### PR DESCRIPTION
## Motivation and Context
Cargo uses the macOS host linker for workspace builds, but that linker cannot 
resolve WASI WebAssembly imports (such as _wasi:cli/run@0.2.x). As a result, 
including a WASI crate in the workspace causes builds to fail on macOS systems 
using arm64.

Solution: Mark the WASI example as non-default by excluding it from the workspace 
members. This makes the WASI package optional, so `cargo build` won't touch it,
and it can be built explicitly when needed with:
  `cargo build -p wasi-mcp-example --target wasm32-wasip2`

## How Has This Been Tested?
Now cargo build works fine on Mac/arm64

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
CI will continue to build the WASI example explicitly during release workflows.