### PR TITLE
feat(auth): CredentialStore trait

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -14,6 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+async-trait = "0.1.89"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "2"


### PR DESCRIPTION
**Description**

Adds the concept of a configurable `CredentialStore` for `AuthorizationManager` to use

The current implementation writes to `credentials` in memory. This change gives the flexibility for users of `AuthorizationManager` to provide a custom implementation that persists credentials (to keychain, disk, etc).

There is no change to default behavior, as a default implementation is provided which does the same as now (`InMemoryCredentialStore`)

**Motivation**

The motivation came from this bug report to goose that new refresh tokens sent from the server during token exchange were not being saved/used https://github.com/block/goose/issues/5259

We store access tokens and refresh tokens via `keyring`, but we only did it on the initial auth and previously had no way to be informed of new refresh tokens received when `rmcp` exchanges tokens.

This allows for a provided `CredentialStore` to always load/save/clear token information from the storage mechanism of choice, and will fix https://github.com/block/goose/issues/5259