### PR TITLE
fix: compilation with --no-default-features

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -77,7 +77,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
 [features]
 default = ["base64", "macros", "server"]
 client = ["dep:tokio-stream"]
-server = ["transport-async-rw", "dep:schemars"]
+server = ["transport-async-rw", "dep:schemars", "dep:pastey"]
 macros = ["dep:rmcp-macros", "dep:pastey"]
 elicitation = []
 

--- a/crates/rmcp/src/error.rs
+++ b/crates/rmcp/src/error.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, fmt::Display};
 
-use crate::ServiceError;
 pub use crate::model::ErrorData;
 #[deprecated(
     note = "Use `rmcp::ErrorData` instead, `rmcp::ErrorData` could become `RmcpError` in the future."
@@ -22,8 +21,9 @@ impl std::error::Error for ErrorData {}
 #[derive(Debug, thiserror::Error)]
 #[allow(clippy::large_enum_variant)]
 pub enum RmcpError {
+    #[cfg(any(feature = "client", feature = "server"))]
     #[error("Service error: {0}")]
-    Service(#[from] ServiceError),
+    Service(#[from] crate::ServiceError),
     #[cfg(feature = "client")]
     #[error("Client initialization error: {0}")]
     ClientInitialize(#[from] crate::service::ClientInitializeError),

--- a/crates/rmcp/src/lib.rs
+++ b/crates/rmcp/src/lib.rs
@@ -178,8 +178,8 @@ pub use pastey::paste;
 #[cfg(all(feature = "macros", feature = "server"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", feature = "server"))))]
 pub use rmcp_macros::*;
-#[cfg(all(feature = "macros", feature = "server"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "macros", feature = "server"))))]
+#[cfg(any(feature = "macros", feature = "server"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "macros", feature = "server"))))]
 pub use schemars;
 #[cfg(feature = "macros")]
 #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]

--- a/crates/rmcp/src/model/prompt.rs
+++ b/crates/rmcp/src/model/prompt.rs
@@ -1,8 +1,7 @@
-use base64::engine::{Engine, general_purpose::STANDARD as BASE64_STANDARD};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    AnnotateAble, Annotations, Icon, Meta, RawEmbeddedResource, RawImageContent,
+    AnnotateAble, Annotations, Icon, Meta, RawEmbeddedResource,
     content::{EmbeddedResource, ImageContent},
     resource::ResourceContents,
 };
@@ -138,11 +137,13 @@ impl PromptMessage {
         meta: Option<crate::model::Meta>,
         annotations: Option<Annotations>,
     ) -> Self {
+        use base64::{Engine, prelude::BASE64_STANDARD};
+
         let base64 = BASE64_STANDARD.encode(data);
         Self {
             role,
             content: PromptMessageContent::Image {
-                image: RawImageContent {
+                image: crate::model::RawImageContent {
                     data: base64,
                     mime_type: mime_type.into(),
                     meta,
@@ -215,7 +216,7 @@ mod tests {
 
     #[test]
     fn test_prompt_message_image_serialization() {
-        let image_content = RawImageContent {
+        let image_content = crate::model::RawImageContent {
             data: "base64data".to_string(),
             mime_type: "image/png".to_string(),
             meta: None,


### PR DESCRIPTION
## Motivation and Context

This is a pretty simple change that fixes feature gates in a couple of places. It allows to use `rmcp` crate in server mode without enabling `macros` and `base64` features reducing the dependency tree for applications that don't use those capabilities.

## How Has This Been Tested?

I verified that it actually compiles now
`cargo build -p rmcp --no-default-features --features server`

## Breaking Changes

There are no breaking changes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

