### PR TITLE
fix: add OpenID Connect discovery support per spec-2025-11-25 4.3

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -1488,31 +1488,64 @@ mod tests {
         let base_url = Url::parse("https://auth.example.com").unwrap();
         let urls = AuthorizationManager::generate_discovery_urls(&base_url);
         assert_eq!(urls.len(), 2);
-        assert_eq!(urls[0].as_str(), "https://auth.example.com/.well-known/oauth-authorization-server");
-        assert_eq!(urls[1].as_str(), "https://auth.example.com/.well-known/openid-configuration");
+        assert_eq!(
+            urls[0].as_str(),
+            "https://auth.example.com/.well-known/oauth-authorization-server"
+        );
+        assert_eq!(
+            urls[1].as_str(),
+            "https://auth.example.com/.well-known/openid-configuration"
+        );
 
         // Test URL with single path segment: follow spec priority order
         let base_url = Url::parse("https://auth.example.com/tenant1").unwrap();
         let urls = AuthorizationManager::generate_discovery_urls(&base_url);
         assert_eq!(urls.len(), 3);
-        assert_eq!(urls[0].as_str(), "https://auth.example.com/.well-known/oauth-authorization-server/tenant1");
-        assert_eq!(urls[1].as_str(), "https://auth.example.com/.well-known/openid-configuration/tenant1");
-        assert_eq!(urls[2].as_str(), "https://auth.example.com/tenant1/.well-known/openid-configuration");
+        assert_eq!(
+            urls[0].as_str(),
+            "https://auth.example.com/.well-known/oauth-authorization-server/tenant1"
+        );
+        assert_eq!(
+            urls[1].as_str(),
+            "https://auth.example.com/.well-known/openid-configuration/tenant1"
+        );
+        assert_eq!(
+            urls[2].as_str(),
+            "https://auth.example.com/tenant1/.well-known/openid-configuration"
+        );
 
         // Test URL with path and trailing slash
         let base_url = Url::parse("https://auth.example.com/v1/mcp/").unwrap();
         let urls = AuthorizationManager::generate_discovery_urls(&base_url);
         assert_eq!(urls.len(), 3);
-        assert_eq!(urls[0].as_str(), "https://auth.example.com/.well-known/oauth-authorization-server/v1/mcp");
-        assert_eq!(urls[1].as_str(), "https://auth.example.com/.well-known/openid-configuration/v1/mcp");
-        assert_eq!(urls[2].as_str(), "https://auth.example.com/v1/mcp/.well-known/openid-configuration");
+        assert_eq!(
+            urls[0].as_str(),
+            "https://auth.example.com/.well-known/oauth-authorization-server/v1/mcp"
+        );
+        assert_eq!(
+            urls[1].as_str(),
+            "https://auth.example.com/.well-known/openid-configuration/v1/mcp"
+        );
+        assert_eq!(
+            urls[2].as_str(),
+            "https://auth.example.com/v1/mcp/.well-known/openid-configuration"
+        );
 
         // Test URL with multiple path segments
         let base_url = Url::parse("https://auth.example.com/tenant1/subtenant").unwrap();
         let urls = AuthorizationManager::generate_discovery_urls(&base_url);
         assert_eq!(urls.len(), 3);
-        assert_eq!(urls[0].as_str(), "https://auth.example.com/.well-known/oauth-authorization-server/tenant1/subtenant");
-        assert_eq!(urls[1].as_str(), "https://auth.example.com/.well-known/openid-configuration/tenant1/subtenant");
-        assert_eq!(urls[2].as_str(), "https://auth.example.com/tenant1/subtenant/.well-known/openid-configuration");
+        assert_eq!(
+            urls[0].as_str(),
+            "https://auth.example.com/.well-known/oauth-authorization-server/tenant1/subtenant"
+        );
+        assert_eq!(
+            urls[1].as_str(),
+            "https://auth.example.com/.well-known/openid-configuration/tenant1/subtenant"
+        );
+        assert_eq!(
+            urls[2].as_str(),
+            "https://auth.example.com/tenant1/subtenant/.well-known/openid-configuration"
+        );
     }
 }


### PR DESCRIPTION
## Motivation and Context
Previously, discovery only tried OAuth 2.0 Authorization Server Metadata endpoints.
Now follows the [spec-mandated priority order](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) (​Version 2025-11-25 Section 4.3 Authorization Server Metadata Discovery):
- For URLs with path components: OAuth with path insertion → OpenID Connect with path insertion → OpenID Connect with path appending
- For URLs without path components: OAuth → OpenID Connect
This ensures interoperability with both OAuth 2.0 and OpenID Connect Discovery 1.0 specifications.

## How Has This Been Tested?
Added unit tests for discovery URL generation covering root URLs, single/multiple path segments, and trailing slashes. All existing tests pass;

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
#597 
[Typescript Implementation ](https://github.com/modelcontextprotocol/typescript-sdk/pull/652/changes)