### PR TITLE
docs: add -p mcp-client-examples to cargo run commands in clients/README.md

### DIFF
--- a/examples/clients/README.md
+++ b/examples/clients/README.md
@@ -63,7 +63,7 @@ A client demonstrating how to use the sampling tool.
 
 A client that communicates with an MCP server using progress notifications.
 
-- Launches the `cargo run --example clients_progress_client -- --transport {stdio|http|all}` to test the progress notifications
+- Launches the `cargo run -p mcp-client-examples --example clients_progress_client -- --transport {stdio|http|all}` to test the progress notifications
 - Connects to the server using different transport methods
 - Tests the progress notifications
 - The http transport should run the server first
@@ -75,22 +75,22 @@ Each example can be run using Cargo:
 
 ```bash
 # Run the Git standard I/O client example
-cargo run --example clients_git_stdio
+cargo run -p mcp-client-examples --example clients_git_stdio
 
 # Run the streamable HTTP client example
-cargo run --example clients_streamable_http
+cargo run -p mcp-client-examples --example clients_streamable_http
 
 # Run the full-featured standard I/O client example
-cargo run --example clients_everything_stdio
+cargo run -p mcp-client-examples --example clients_everything_stdio
 
 # Run the client collection example
-cargo run --example clients_collection
+cargo run -p mcp-client-examples --example clients_collection
 
 # Run the OAuth client example
-cargo run --example clients_oauth_client
+cargo run -p mcp-client-examples --example clients_oauth_client
 
 # Run the sampling standard I/O client example
-cargo run --example clients_sampling_stdio
+cargo run -p mcp-client-examples --example clients_sampling_stdio
 ```
 
 ## Dependencies


### PR DESCRIPTION
Add `-p mcp-client-examples` to cargo run commands in `examples/clients/README.md` to fix errors like:
```
error: no example target named `clients_everything_stdio` in default-run packages
```

## Motivation and Context
When I ran command as `examples/clients/README.md`:
```shell
cargo runcargo run --example clients_everything_stdio
```
I got errors like:
```
error: no example target named `clients_everything_stdio` in default-run packages
```

## How Has This Been Tested?
Run the new commands.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
