### PR TITLE
re-export ServerSseMessage from session module

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/session.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session.rs
@@ -1,10 +1,9 @@
 use futures::Stream;
 
-pub use crate::transport::common::server_side_http::SessionId;
+pub use crate::transport::common::server_side_http::{ServerSseMessage, SessionId};
 use crate::{
     RoleServer,
     model::{ClientJsonRpcMessage, ServerJsonRpcMessage},
-    transport::common::server_side_http::ServerSseMessage,
 };
 
 pub mod local;


### PR DESCRIPTION
Re-export `ServerSseMessage` from the session module for consistency with `SessionId`.

## Motivation and Context

To mitigate the impact of the breaking changes introduced in PR #604, I wanted to stop exposing `ServerSseMessage` but I realized the `SessionManager` trait uses `ServerSseMessage` in return types for its methods. For example:

https://github.com/modelcontextprotocol/rust-sdk/blob/971c64c31f17b0b4055aa8067426e8a1ec0f7fad/crates/rmcp/src/transport/streamable_http_server/session.rs#L29-L35

I was misled into thinking we could apply `pub(crate)` because unlike `SessionId` that is also used by `SessionManager`, `ServerSseMessage` was not re-exported from the session module. This meant users implementing a custom session manager had to import types inconsistently:

### Before

```rs
use rmcp::transport::streamable_http_server::session::{SessionId, SessionManager};
use rmcp::transport::common::server_side_http::ServerSseMessage;  // inconsistent path
```

### After

```rs
use rmcp::transport::streamable_http_server::session::{ServerSseMessage, SessionId, SessionManager};
```

I think it makes more sense to re-exports `ServerSseMessage` from the session module as well so that users can import all session-related types from the same location. This change will makes the public API more ergonomic by co-locating related exports.

## How Has This Been Tested?

`cargo test --all-features` passes

## Breaking Changes

Not a breaking change. `ServerSseMessage` can still be imported from `rmcp::transport::common::server_side_http` if desired.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
