### PR TITLE
docs: add video-transcriber-mcp-rs to projects built with rmcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ See [oauth_support](docs/OAUTH_SUPPORT.md) for details.
 - [nvim-mcp](https://github.com/linw1995/nvim-mcp) - A MCP server to interact with Neovim
 - [terminator](https://github.com/mediar-ai/terminator) - AI-powered desktop automation MCP server with cross-platform support and >95% success rate
 - [stakpak-agent](https://github.com/stakpak/agent) - Security-hardened terminal agent for DevOps with MCP over mTLS, streaming, secret tokenization, and async task management
+- [video-transcriber-mcp-rs](https://github.com/nhatvu148/video-transcriber-mcp-rs) - High-performance MCP server for transcribing videos from 1000+ platforms using whisper.cpp
 
 
 ## Development


### PR DESCRIPTION
Adding video-transcriber-mcp-rs to the list of projects built with rmcp

  ## Motivation and Context
  This PR adds [video-transcriber-mcp-rs](https://github.com/nhatvu148/video-transcriber-mcp-rs) to
  the "Built with rmcp" section of the README. The project is a high-performance MCP server for
  transcribing videos from 1000+ platforms using whisper.cpp, demonstrating real-world usage of the
  rmcp SDK.

  ## How Has This Been Tested?
  The project itself has been tested and is functional. This PR only adds a documentation entry to
  the README following the existing format in the "Built with rmcp" section.

  ## Breaking Changes
  No breaking changes - this is purely a documentation update.

  ## Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update

  ## Checklist
  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
  - [x] My code follows the repository's style guidelines
  - [x] New and existing tests pass locally
  - [x] I have added appropriate error handling
  - [x] I have added or updated documentation as needed

  ## Additional context
  The video-transcriber-mcp-rs project provides video transcription capabilities through MCP,
  supporting 1000+ platforms via yt-dlp integration and using whisper.cpp for efficient
  transcription. Adding it to this list helps showcase the versatility of rmcp and provides a
  reference implementation for others interested in building media processing MCP servers.