### PR TITLE
Add native-tls feature for reqwest dependency

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -86,6 +86,8 @@ __reqwest = ["dep:reqwest"]
 
 reqwest = ["__reqwest", "reqwest?/rustls-tls"]
 
+reqwest-native-tls = ["__reqwest", "reqwest?/native-tls"]
+
 reqwest-tls-no-provider = ["__reqwest", "reqwest?/rustls-tls-no-provider"]
 
 server-side-http = [


### PR DESCRIPTION
This new feature avoids bringing the ring dependency that comes through even when using the reqwest-tls-no-provider feature

## Motivation and Context
This change adds a new feature that entirely avoids the transitive `ring` dependency. Ring is not allowed in Microsoft's internal repos and use of rmcp is flagged by compliance.

## How Has This Been Tested?
Tested in Codex agent from https://github.com/openai/codex

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

