### PR TITLE
Update process-wrap to v9.0

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -48,7 +48,7 @@ url = { version = "2.4", optional = true }
 tower-service = { version = "0.3", optional = true }
 
 # for child process transport
-process-wrap = { version = "8.2", features = ["tokio1"], optional = true }
+process-wrap = { version = "9.0", features = ["tokio1"], optional = true }
 
 # for ws transport
 # tokio-tungstenite ={ version = "0.26", optional = true }


### PR DESCRIPTION
Updates process-wrap dependency from v8.2.1 to v9.0.0 and adapts code to API changes.

## Motivation and Context

Fixes #578

The rmcp crate was using process-wrap v8.2.1, but v9.0.0 introduced breaking API changes that caused dependency conflicts for users who needed both rmcp and the latest process-wrap in their projects. This update ensures compatibility with process-wrap v9.0.0 and prevents version conflicts.

## How Has This Been Tested?

All the existing unit tests are passing, and all the examples are building.

## Breaking Changes

None for users of rmcp. This is an internal dependency update that maintains the same public API.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context