### PR TITLE
fix: Don't treat non-success HTTP codes as transport errors

### DIFF
--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -121,7 +121,6 @@ impl StreamableHttpClient for reqwest::Client {
             }
         }
         let status = response.status();
-        let response = response.error_for_status()?;
         if matches!(
             status,
             reqwest::StatusCode::ACCEPTED | reqwest::StatusCode::NO_CONTENT


### PR DESCRIPTION
Bringing back the remaining relevant change from https://github.com/modelcontextprotocol/rust-sdk/pull/486

cc @SteffenDE