### PR TITLE
feat(service): add close() method for graceful connection shutdown

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -333,37 +333,10 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
             }
             None
         };
-        // delete session when drop guard is dropped
-        if let Some(session_id) = &session_id {
-            let ct = transport_task_ct.clone();
-            let client = self.client.clone();
-            let session_id = session_id.clone();
-            let url = config.uri.clone();
-            let auth_header = config.auth_header.clone();
-            tokio::spawn(async move {
-                ct.cancelled().await;
-                let delete_session_result = client
-                    .delete_session(url, session_id.clone(), auth_header.clone())
-                    .await;
-                match delete_session_result {
-                    Ok(_) => {
-                        tracing::info!(session_id = session_id.as_ref(), "delete session success")
-                    }
-                    Err(StreamableHttpError::ServerDoesNotSupportDeleteSession) => {
-                        tracing::info!(
-                            session_id = session_id.as_ref(),
-                            "server doesn't support delete session"
-                        )
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            session_id = session_id.as_ref(),
-                            "fail to delete session: {e}"
-                        );
-                    }
-                };
-            });
-        }
+        // Store session info for cleanup when run() exits (not spawned, so cleanup completes before close() returns)
+        let session_cleanup_info = session_id.as_ref().map(|sid| {
+            (self.client.clone(), config.uri.clone(), sid.clone(), config.auth_header.clone())
+        });
 
         context.send_to_handler(message).await?;
         let initialized_notification = context.recv_from_handler().await?;
@@ -437,20 +410,23 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                 }
             });
         }
-        loop {
+        // Main event loop - capture exit reason so we can do cleanup before returning
+        let loop_result: Result<(), WorkerQuitReason<Self::Error>> = 'main_loop: loop {
             let event = tokio::select! {
                 _ = transport_task_ct.cancelled() => {
                     tracing::debug!("cancelled");
-                    return Err(WorkerQuitReason::Cancelled);
+                    break 'main_loop Err(WorkerQuitReason::Cancelled);
                 }
                 message = context.recv_from_handler() => {
-                    let message = message?;
-                    Event::ClientMessage(message)
+                    match message {
+                        Ok(msg) => Event::ClientMessage(msg),
+                        Err(e) => break 'main_loop Err(e),
+                    }
                 },
                 message = sse_worker_rx.recv() => {
                     let Some(message) = message else {
                         tracing::trace!("transport dropped, exiting");
-                        return Err(WorkerQuitReason::HandlerTerminated);
+                        break 'main_loop Err(WorkerQuitReason::HandlerTerminated);
                     };
                     Event::ServerMessage(message)
                 },
@@ -525,7 +501,9 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                 }
                 Event::ServerMessage(json_rpc_message) => {
                     // send the message to the handler
-                    context.send_to_handler(json_rpc_message).await?;
+                    if let Err(e) = context.send_to_handler(json_rpc_message).await {
+                        break 'main_loop Err(e);
+                    }
                 }
                 Event::StreamResult(result) => {
                     if result.is_err() {
@@ -536,7 +514,44 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                     }
                 }
             }
+        };
+
+        // Cleanup session before returning (ensures close() waits for session deletion)
+        // Use a timeout to prevent indefinite hangs if the server is unresponsive
+        if let Some((client, url, session_id, auth_header)) = session_cleanup_info {
+            const SESSION_CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+            match tokio::time::timeout(
+                SESSION_CLEANUP_TIMEOUT,
+                client.delete_session(url, session_id.clone(), auth_header),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {
+                    tracing::info!(session_id = session_id.as_ref(), "delete session success")
+                }
+                Ok(Err(StreamableHttpError::ServerDoesNotSupportDeleteSession)) => {
+                    tracing::info!(
+                        session_id = session_id.as_ref(),
+                        "server doesn't support delete session"
+                    )
+                }
+                Ok(Err(e)) => {
+                    tracing::error!(
+                        session_id = session_id.as_ref(),
+                        "fail to delete session: {e}"
+                    );
+                }
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        session_id = session_id.as_ref(),
+                        "session cleanup timed out after {:?}",
+                        SESSION_CLEANUP_TIMEOUT
+                    );
+                }
+            }
         }
+
+        loop_result
     }
 }
 

