### PR TITLE
docs: update README external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ See [oauth_support](docs/OAUTH_SUPPORT.md) for details.
 
 ## Related Resources
 
-- [MCP Specification](https://spec.modelcontextprotocol.io/specification/2024-11-05/)
-- [Schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.ts)
+- [MCP Specification](https://modelcontextprotocol.io/specification/2025-11-25)
+- [Schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-11-25/schema.ts)
 
 ## Related Projects
 

--- a/docs/OAUTH_SUPPORT.md
+++ b/docs/OAUTH_SUPPORT.md
@@ -1,6 +1,6 @@
 # Model Context Protocol OAuth Authorization
 
-This document describes the OAuth 2.1 authorization implementation for Model Context Protocol (MCP), following the [MCP 2025-03-26 Authorization Specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/).
+This document describes the OAuth 2.1 authorization implementation for Model Context Protocol (MCP), following the [MCP 2025-03-26 Authorization Specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization/).
 
 ## Features
 
@@ -117,7 +117,7 @@ If you encounter authorization issues, check the following:
 
 ## References
 
-- [MCP Authorization Specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/)
+- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization/)
 - [OAuth 2.1 Specification Draft](https://oauth.net/2.1/)
 - [RFC 8414: OAuth 2.0 Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414)
 - [RFC 7591: OAuth 2.0 Dynamic Client Registration Protocol](https://datatracker.ietf.org/doc/html/rfc7591)

--- a/docs/readme/README.zh-cn.md
+++ b/docs/readme/README.zh-cn.md
@@ -106,8 +106,8 @@ let quit_reason = server.cancel().await?;
 
 ## 相关资源
 
-- [MCP Specification](https://spec.modelcontextprotocol.io/specification/2024-11-05/)
-- [Schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.ts)
+- [MCP Specification](https://modelcontextprotocol.io/specification/2025-11-25)
+- [Schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-11-25/schema.ts)
 
 ## 相关项目
 - [containerd-mcp-server](https://github.com/jokemanfire/mcp-containerd) - 基于 containerd 实现的 MCP 服务


### PR DESCRIPTION
Fix links in the README file.

## Motivation and Context

It appears that the domain spec.modelcontextprotocol.io is no longer valid, the documentation is now at modelcontextprotocol.io. Also, the documentation points to a version of the specification that no longer seems to be aligned with the current implementation.

## How Has This Been Tested?

N/A - documentation update

## Breaking Changes

No breaking change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

This is my first PR here, please feel free to comment on the commit format or make any other suggestions :)
