### PR TITLE
chore: release v0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ default-members = ["crates/rmcp", "crates/rmcp-macros"]
 resolver = "2"
 
 [workspace.dependencies]
-rmcp = { version = "0.12.0", path = "./crates/rmcp" }
-rmcp-macros = { version = "0.12.0", path = "./crates/rmcp-macros" }
+rmcp = { version = "0.13.0", path = "./crates/rmcp" }
+rmcp-macros = { version = "0.13.0", path = "./crates/rmcp-macros" }
 
 [workspace.package]
 edition = "2024"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["4t145 <u4t145@163.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/modelcontextprotocol/rust-sdk/"

--- a/crates/rmcp-macros/CHANGELOG.md
+++ b/crates/rmcp-macros/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/modelcontextprotocol/rust-sdk/compare/rmcp-macros-v0.12.0...rmcp-macros-v0.13.0) - 2026-01-15
+
+### Added
+
+- *(task)* add task support (SEP-1686) ([#536](https://github.com/modelcontextprotocol/rust-sdk/pull/536))
+
+### Fixed
+
+- *(docs)* add spreadsheet-mcp to Built with rmcp ([#582](https://github.com/modelcontextprotocol/rust-sdk/pull/582))
+
+### Other
+
+- update README external links ([#603](https://github.com/modelcontextprotocol/rust-sdk/pull/603))
+- clarity and formatting ([#602](https://github.com/modelcontextprotocol/rust-sdk/pull/602))
+
 ## [0.12.0](https://github.com/modelcontextprotocol/rust-sdk/compare/rmcp-macros-v0.11.0...rmcp-macros-v0.12.0) - 2025-12-18
 
 ### Other

--- a/crates/rmcp/CHANGELOG.md
+++ b/crates/rmcp/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/modelcontextprotocol/rust-sdk/compare/rmcp-v0.12.0...rmcp-v0.13.0) - 2026-01-15
+
+### Added
+
+- provide blanket implementations for ClientHandler and ServerHandler traits ([#609](https://github.com/modelcontextprotocol/rust-sdk/pull/609))
+- *(service)* add close() method for graceful connection shutdown ([#588](https://github.com/modelcontextprotocol/rust-sdk/pull/588))
+- *(auth)* add StateStore trait for pluggable OAuth state storage ([#614](https://github.com/modelcontextprotocol/rust-sdk/pull/614))
+- *(elicitation)* implement SEP-1330 Elicitation Enum Schema Improvements ([#539](https://github.com/modelcontextprotocol/rust-sdk/pull/539))
+- *(task)* add task support (SEP-1686) ([#536](https://github.com/modelcontextprotocol/rust-sdk/pull/536))
+
+### Fixed
+
+- use the json rpc error from the initialize response and bubble it up to the client ([#569](https://github.com/modelcontextprotocol/rust-sdk/pull/569))
+- *(build)* fix build of the project when no features are selected ([#606](https://github.com/modelcontextprotocol/rust-sdk/pull/606))
+- use Semaphore instead of Notify in OneshotTransport to prevent race condition ([#611](https://github.com/modelcontextprotocol/rust-sdk/pull/611))
+- add OpenID Connect discovery support per spec-2025-11-25 4.3 ([#598](https://github.com/modelcontextprotocol/rust-sdk/pull/598))
+- only try to refresh access tokens if we have a refresh token or an expiry time ([#594](https://github.com/modelcontextprotocol/rust-sdk/pull/594))
+- *(docs)* add spreadsheet-mcp to Built with rmcp ([#582](https://github.com/modelcontextprotocol/rust-sdk/pull/582))
+
+### Other
+
+- *(elicitation)* improve enum schema builder, small changes of elicitation builder ([#608](https://github.com/modelcontextprotocol/rust-sdk/pull/608))
+- add pre-commit hook for conventional commit verification ([#619](https://github.com/modelcontextprotocol/rust-sdk/pull/619))
+- clean up optional dependencies ([#546](https://github.com/modelcontextprotocol/rust-sdk/pull/546))
+- re-export ServerSseMessage from session module ([#612](https://github.com/modelcontextprotocol/rust-sdk/pull/612))
+- Implement SEP-1699: Support SSE Polling via Server-Side Disconnect ([#604](https://github.com/modelcontextprotocol/rust-sdk/pull/604))
+- update README external links ([#603](https://github.com/modelcontextprotocol/rust-sdk/pull/603))
+- clarity and formatting ([#602](https://github.com/modelcontextprotocol/rust-sdk/pull/602))
+- Add optional icons field to RawResourceTemplate ([#589](https://github.com/modelcontextprotocol/rust-sdk/pull/589))
+
 ## [0.12.0](https://github.com/modelcontextprotocol/rust-sdk/compare/rmcp-v0.11.0...rmcp-v0.12.0) - 2025-12-18
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `rmcp-macros`: 0.12.0 -> 0.13.0
* `rmcp`: 0.12.0 -> 0.13.0 (⚠ API breaking changes)

### ⚠ `rmcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field StreamableHttpServerConfig.sse_retry in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/transport/streamable_http_server/tower.rs:36
  field StreamableHttpServerConfig.sse_retry in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/transport/streamable_http_server/tower.rs:36
  field StreamableHttpServerConfig.sse_retry in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/transport/streamable_http_server/tower.rs:36
  field ClientCapabilitiesBuilder.tasks in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model/capabilities.rs:294
  field RawResourceTemplate.icons in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model/resource.rs:53
  field CallToolRequestParam.task in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model.rs:1711
  field ServerSseMessage.retry in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/transport/common/server_side_http.rs:70
  field ClientCapabilities.tasks in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model/capabilities.rs:101
  field ServerCapabilitiesBuilder.tasks in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model/capabilities.rs:242
  field ToolCallContext.task in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/handler/server/tool.rs:36
  field ServerCapabilities.tasks in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model/capabilities.rs:134

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant SessionEvent:CloseSseStream in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/transport/streamable_http_server/session/local.rs:616
  variant ClientRequest:GetTaskInfoRequest in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model.rs:1857
  variant ClientRequest:ListTasksRequest in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model.rs:1857
  variant ClientRequest:GetTaskResultRequest in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model.rs:1857
  variant ClientRequest:CancelTaskRequest in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model.rs:1857
  variant RmcpError:TaskError in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/error.rs:48
  variant ClientInitializeError:JsonRpcError in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/service/client.rs:48
  variant ServerResult:CreateTaskResult in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model.rs:1951
  variant ServerResult:ListTasksResult in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model.rs:1951
  variant ServerResult:GetTaskInfoResult in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model.rs:1951
  variant ServerResult:TaskResult in /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model.rs:1951

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/feature_missing.ron

Failed in:
  feature axum in the package's Cargo.toml

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  EnumSchema::new, previously in file /tmp/.tmpKum4Ce/rmcp/src/model/elicitation_schema.rs:498
  EnumSchema::enum_names, previously in file /tmp/.tmpKum4Ce/rmcp/src/model/elicitation_schema.rs:509
  EnumSchema::title, previously in file /tmp/.tmpKum4Ce/rmcp/src/model/elicitation_schema.rs:515
  EnumSchema::description, previously in file /tmp/.tmpKum4Ce/rmcp/src/model/elicitation_schema.rs:521

--- failure struct_with_pub_fields_changed_type: struct with pub fields became an enum or union ---

Description:
A struct with pub fields became an enum or union, breaking accesses to its public fields.
        ref: https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_with_pub_fields_changed_type.ron

Failed in:
  struct rmcp::model::EnumSchema became enum in file /tmp/.tmp4gVt2S/rust-sdk/crates/rmcp/src/model/elicitation_schema.rs:629
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rmcp-macros`

<blockquote>

## [0.13.0](https://github.com/modelcontextprotocol/rust-sdk/compare/rmcp-macros-v0.12.0...rmcp-macros-v0.13.0) - 2026-01-15

### Added

- *(task)* add task support (SEP-1686) ([#536](https://github.com/modelcontextprotocol/rust-sdk/pull/536))

### Fixed

- *(docs)* add spreadsheet-mcp to Built with rmcp ([#582](https://github.com/modelcontextprotocol/rust-sdk/pull/582))

### Other

- update README external links ([#603](https://github.com/modelcontextprotocol/rust-sdk/pull/603))
- clarity and formatting ([#602](https://github.com/modelcontextprotocol/rust-sdk/pull/602))
</blockquote>

## `rmcp`

<blockquote>

## [0.13.0](https://github.com/modelcontextprotocol/rust-sdk/compare/rmcp-v0.12.0...rmcp-v0.13.0) - 2026-01-15

### Added

- provide blanket implementations for ClientHandler and ServerHandler traits ([#609](https://github.com/modelcontextprotocol/rust-sdk/pull/609))
- *(service)* add close() method for graceful connection shutdown ([#588](https://github.com/modelcontextprotocol/rust-sdk/pull/588))
- *(auth)* add StateStore trait for pluggable OAuth state storage ([#614](https://github.com/modelcontextprotocol/rust-sdk/pull/614))
- *(elicitation)* implement SEP-1330 Elicitation Enum Schema Improvements ([#539](https://github.com/modelcontextprotocol/rust-sdk/pull/539))
- *(task)* add task support (SEP-1686) ([#536](https://github.com/modelcontextprotocol/rust-sdk/pull/536))

### Fixed

- use the json rpc error from the initialize response and bubble it up to the client ([#569](https://github.com/modelcontextprotocol/rust-sdk/pull/569))
- *(build)* fix build of the project when no features are selected ([#606](https://github.com/modelcontextprotocol/rust-sdk/pull/606))
- use Semaphore instead of Notify in OneshotTransport to prevent race condition ([#611](https://github.com/modelcontextprotocol/rust-sdk/pull/611))
- add OpenID Connect discovery support per spec-2025-11-25 4.3 ([#598](https://github.com/modelcontextprotocol/rust-sdk/pull/598))
- only try to refresh access tokens if we have a refresh token or an expiry time ([#594](https://github.com/modelcontextprotocol/rust-sdk/pull/594))
- *(docs)* add spreadsheet-mcp to Built with rmcp ([#582](https://github.com/modelcontextprotocol/rust-sdk/pull/582))

### Other

- *(elicitation)* improve enum schema builder, small changes of elicitation builder ([#608](https://github.com/modelcontextprotocol/rust-sdk/pull/608))
- add pre-commit hook for conventional commit verification ([#619](https://github.com/modelcontextprotocol/rust-sdk/pull/619))
- clean up optional dependencies ([#546](https://github.com/modelcontextprotocol/rust-sdk/pull/546))
- re-export ServerSseMessage from session module ([#612](https://github.com/modelcontextprotocol/rust-sdk/pull/612))
- Implement SEP-1699: Support SSE Polling via Server-Side Disconnect ([#604](https://github.com/modelcontextprotocol/rust-sdk/pull/604))
- update README external links ([#603](https://github.com/modelcontextprotocol/rust-sdk/pull/603))
- clarity and formatting ([#602](https://github.com/modelcontextprotocol/rust-sdk/pull/602))
- Add optional icons field to RawResourceTemplate ([#589](https://github.com/modelcontextprotocol/rust-sdk/pull/589))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).