--- a/crates/rmcp/tests/test_close_connection.rs
+++ b/crates/rmcp/tests/test_close_connection.rs
@@ -1,0 +1,127 @@
+//cargo test --test test_close_connection --features "client server"
+
+mod common;
+use std::time::Duration;
+
+use common::handlers::{TestClientHandler, TestServer};
+use rmcp::{service::QuitReason, ServiceExt};
+
+/// Test that close() properly shuts down the connection
+#[tokio::test]
+async fn test_close_method() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    // Start server
+    let server_handle = tokio::spawn(async move {
+        let server = TestServer::new().serve(server_transport).await?;
+        server.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    // Start client
+    let handler = TestClientHandler::new(true, true);
+    let mut client = handler.serve(client_transport).await?;
+
+    // Verify client is not closed
+    assert!(!client.is_closed());
+
+    // Call close() and verify it returns
+    let result = client.close().await?;
+    assert!(matches!(result, QuitReason::Cancelled));
+
+    // Verify client is now closed
+    assert!(client.is_closed());
+
+    // Calling close() again should return Closed immediately
+    let result = client.close().await?;
+    assert!(matches!(result, QuitReason::Closed));
+
+    // Wait for server to finish
+    server_handle.await??;
+    Ok(())
+}
+
+/// Test that close_with_timeout() respects the timeout
+#[tokio::test]
+async fn test_close_with_timeout() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    // Start server
+    let server_handle = tokio::spawn(async move {
+        let server = TestServer::new().serve(server_transport).await?;
+        server.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    // Start client
+    let handler = TestClientHandler::new(true, true);
+    let mut client = handler.serve(client_transport).await?;
+
+    // Close with a reasonable timeout
+    let result = client.close_with_timeout(Duration::from_secs(5)).await?;
+    assert!(result.is_some());
+    assert!(matches!(result.unwrap(), QuitReason::Cancelled));
+
+    // Verify client is now closed
+    assert!(client.is_closed());
+
+    // Wait for server to finish
+    server_handle.await??;
+    Ok(())
+}
+
+/// Test that cancel() still works and consumes self
+#[tokio::test]
+async fn test_cancel_method() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    // Start server
+    let server_handle = tokio::spawn(async move {
+        let server = TestServer::new().serve(server_transport).await?;
+        server.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    // Start client
+    let handler = TestClientHandler::new(true, true);
+    let client = handler.serve(client_transport).await?;
+
+    // Cancel should work as before
+    let result = client.cancel().await?;
+    assert!(matches!(result, QuitReason::Cancelled));
+
+    // Wait for server to finish
+    server_handle.await??;
+    Ok(())
+}
+
+/// Test that dropping without close() logs a debug message (we can't easily test
+/// the log output, but we can verify the drop doesn't panic)
+#[tokio::test]
+async fn test_drop_without_close() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    // Start server that will handle the drop
+    let server_handle = tokio::spawn(async move {
+        let server = TestServer::new().serve(server_transport).await?;
+        // The server should close when the client drops
+        let result = server.waiting().await?;
+        // Server should detect closure
+        assert!(matches!(result, QuitReason::Closed | QuitReason::Cancelled));
+        anyhow::Ok(())
+    });
+
+    // Create and immediately drop the client
+    {
+        let handler = TestClientHandler::new(true, true);
+        let _client = handler.serve(client_transport).await?;
+        // Client dropped here without calling close()
+    }
+
+    // Give the async cleanup a moment to run
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Wait for server to finish (it should detect the closure)
+    server_handle.await??;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

This PR primarily fixes #572 by enabling graceful shutdown without consuming self. While implementing this, I noticed `delete_session()` is spawned as a background task, which means `close()` may return before HTTP session cleanup completes. Since this is part of the same shutdown lifecycle and can cause resource leaks/races, I'm including a small, localized fix to ensure cleanup is completed before `close()` returns. If maintainers prefer, I can split the cleanup timing change into a follow-up PR.

## Changes

### Service Layer (`service.rs`)
- **`close(&mut self)`** - Gracefully shuts down the connection and waits for cleanup to complete without consuming the `RunningService`. This was the main ask in #572.
- **`close_with_timeout(&mut self, Duration)`** - Same as `close()` but with a bounded wait time. Useful for apps that need deterministic shutdown.
- **`is_closed(&self)`** - Check if the service has already been closed or cancelled.
- **`Drop` impl** - Logs a debug message if dropped without explicit `close()` call. The `DropGuard` still handles async cleanup, but this helps developers catch missing cleanup calls.

### HTTP Transport (`streamable_http_client.rs`)
- Moved `delete_session()` from a fire-and-forget `tokio::spawn` to inline cleanup at the end of the worker's `run()` method
- Added a **5-second timeout** on the cleanup HTTP request to prevent `close()` from hanging indefinitely if the server is unresponsive
- This ensures the HTTP DELETE request completes (or times out) **before** `close()` returns, preventing orphaned sessions on authenticated MCP servers

## Why both changes together?

The original issue mentions that "for authenticated MCP connections, the sessions on the remote would still be active." The service-layer `close()` method alone doesn't fully solve this because the HTTP transport's session deletion was spawned as a background task. By moving it inline with a timeout, `close()` now guarantees bounded, deterministic cleanup.

## Design Decisions

**Q: Can `close()` hang forever?**  
No. The HTTP session cleanup has a 5-second timeout. If the server doesn't respond, we log a warning and continue. `close_with_timeout()` provides an additional layer of control at the service level.

**Q: What happens if cancelled mid-cleanup?**  
The cleanup runs after the main loop exits, so the cancellation token has already fired. The timeout ensures we don't block indefinitely regardless of server behavior.

## Manual Verification

```bash
# Build
cargo check -p rmcp --all-features

# Run all tests
cargo test -p rmcp --all-features

# Run the new close() tests specifically  
cargo test --test test_close_connection --features "client server"

# Clippy
cargo clippy -p rmcp --all-features
```

All tests pass, clippy is clean.

## Test Plan

- [x] `test_close_method` - Verifies `close()` works and can be called twice safely
- [x] `test_close_with_timeout` - Verifies timeout-bounded shutdown
- [x] `test_cancel_method` - Confirms existing `cancel()` API still works (backward compat)
- [x] `test_drop_without_close` - Verifies drop behavior doesn't panic and async cleanup still happens

## Backward Compatibility

- Existing `cancel()` method still works (now delegates to `close()` internally)
- Existing `waiting()` method still works
- Dropping without `close()` still triggers cleanup via `DropGuard` - just with a debug log now

Fixes #572