### PR TITLE
fix(tasks): correct enum variant ordering for deserialization

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -2045,6 +2045,7 @@ impl RequestParamsMeta for CancelTaskParams {
 pub type CancelTaskParam = CancelTaskParams;
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct GetTaskInfoResult {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2130,11 +2131,11 @@ ts_union!(
     | UnsubscribeRequest
     | CallToolRequest
     | ListToolsRequest
-    | CustomRequest
     | GetTaskInfoRequest
     | ListTasksRequest
     | GetTaskResultRequest
-    | CancelTaskRequest;
+    | CancelTaskRequest
+    | CustomRequest;
 );
 
 impl ClientRequest {
@@ -2153,11 +2154,11 @@ impl ClientRequest {
             ClientRequest::UnsubscribeRequest(r) => r.method.as_str(),
             ClientRequest::CallToolRequest(r) => r.method.as_str(),
             ClientRequest::ListToolsRequest(r) => r.method.as_str(),
-            ClientRequest::CustomRequest(r) => r.method.as_str(),
             ClientRequest::GetTaskInfoRequest(r) => r.method.as_str(),
             ClientRequest::ListTasksRequest(r) => r.method.as_str(),
             ClientRequest::GetTaskResultRequest(r) => r.method.as_str(),
             ClientRequest::CancelTaskRequest(r) => r.method.as_str(),
+            ClientRequest::CustomRequest(r) => r.method.as_str(),
         }
     }
 }
@@ -2222,11 +2223,11 @@ ts_union!(
     | ListToolsResult
     | CreateElicitationResult
     | EmptyResult
-    | CustomResult
     | CreateTaskResult
     | ListTasksResult
     | GetTaskInfoResult
     | TaskResult
+    | CustomResult
     ;
 );
 

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
@@ -863,9 +863,6 @@
           "$ref": "#/definitions/RequestOptionalParam4"
         },
         {
-          "$ref": "#/definitions/CustomRequest"
-        },
-        {
           "$ref": "#/definitions/Request9"
         },
         {
@@ -876,6 +873,9 @@
         },
         {
           "$ref": "#/definitions/Request11"
+        },
+        {
+          "$ref": "#/definitions/CustomRequest"
         }
       ],
       "required": [

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
@@ -863,9 +863,6 @@
           "$ref": "#/definitions/RequestOptionalParam4"
         },
         {
-          "$ref": "#/definitions/CustomRequest"
-        },
-        {
           "$ref": "#/definitions/Request9"
         },
         {
@@ -876,6 +873,9 @@
         },
         {
           "$ref": "#/definitions/Request11"
+        },
+        {
+          "$ref": "#/definitions/CustomRequest"
         }
       ],
       "required": [

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -857,7 +857,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Icon": {
       "description": "A URL pointing to an icon resource or a base64-encoded data URI.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- image/png - PNG images (safe, universal compatibility)\n- image/jpeg (and image/jpg) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- image/svg+xml - SVG images (scalable but requires security precautions)\n- image/webp - WebP images (modern, efficient format)",
@@ -2453,9 +2454,6 @@
           "$ref": "#/definitions/EmptyObject"
         },
         {
-          "$ref": "#/definitions/CustomResult"
-        },
-        {
           "$ref": "#/definitions/CreateTaskResult"
         },
         {
@@ -2466,6 +2464,9 @@
         },
         {
           "$ref": "#/definitions/TaskResult"
+        },
+        {
+          "$ref": "#/definitions/CustomResult"
         }
       ]
     },

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -857,7 +857,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Icon": {
       "description": "A URL pointing to an icon resource or a base64-encoded data URI.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- image/png - PNG images (safe, universal compatibility)\n- image/jpeg (and image/jpg) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- image/svg+xml - SVG images (scalable but requires security precautions)\n- image/webp - WebP images (modern, efficient format)",
@@ -2453,9 +2454,6 @@
           "$ref": "#/definitions/EmptyObject"
         },
         {
-          "$ref": "#/definitions/CustomResult"
-        },
-        {
           "$ref": "#/definitions/CreateTaskResult"
         },
         {
@@ -2466,6 +2464,9 @@
         },
         {
           "$ref": "#/definitions/TaskResult"
+        },
+        {
+          "$ref": "#/definitions/CustomResult"
         }
       ]
     },


### PR DESCRIPTION
Move CustomRequest and CustomResult to end of their respective untagged enums to ensure specific task variants match before catch-all custom types. Add deny_unknown_fields to GetTaskInfoResult to prevent matching arbitrary JSON objects.

Fixes issue where tasks/get, tasks/list, tasks/result, and tasks/cancel incorrectly deserialized as CustomRequest instead of their typed variants.

## Motivation and Context

Fixes deserialization bug where task-related requests (tasks/get, tasks/list, tasks/result, tasks/cancel) were incorrectly matching CustomRequest instead of their specific typed variants. This occurred because serde tries untagged enum variants in order, and CustomRequest accepted any method string.

The bug prevented proper routing of task requests in gateways and servers that deserialize into ClientRequest/ServerResult enums.

## How Has This Been Tested?

- All existing tests pass (268 tests)
- Tested with custom request integration tests
- Schema validation tests updated and passing
- Verified task requests now deserialize to correct types (GetTaskInfoRequest, etc.) instead of CustomRequest

## Breaking Changes

None. This is a bug fix that corrects deserialization behavior without changing the public API.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The fix involves two changes:
1. Reordering enum variants to place catch-all types (CustomRequest, CustomResult) last
2. Adding #[serde(deny_unknown_fields)] to GetTaskInfoResult to prevent it from matching arbitrary JSON

This ensures serde's untagged enum deserialization tries specific variants before falling back to custom types.