### PR TITLE
fix: only try to refresh access tokens if we have a refresh token or an expiry time

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -612,13 +612,16 @@ impl AuthorizationManager {
         let credentials = stored.and_then(|s| s.token_response);
 
         if let Some(creds) = credentials.as_ref() {
-            let expires_in = creds.expires_in().unwrap_or(Duration::from_secs(0));
-            if expires_in <= Duration::from_secs(0) {
-                tracing::info!("Access token expired, refreshing.");
+            // check token expiry if we have a refresh token or an expiry time
+            if creds.refresh_token().is_some() || creds.expires_in().is_some() {
+                let expires_in = creds.expires_in().unwrap_or(Duration::from_secs(0));
+                if expires_in <= Duration::from_secs(0) {
+                    tracing::info!("Access token expired, refreshing.");
 
-                let new_creds = self.refresh_token().await?;
-                tracing::info!("Refreshed access token.");
-                return Ok(new_creds.access_token().secret().to_string());
+                    let new_creds = self.refresh_token().await?;
+                    tracing::info!("Refreshed access token.");
+                    return Ok(new_creds.access_token().secret().to_string());
+                }
             }
 
             Ok(creds.access_token().secret().to_string())


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

When connecting to the GitHub remote MCP server as an "OAuth App" client (as opposed to a "GitHub App" client), GitHub issues a persistent, non-expiring access token and no refresh token.

The current logic treats a lack of an expiry time as "the token is already expired", which is incorrect in this use case, as the token never expires, and we are unable to refresh it (as we were never issued a refresh token).

This fixes the issue by only attempting to refresh if we have either a refresh token or an expiry time.

## How Has This Been Tested?

Tested it with a local build of Warp, and verified that instead of getting `OAuth token refresh failed: No refresh token available` errors, we now are able to properly make an authenticated connection to the GitHub remote MCP server.

## Breaking Changes

No, this is not a breaking API change, and should not break any functional behavior.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
