### PR TITLE
SEP-1577 follow-ups

### DIFF
--- a/crates/rmcp/src/model/content.rs
+++ b/crates/rmcp/src/model/content.rs
@@ -129,67 +129,6 @@ impl ToolResultContent {
     }
 }
 
-/// Assistant message content types (SEP-1577).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub enum AssistantMessageContent {
-    Text(RawTextContent),
-    Image(RawImageContent),
-    Audio(RawAudioContent),
-    ToolUse(ToolUseContent),
-}
-
-/// User message content types (SEP-1577).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub enum UserMessageContent {
-    Text(RawTextContent),
-    Image(RawImageContent),
-    Audio(RawAudioContent),
-    ToolResult(ToolResultContent),
-}
-
-impl AssistantMessageContent {
-    /// Create a text content
-    pub fn text(text: impl Into<String>) -> Self {
-        Self::Text(RawTextContent {
-            text: text.into(),
-            meta: None,
-        })
-    }
-
-    /// Create a tool use content
-    pub fn tool_use(
-        id: impl Into<String>,
-        name: impl Into<String>,
-        input: super::JsonObject,
-    ) -> Self {
-        Self::ToolUse(ToolUseContent::new(id, name, input))
-    }
-}
-
-impl UserMessageContent {
-    /// Create a text content
-    pub fn text(text: impl Into<String>) -> Self {
-        Self::Text(RawTextContent {
-            text: text.into(),
-            meta: None,
-        })
-    }
-
-    /// Create a tool result content
-    pub fn tool_result(tool_use_id: impl Into<String>, content: Vec<Content>) -> Self {
-        Self::ToolResult(ToolResultContent::new(tool_use_id, content))
-    }
-
-    /// Create an error tool result content
-    pub fn tool_result_error(tool_use_id: impl Into<String>, content: Vec<Content>) -> Self {
-        Self::ToolResult(ToolResultContent::error(tool_use_id, content))
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]


### PR DESCRIPTION
## Motivation and Context

The SEP-1577 implementation in PR #628 doesn't fully enforce the spec's MUST requirements.

This PR adds a `validate()` method to `CreateMessageRequestParams` that checks role constraints (`ToolUse` only in assistant messages, `ToolResult` only in user messages), ensures tool result messages don't mix in other content types, and verifies that every `ToolUse` is balanced with a corresponding `ToolResult`. A matching `validate()` on `CreateMessageResult` enforces that the role is always `"assistant"`.

## How Has This Been Tested?

8 new unit tests covering all validation paths (role constraints, exclusivity, balance, result role)

## Breaking Changes

None. The removed enums and unvalidated `create_message` behavior were introduced in PR #628, which has not been released.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
