### PR TITLE
refactor: remove unused axum dependency from server-side-http feature

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -54,7 +54,6 @@ process-wrap = { version = "9.0", features = ["tokio1"], optional = true }
 # tokio-tungstenite ={ version = "0.26", optional = true }
 
 # for http-server transport
-axum = { version = "0.8", features = [], optional = true }
 rand = { version = "0.9", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
@@ -133,7 +132,7 @@ schemars = ["dep:schemars"]
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 schemars = { version = "1.1.0", features = ["chrono04"] }
-
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 anyhow = "1.0"
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",


### PR DESCRIPTION
## Summary

The `server-side-http` feature included `dep:axum` but axum was never actually used in the rmcp library source code (verified: 0 references found via grep).

The `StreamableHttpService` is a tower service that works with any HTTP server framework. Users can choose to use:
- **axum** (via `Router::nest_service()` or `fallback_service()`)
- **hyper** directly (via `hyper_util::service::TowerToHyperService`)
- any other tower-compatible HTTP server

## Motivation

This came up while integrating rmcp into nushell ([PR #17161](https://github.com/nushell/nushell/pull/17161)) - a reviewer raised concerns about adding axum as a dependency. After investigation, we found that:

1. `StreamableHttpService` only uses `tower_service::Service` trait
2. axum is listed as a dependency but has 0 actual usages in rmcp source
3. Examples that use axum already have their own explicit dependency

## Changes

- Remove `dep:axum` from the `server-side-http` feature in `crates/rmcp/Cargo.toml`

## Testing

- `cargo build -p rmcp --features "transport-streamable-http-server"` ✓
- `cargo test -p rmcp --all-features` ✓
- Examples still work (they have their own axum dependency)

## Impact

Users who want to use axum can add it as a direct dependency (as the examples do). Users who prefer hyper or another tower-compatible server no longer have axum as a transitive dependency.