### PR TITLE
fix: correct redirect URI in client-metadata.json

### DIFF
--- a/client-metadata.json
+++ b/client-metadata.json
@@ -1,6 +1,6 @@
 {
   "client_id": "https://raw.githubusercontent.com/modelcontextprotocol/rust-sdk/refs/heads/main/client-metadata.json",
-  "redirect_uris": ["http://localhost:4000/callback"],
+  "redirect_uris": ["http://127.0.0.1:8080/callback"],
   "grant_types": ["authorization_code"],
   "response_types": ["code"],
   "token_endpoint_auth_method": "none"


### PR DESCRIPTION
Switch client-metadata.json to the 127.0.0.1:8080 callback URL for local OAuth flows

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Fix #570 