### PR TITLE
docs: add rudof-mcp to the "Built with rmcp" list in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ See [Oauth_support](docs/OAUTH_SUPPORT.md) for details.
 - [NexusCore MCP](https://github.com/sjkim1127/Nexuscore_MCP) - Advanced malware analysis & dynamic instrumentation MCP server with Frida integration and stealth unpacking capabilities
 - [spreadsheet-mcp](https://github.com/PSU3D0/spreadsheet-mcp) - Token-efficient MCP server for spreadsheet analysis with automatic region detection, recalculation, screenshot, and editing support for LLM agents
 - [hyper-mcp](https://github.com/hyper-mcp-rs/hyper-mcp) - A fast, secure MCP server that extends its capabilities through WebAssembly (WASM) plugins
+- [rudof-mcp](https://github.com/rudof-project/rudof/tree/master/rudof_mcp) - RDF validation and data processing MCP server with ShEx/SHACL validation, SPARQL queries, and format conversion. Supports stdio and streamable HTTP transports with full MCP capabilities (tools, prompts, resources, logging, completions, tasks)
 
 
 ## Development


### PR DESCRIPTION
## Motivation and Context
rudof-mcp is a production-ready MCP server built with rmcp that showcases several advanced features of the SDK. Adding it to the list provides another reference implementation for developers looking to build MCP servers with rmcp, particularly those interested in:
- Dual transport support (stdio + streamable HTTP)
- Full MCP capabilities implementation (tools, prompts, resources, logging, completions)
- Docker MCP Registry integration with state persistence

## How Has This Been Tested?
None. This is a documentation-only change.

## Breaking Changes
None. This is a documentation-only change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
rudof is an RDF, ShEx, and SHACL processing library. The MCP server exposes its functionality to AI assistants, enabling them to load, validate, query, and transform RDF data. The implementation can serve as a reference for building complex MCP servers.

Repository: https://github.com/rudof-project/rudof
MCP crate: https://github.com/rudof-project/rudof/tree/master/rudof_mcp
