### PR TITLE
fix(auth): oauth metadata discovery

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -1804,11 +1804,12 @@ mod tests {
     fn test_discovery_urls_with_path_suffix() {
         // When the base URL has a path suffix (e.g., /mcp), the discovery should
         // eventually fall back to checking /.well-known/oauth-authorization-server
-        // at the root, not just /.well-known/oauth-authorization-server/{path}.        
+        // at the root, not just /.well-known/oauth-authorization-server/{path}.
         let base_url = Url::parse("https://mcp.example.com/mcp").unwrap();
         let urls = AuthorizationManager::generate_discovery_urls(&base_url);
 
-        let canonical_oauth_fallback = "https://mcp.example.com/.well-known/oauth-authorization-server";
+        let canonical_oauth_fallback =
+            "https://mcp.example.com/.well-known/oauth-authorization-server";
 
         assert!(
             urls.iter().any(|u| u.as_str() == canonical_oauth_fallback),


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Auth metadata discovery stopped checking <base_domain>/.well-known/oauth-authorization-server with the 0.13 release. Adding a fix.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
See #632 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Added unit test that failed before the fix and passes after the fix

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ x I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
