### PR TITLE
Added _meta field to prompts, resources and paginated results

### DIFF
--- a/crates/rmcp-macros/src/prompt.rs
+++ b/crates/rmcp-macros/src/prompt.rs
@@ -18,6 +18,8 @@ pub struct PromptAttribute {
     pub arguments: Option<Expr>,
     /// Optional icons for the prompt
     pub icons: Option<Expr>,
+    /// Optional metadata for the prompt
+    pub meta: Option<Expr>,
 }
 
 pub struct ResolvedPromptAttribute {
@@ -26,6 +28,7 @@ pub struct ResolvedPromptAttribute {
     pub description: Option<Expr>,
     pub arguments: Expr,
     pub icons: Option<Expr>,
+    pub meta: Option<Expr>,
 }
 
 impl ResolvedPromptAttribute {
@@ -36,6 +39,7 @@ impl ResolvedPromptAttribute {
             arguments,
             title,
             icons,
+            meta,
         } = self;
         let description = if let Some(description) = description {
             quote! { Some(#description.into()) }
@@ -52,6 +56,11 @@ impl ResolvedPromptAttribute {
         } else {
             quote! { None }
         };
+        let meta = if let Some(meta) = meta {
+            quote! { Some(#meta) }
+        } else {
+            quote! { None }
+        };
         let tokens = quote! {
             pub fn #fn_ident() -> rmcp::model::Prompt {
                 rmcp::model::Prompt {
@@ -60,6 +69,7 @@ impl ResolvedPromptAttribute {
                     arguments: #arguments,
                     title: #title,
                     icons: #icons,
+                    meta: #meta,
                 }
             }
         };
@@ -114,6 +124,7 @@ pub fn prompt(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream>
         arguments: arguments.clone(),
         title: attribute.title,
         icons: attribute.icons,
+        meta: attribute.meta,
     };
     let prompt_attr_fn = resolved_prompt_attr.into_fn(prompt_attr_fn_ident.clone())?;
 

--- a/crates/rmcp-macros/src/prompt_handler.rs
+++ b/crates/rmcp-macros/src/prompt_handler.rs
@@ -7,6 +7,7 @@ use syn::{Expr, ImplItem, ItemImpl, parse_quote};
 #[darling(default)]
 pub struct PromptHandlerAttribute {
     pub router: Option<Expr>,
+    pub meta: Option<Expr>,
 }
 
 pub fn prompt_handler(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
@@ -40,6 +41,12 @@ pub fn prompt_handler(attr: TokenStream, input: TokenStream) -> syn::Result<Toke
         }
     };
 
+    let meta = if let Some(meta) = attribute.meta {
+        quote! { Some(#meta) }
+    } else {
+        quote! { None }
+    };
+
     // Add list_prompts implementation
     let list_prompts_impl: ImplItem = parse_quote! {
         async fn list_prompts(
@@ -50,6 +57,7 @@ pub fn prompt_handler(attr: TokenStream, input: TokenStream) -> syn::Result<Toke
             let prompts = #router_expr.list_all();
             Ok(ListPromptsResult {
                 prompts,
+                meta: #meta,
                 next_cursor: None,
             })
         }

--- a/crates/rmcp/src/handler/server/router.rs
+++ b/crates/rmcp/src/handler/server/router.rs
@@ -102,7 +102,7 @@ where
                 let tools = self.tool_router.list_all();
                 Ok(ServerResult::ListToolsResult(ListToolsResult {
                     tools,
-                    next_cursor: None,
+                    ..Default::default()
                 }))
             }
             ClientRequest::GetPromptRequest(request) => {
@@ -125,7 +125,7 @@ where
                 let prompts = self.prompt_router.list_all();
                 Ok(ServerResult::ListPromptsResult(ListPromptsResult {
                     prompts,
-                    next_cursor: None,
+                    ..Default::default()
                 }))
             }
             rest => self.service.handle_request(rest, context).await,

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -828,6 +828,8 @@ macro_rules! paginated_result {
         #[serde(rename_all = "camelCase")]
         #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
         pub struct $t {
+            #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+            pub meta: Option<Meta>,
             #[serde(skip_serializing_if = "Option::is_none")]
             pub next_cursor: Option<Cursor>,
             pub $i_item: $t_item,
@@ -838,6 +840,7 @@ macro_rules! paginated_result {
                 items: $t_item,
             ) -> Self {
                 Self {
+                    meta: None,
                     next_cursor: None,
                     $i_item: items,
                 }

--- a/crates/rmcp/src/model/content.rs
+++ b/crates/rmcp/src/model/content.rs
@@ -258,6 +258,7 @@ mod tests {
             mime_type: Some("text/plain".to_string()),
             size: Some(100),
             icons: None,
+            meta: None,
         });
 
         let json = serde_json::to_string(&resource_link).unwrap();

--- a/crates/rmcp/src/model/prompt.rs
+++ b/crates/rmcp/src/model/prompt.rs
@@ -2,7 +2,7 @@ use base64::engine::{Engine, general_purpose::STANDARD as BASE64_STANDARD};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    AnnotateAble, Annotations, Icon, RawEmbeddedResource, RawImageContent,
+    AnnotateAble, Annotations, Icon, Meta, RawEmbeddedResource, RawImageContent,
     content::{EmbeddedResource, ImageContent},
     resource::ResourceContents,
 };
@@ -25,6 +25,9 @@ pub struct Prompt {
     /// Optional list of icons for the prompt
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
+    /// Optional additional metadata for this prompt
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl Prompt {
@@ -44,6 +47,7 @@ impl Prompt {
             description: description.map(Into::into),
             arguments,
             icons: None,
+            meta: None,
         }
     }
 }

--- a/crates/rmcp/src/model/resource.rs
+++ b/crates/rmcp/src/model/resource.rs
@@ -29,6 +29,9 @@ pub struct RawResource {
     /// Optional list of icons for the resource
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
+    /// Optional additional metadata for this resource
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 pub type Resource = Annotated<RawResource>;
@@ -95,6 +98,7 @@ impl RawResource {
             mime_type: None,
             size: None,
             icons: None,
+            meta: None,
         }
     }
 }
@@ -115,6 +119,7 @@ mod tests {
             mime_type: Some("text/plain".to_string()),
             size: Some(100),
             icons: None,
+            meta: None,
         };
 
         let json = serde_json::to_string(&resource).unwrap();

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
@@ -992,6 +992,14 @@
       "description": "Represents a resource in the extension with metadata",
       "type": "object",
       "properties": {
+        "_meta": {
+          "description": "Optional additional metadata for this resource",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "description": {
           "description": "Optional description of the resource",
           "type": [

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
@@ -992,6 +992,14 @@
       "description": "Represents a resource in the extension with metadata",
       "type": "object",
       "properties": {
+        "_meta": {
+          "description": "Optional additional metadata for this resource",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "description": {
           "description": "Optional description of the resource",
           "type": [

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -172,6 +172,14 @@
       "description": "Represents a resource in the extension with metadata",
       "type": "object",
       "properties": {
+        "_meta": {
+          "description": "Optional additional metadata for this resource",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "annotations": {
           "anyOf": [
             {
@@ -1031,6 +1039,13 @@
     "ListPromptsResult": {
       "type": "object",
       "properties": {
+        "_meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "nextCursor": {
           "type": [
             "string",
@@ -1051,6 +1066,13 @@
     "ListResourceTemplatesResult": {
       "type": "object",
       "properties": {
+        "_meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "nextCursor": {
           "type": [
             "string",
@@ -1071,6 +1093,13 @@
     "ListResourcesResult": {
       "type": "object",
       "properties": {
+        "_meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "nextCursor": {
           "type": [
             "string",
@@ -1096,6 +1125,13 @@
     "ListToolsResult": {
       "type": "object",
       "properties": {
+        "_meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "nextCursor": {
           "type": [
             "string",
@@ -1472,6 +1508,14 @@
       "description": "A prompt that can be used to generate text from a model",
       "type": "object",
       "properties": {
+        "_meta": {
+          "description": "Optional additional metadata for this prompt",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "arguments": {
           "description": "Optional arguments that can be passed to customize the prompt",
           "type": [
@@ -1660,6 +1704,14 @@
           "description": "A link to a resource that can be fetched separately",
           "type": "object",
           "properties": {
+            "_meta": {
+              "description": "Optional additional metadata for this resource",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            },
             "annotations": {
               "anyOf": [
                 {
@@ -1816,6 +1868,14 @@
       "description": "Represents a resource in the extension with metadata",
       "type": "object",
       "properties": {
+        "_meta": {
+          "description": "Optional additional metadata for this resource",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "description": {
           "description": "Optional description of the resource",
           "type": [

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -172,6 +172,14 @@
       "description": "Represents a resource in the extension with metadata",
       "type": "object",
       "properties": {
+        "_meta": {
+          "description": "Optional additional metadata for this resource",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "annotations": {
           "anyOf": [
             {
@@ -1031,6 +1039,13 @@
     "ListPromptsResult": {
       "type": "object",
       "properties": {
+        "_meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "nextCursor": {
           "type": [
             "string",
@@ -1051,6 +1066,13 @@
     "ListResourceTemplatesResult": {
       "type": "object",
       "properties": {
+        "_meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "nextCursor": {
           "type": [
             "string",
@@ -1071,6 +1093,13 @@
     "ListResourcesResult": {
       "type": "object",
       "properties": {
+        "_meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "nextCursor": {
           "type": [
             "string",
@@ -1096,6 +1125,13 @@
     "ListToolsResult": {
       "type": "object",
       "properties": {
+        "_meta": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "nextCursor": {
           "type": [
             "string",
@@ -1472,6 +1508,14 @@
       "description": "A prompt that can be used to generate text from a model",
       "type": "object",
       "properties": {
+        "_meta": {
+          "description": "Optional additional metadata for this prompt",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "arguments": {
           "description": "Optional arguments that can be passed to customize the prompt",
           "type": [
@@ -1660,6 +1704,14 @@
           "description": "A link to a resource that can be fetched separately",
           "type": "object",
           "properties": {
+            "_meta": {
+              "description": "Optional additional metadata for this resource",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            },
             "annotations": {
               "anyOf": [
                 {
@@ -1816,6 +1868,14 @@
       "description": "Represents a resource in the extension with metadata",
       "type": "object",
       "properties": {
+        "_meta": {
+          "description": "Optional additional metadata for this resource",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "description": {
           "description": "Optional description of the resource",
           "type": [

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -110,7 +110,10 @@ impl Counter {
 #[prompt_router]
 impl Counter {
     /// This is an example prompt that takes one required argument, message
-    #[prompt(name = "example_prompt")]
+    #[prompt(
+        name = "example_prompt",
+        meta = Meta(rmcp::object!({"meta_key": "meta_value"}))
+    )]
     async fn example_prompt(
         &self,
         Parameters(args): Parameters<ExamplePromptArgs>,
@@ -161,8 +164,8 @@ impl Counter {
     }
 }
 
-#[tool_handler]
-#[prompt_handler]
+#[tool_handler(meta = Meta(rmcp::object!({"tool_meta_key": "tool_meta_value"})))]
+#[prompt_handler(meta = Meta(rmcp::object!({"router_meta_key": "router_meta_value"})))]
 impl ServerHandler for Counter {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
@@ -188,6 +191,7 @@ impl ServerHandler for Counter {
                 self._create_resource_text("memo://insights", "memo-name"),
             ],
             next_cursor: None,
+            meta: None,
         })
     }
 
@@ -226,6 +230,7 @@ impl ServerHandler for Counter {
         Ok(ListResourceTemplatesResult {
             next_cursor: None,
             resource_templates: Vec::new(),
+            meta: None,
         })
     }
 

--- a/examples/servers/src/sampling_stdio.rs
+++ b/examples/servers/src/sampling_stdio.rs
@@ -125,6 +125,7 @@ impl ServerHandler for SamplingDemoServer {
                 icons: None,
                 meta: None,
             }],
+            meta: None,
             next_cursor: None,
         })
     }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
MCP specifies _meta field for requested entities. Currently `_meta` field implemeted for tool, but missing for others.

This PR:
- adds `_meta` field for [Prompt](https://modelcontextprotocol.io/specification/2025-06-18/schema#prompt), [Resource](https://modelcontextprotocol.io/specification/2025-06-18/schema#resource)
- adds `_meta` field for PaginatedResult: ListToolsResult, ListPromptsResult, ListResourceTemplatesResult, ListPromptsResult.
- adds the `meta` attribute to tool_handler and prompt_handler macros
- updates Counter example to include example of usage new attributes(there is an issues with RustRover to parse attributes, but examples are working)

Format of meta attribute is the same as existed for tool. 
https://github.com/modelcontextprotocol/rust-sdk/blob/2b60f8af0ffccf6ec9f21ac8f95feecfc28dea18/crates/rmcp-macros/src/tool.rs#L127-L131
In this case you need to provide Meta object, but we can update to something like
```rust
        let meta = if let Some(meta) = meta {
            quote! { rmcp::model::Meta(rmcp::object!(#meta)) }
        } else {
            quote! { None }
        };
```
and use with item definition only with json, for instance
```rust
    #[prompt(
        name = "example_prompt",
        meta = {"meta_key": "meta_value"}
    )]
    async fn example_prompt(
```

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Code was tested via modelcontextprotocol/inspector.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

Closes https://github.com/modelcontextprotocol/rust-sdk/issues/557

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
