### PR TITLE
feat: add native-tls as an optional TLS backend

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -88,6 +88,8 @@ reqwest = ["__reqwest", "reqwest?/rustls-tls"]
 
 reqwest-tls-no-provider = ["__reqwest", "reqwest?/rustls-tls-no-provider"]
 
+reqwest-native-tls = ["__reqwest", "reqwest?/native-tls"]
+
 server-side-http = [
   "uuid",
   "dep:rand",

--- a/crates/rmcp/README.md
+++ b/crates/rmcp/README.md
@@ -270,6 +270,10 @@ RMCP uses feature flags to control which components are included:
     - `transport-streamable-http-client-reqwest`: a default `reqwest` implementation of the streamable http client
 - `auth`: OAuth2 authentication support
 - `schemars`: JSON Schema generation (for tool definitions)
+- TLS backend options (for HTTP transports):
+  - `reqwest`: Uses rustls (pure Rust TLS, recommended default)
+  - `reqwest-native-tls`: Uses platform native TLS (OpenSSL on Linux, Secure Transport on macOS, SChannel on Windows)
+  - `reqwest-tls-no-provider`: Uses rustls without a default crypto provider (bring your own)
 
 
 ## Transports


### PR DESCRIPTION
Add reqwest-native-tls feature flag to allow users to choose between rustls (default) and native-tls for HTTP transports.

native-tls uses platform-native TLS implementations:
- OpenSSL on Linux
- Secure Transport on macOS
- SChannel on Windows

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

This is particularly useful for Linux distribution packagers who need to link against system TLS libraries (e.g., OpenSSL) rather than bundling a separate TLS implementation. Linking against system libs ensures security updates are applied system-wide and satisfies distribution packaging policies.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Ran `cargo test` locally, but it seems that even the default upstream tests are failing right now.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
