### PR TITLE
fix: use the json rpc error from the initialize response and bubble up to the client

### DIFF
--- a/crates/rmcp/tests/test_client_initialization.rs
+++ b/crates/rmcp/tests/test_client_initialization.rs
@@ -1,0 +1,51 @@
+// cargo test --features "server client" --package rmcp test_client_initialization
+mod common;
+
+use std::borrow::Cow;
+
+use common::handlers::TestClientHandler;
+use rmcp::{
+    ServiceExt,
+    model::{
+        ErrorCode, ErrorData, JsonRpcError, JsonRpcVersion2_0, RequestId, ServerJsonRpcMessage,
+    },
+    transport::{IntoTransport, Transport},
+};
+
+#[tokio::test]
+async fn test_client_init_handles_jsonrpc_error() {
+    let (server_transport, client_transport) = tokio::io::duplex(1024);
+    let mut server = IntoTransport::<rmcp::RoleServer, _, _>::into_transport(server_transport);
+
+    let client_handle = tokio::spawn(async move {
+        TestClientHandler::new(true, true)
+            .serve(client_transport)
+            .await
+    });
+
+    tokio::spawn(async move {
+        let _init_request = server.receive().await;
+
+        let error_msg = ServerJsonRpcMessage::Error(JsonRpcError {
+            jsonrpc: JsonRpcVersion2_0,
+            id: RequestId::Number(1),
+            error: ErrorData {
+                code: ErrorCode(-32600),
+                message: Cow::Borrowed("Invalid Request"),
+                data: None,
+            },
+        });
+        let _: Result<(), _> = server.send(error_msg).await;
+    });
+
+    let result = client_handle.await.unwrap();
+
+    assert!(result.is_err());
+    match result {
+        Err(rmcp::service::ClientInitializeError::JsonRpcError(error_data)) => {
+            assert_eq!(error_data.code, ErrorCode(-32600));
+            assert_eq!(error_data.message, "Invalid Request");
+        }
+        _ => panic!("Expected ClientInitializeError::JsonRpcError"),
+    }
+}


### PR DESCRIPTION


<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Returns the error when initialization response is a json rpc error. Otherwise the client would be waiting in the loop and hangs until timeout.

fixes: https://github.com/modelcontextprotocol/rust-sdk/issues/563

Before the change:
- If the server sent a JSON-RPC error during initialization, it fell through to the catch-all _ pattern
- The error was only logged with tracing::warn! and ignored
- The client would hang waiting for a valid response that never comes
- User gets a timeout or connection closed error instead of the actual error


After the change:
- JSON-RPC error is caught and converted to ClientInitializeError::JsonRpcError
- The error propagates up through the ? operator at line 241: .await?
- Returns immediately from serve_client_with_ct_inner with the error
- User receives Err(ClientInitializeError::JsonRpcError(error_data)) from .serve()
- User can see the actual error code and message from the server


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

This is not a breaking change. But it should fix the issues where the client response with a default error message when the session connection failed.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
