### PR TITLE
fix(tasks): avoid dropping completed task results during collection

### DIFF
--- a/crates/rmcp-macros/src/task_handler.rs
+++ b/crates/rmcp-macros/src/task_handler.rs
@@ -132,7 +132,6 @@ pub fn task_handler(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
                 use rmcp::task_manager::current_timestamp;
                 let task_id = request.task_id.clone();
                 let mut processor = (#processor).lock().await;
-                processor.collect_completed_results();
 
                 // Check completed results first
                 let completed = processor.peek_completed().iter().rev().find(|r| r.descriptor.operation_id == task_id);
@@ -200,7 +199,6 @@ pub fn task_handler(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
                     // Scope the lock so we can await outside if needed
                     {
                         let mut processor = (#processor).lock().await;
-                        processor.collect_completed_results();
 
                         if let Some(task_result) = processor.take_completed_result(&task_id) {
                             match task_result.result {
@@ -256,7 +254,6 @@ pub fn task_handler(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
             ) -> Result<(), McpError> {
                 let task_id = request.task_id;
                 let mut processor = (#processor).lock().await;
-                processor.collect_completed_results();
 
                 if processor.cancel_task(&task_id) {
                     return Ok(());

--- a/crates/rmcp/src/task_manager.rs
+++ b/crates/rmcp/src/task_manager.rs
@@ -195,7 +195,7 @@ impl OperationProcessor {
     }
 
     /// Collect completed results from running tasks and remove them from the running tasks map.
-    pub fn collect_completed_results(&mut self) {
+    fn collect_completed_results(&mut self) {
         while let Ok(result) = self.task_result_receiver.try_recv() {
             self.running_tasks.remove(&result.descriptor.operation_id);
             self.completed_results.push(result);
@@ -204,6 +204,7 @@ impl OperationProcessor {
 
     /// Check for tasks that have exceeded their timeout and handle them appropriately.
     pub fn check_timeouts(&mut self) {
+        self.collect_completed_results();
         let now = std::time::Instant::now();
         let mut timed_out_tasks = Vec::new();
 
@@ -228,7 +229,8 @@ impl OperationProcessor {
     }
 
     /// Get the number of running tasks.
-    pub fn running_task_count(&self) -> usize {
+    pub fn running_task_count(&mut self) -> usize {
+        self.collect_completed_results();
         self.running_tasks.len()
     }
 
@@ -237,15 +239,19 @@ impl OperationProcessor {
         for (_, task) in self.running_tasks.drain() {
             task.task_handle.abort();
         }
+        while self.task_result_receiver.try_recv().is_ok() {}
         self.completed_results.clear();
     }
+
     /// List running task ids.
-    pub fn list_running(&self) -> Vec<String> {
+    pub fn list_running(&mut self) -> Vec<String> {
+        self.collect_completed_results();
         self.running_tasks.keys().cloned().collect()
     }
 
-    /// Note: collectors should call collect_completed_results; this provides a snapshot of queued results.
-    pub fn peek_completed(&self) -> &[TaskResult] {
+    /// Returns a snapshot of completed task results.
+    pub fn peek_completed(&mut self) -> &[TaskResult] {
+        self.collect_completed_results();
         &self.completed_results
     }
 
@@ -263,6 +269,7 @@ impl OperationProcessor {
 
     /// Attempt to cancel a running task.
     pub fn cancel_task(&mut self, task_id: &str) -> bool {
+        self.collect_completed_results();
         if let Some(task) = self.running_tasks.remove(task_id) {
             task.task_handle.abort();
             // Insert a cancelled result so callers can observe the terminal state.
@@ -278,6 +285,7 @@ impl OperationProcessor {
 
     /// Retrieve a completed task result if available.
     pub fn take_completed_result(&mut self, task_id: &str) -> Option<TaskResult> {
+        self.collect_completed_results();
         if let Some(position) = self
             .completed_results
             .iter()

--- a/crates/rmcp/tests/test_task.rs
+++ b/crates/rmcp/tests/test_task.rs
@@ -36,7 +36,6 @@ async fn executes_enqueued_future() {
         .expect("submit operation");
 
     tokio::time::sleep(Duration::from_millis(30)).await;
-    processor.collect_completed_results();
     let results = processor.peek_completed();
     assert_eq!(results.len(), 1);
     let payload = results[0]


### PR DESCRIPTION
Remove the `std::mem::take` from `OperationProcessor::collect_completed_results`

## Motivation and Context
`std::mem::take` would clear `OperationProcessor::completed_results`, causing completed tasks to be dropped. This made `tasks/get` and `tasks/result` to fail for subsequent requests. 

## How Has This Been Tested?
- All existing tests passed
- Tested with a custom task server/client implementation (Will add this to examples if requested)

## Breaking Changes
This is technically a breaking change that changes the return type of `OperationProcessor::collect_completed_results` from `Vec<TaskResult>` to `()`. However, I doubt there was anyone calling the method directly without using the `#[tool_handler]` macro.

I did this to avoid introducing an unnecessary `clone` call. If this is a problem, I can change the method so it returns either:
- `self.completed_results.clone()`
-  An owned vector of newly collected items, which I think was the intended return value in the first place.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Fixes #638 
