### PR TITLE
chore: replace paste with pastey

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -23,8 +23,7 @@ futures = "0.3"
 tracing = { version = "0.1" }
 tokio-util = { version = "0.7" }
 pin-project-lite = "0.2"
-paste = { version = "1", optional = true }
-
+pastey = { version = "0.2.0", optional = true }
 # oauth2 support
 oauth2 = { version = "5.0", optional = true }
 
@@ -79,7 +78,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
 default = ["base64", "macros", "server"]
 client = ["dep:tokio-stream"]
 server = ["transport-async-rw", "dep:schemars"]
-macros = ["dep:rmcp-macros", "dep:paste"]
+macros = ["dep:rmcp-macros", "dep:pastey"]
 elicitation = []
 
 # reqwest http client

--- a/crates/rmcp/src/lib.rs
+++ b/crates/rmcp/src/lib.rs
@@ -167,7 +167,7 @@ pub mod transport;
 // re-export
 #[cfg(all(feature = "macros", feature = "server"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", feature = "server"))))]
-pub use paste::paste;
+pub use pastey::paste;
 #[cfg(all(feature = "macros", feature = "server"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", feature = "server"))))]
 pub use rmcp_macros::*;

--- a/crates/rmcp/src/model/capabilities.rs
+++ b/crates/rmcp/src/model/capabilities.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
-use paste::paste;
+use pastey::paste;
 use serde::{Deserialize, Serialize};
 
 use super::JsonObject;


### PR DESCRIPTION
## Motivation and Context
cargo deny currently fails because the paste crate is archived and flagged unmaintained (RUSTSEC-2024-0436), so this PR swaps our macros feature dependency to pastey, a maintained drop-in replacement, which clears the advisory and keeps downstream consumers unblocked.

## How Has This Been Tested?
-  Standard lint/test suite passes locally.
- `cargo deny check advisories` now succeeds with pastey.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
reference issue #560 