### PR TITLE
refactor: merge cached_schema_for_type into schema_for_type

### DIFF
--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -220,7 +220,7 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
         if let Some(params_ty) = params_ty {
             // if found, use the Parameters schema
             syn::parse2::<Expr>(quote! {
-                rmcp::handler::server::common::cached_schema_for_type::<#params_ty>()
+                rmcp::handler::server::common::schema_for_type::<#params_ty>()
             })?
         } else {
             // if not found, use a default empty JSON schema object

--- a/crates/rmcp/src/handler/server/prompt.rs
+++ b/crates/rmcp/src/handler/server/prompt.rs
@@ -325,7 +325,7 @@ impl_prompt_handler_for!(T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
 /// as PromptArgument entries with name, description, and required status
 pub fn cached_arguments_from_schema<T: schemars::JsonSchema + std::any::Any>()
 -> Option<Vec<crate::model::PromptArgument>> {
-    let schema = super::common::cached_schema_for_type::<T>();
+    let schema = super::common::schema_for_type::<T>();
     let schema_value = serde_json::Value::Object((*schema).clone());
 
     let properties = schema_value.get("properties").and_then(|p| p.as_object());

--- a/crates/rmcp/src/handler/server/router/tool.rs
+++ b/crates/rmcp/src/handler/server/router/tool.rs
@@ -154,8 +154,8 @@ where
         self.attr.description = Some(description.into());
         self
     }
-    pub fn parameters<T: JsonSchema>(mut self) -> Self {
-        self.attr.input_schema = schema_for_type::<T>().into();
+    pub fn parameters<T: JsonSchema + 'static>(mut self) -> Self {
+        self.attr.input_schema = schema_for_type::<T>();
         self
     }
     pub fn parameters_value(mut self, schema: serde_json::Value) -> Self {

--- a/crates/rmcp/src/handler/server/tool.rs
+++ b/crates/rmcp/src/handler/server/tool.rs
@@ -9,7 +9,7 @@ use serde::de::DeserializeOwned;
 
 use super::common::{AsRequestContext, FromContextPart};
 pub use super::{
-    common::{Extension, RequestId, cached_schema_for_type, schema_for_output, schema_for_type},
+    common::{Extension, RequestId, schema_for_output, schema_for_type},
     router::tool::{ToolRoute, ToolRouter},
 };
 use crate::{

--- a/crates/rmcp/src/model/tool.rs
+++ b/crates/rmcp/src/model/tool.rs
@@ -178,7 +178,7 @@ impl Tool {
 
     /// Set the input schema using a type that implements JsonSchema
     pub fn with_input_schema<T: JsonSchema + 'static>(mut self) -> Self {
-        self.input_schema = crate::handler::server::tool::cached_schema_for_type::<T>();
+        self.input_schema = crate::handler::server::tool::schema_for_type::<T>();
         self
     }
 

--- a/crates/rmcp/tests/test_json_schema_detection.rs
+++ b/crates/rmcp/tests/test_json_schema_detection.rs
@@ -55,7 +55,7 @@ impl TestServer {
     }
 
     /// Tool with explicit output_schema attribute - should have output schema
-    #[tool(name = "explicit-schema", output_schema = rmcp::handler::server::tool::cached_schema_for_type::<TestData>())]
+    #[tool(name = "explicit-schema", output_schema = rmcp::handler::server::tool::schema_for_type::<TestData>())]
     pub async fn explicit_schema(&self) -> Result<String, String> {
         Ok("test".to_string())
     }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Following @alexhancock's suggestion in https://github.com/modelcontextprotocol/rust-sdk/pull/566#discussion_r2600039757 to consolidate caching logic into the primary public method, this PR applies the same refactoring pattern to `schema_for_type` and `cached_schema_for_type`.

Previously, we had two public functions serving the same purpose:
  - `schema_for_type<T>() -> JsonObject` - no caching
  - `cached_schema_for_type<T>() -> Arc<JsonObject>` - with caching

This duplication can create confusion about which to use and led to inefficient Arc-to-JsonObject-to-Arc conversions. Following the pattern established in #566, caching is now an internal optimization detail, not part of the public API.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Added a few new unit tests

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

Functionality remains the same with improved performance.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
