### PR TITLE
chore: clean up optional dependencies

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -25,7 +25,7 @@ tokio-util = { version = "0.7" }
 pin-project-lite = "0.2"
 pastey = { version = "0.2.0", optional = true }
 # oauth2 support
-oauth2 = { version = "5.0", optional = true }
+oauth2 = { version = "5.0", optional = true, default-features = false, features = ["reqwest"] }
 
 # for auto generate schema
 schemars = { version = "1.0", optional = true, features = ["chrono04"] }
@@ -108,7 +108,7 @@ client-side-sse = ["dep:sse-stream", "dep:http"]
 
 # Streamable HTTP client
 transport-streamable-http-client = ["client-side-sse", "transport-worker"]
-transport-streamable-http-client-reqwest = ["transport-streamable-http-client", "reqwest"]
+transport-streamable-http-client-reqwest = ["transport-streamable-http-client", "__reqwest"]
 
 transport-async-rw = ["tokio/io-util", "tokio-util/codec"]
 transport-io = ["transport-async-rw", "tokio/io-std"]

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -335,7 +335,12 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
         };
         // Store session info for cleanup when run() exits (not spawned, so cleanup completes before close() returns)
         let session_cleanup_info = session_id.as_ref().map(|sid| {
-            (self.client.clone(), config.uri.clone(), sid.clone(), config.auth_header.clone())
+            (
+                self.client.clone(),
+                config.uri.clone(),
+                sid.clone(),
+                config.auth_header.clone(),
+            )
         });
 
         context.send_to_handler(message).await?;

--- a/crates/rmcp/tests/test_close_connection.rs
+++ b/crates/rmcp/tests/test_close_connection.rs
@@ -4,7 +4,7 @@ mod common;
 use std::time::Duration;
 
 use common::handlers::{TestClientHandler, TestServer};
-use rmcp::{service::QuitReason, ServiceExt};
+use rmcp::{ServiceExt, service::QuitReason};
 
 /// Test that close() properly shuts down the connection
 #[tokio::test]


### PR DESCRIPTION
## Motivation and Context
I was looking at removing `ring` from the dependencies of an app. Trimming these makes that possible.

## How Has This Been Tested?
`cargo build` here and in the dependent app

## Breaking Changes
If they have an undeclared dependency in their own app, possibly yes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
