### PR TITLE
feat(auth): add token_endpoint_auth_method to OAuthClientConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ __pycache__/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-node_modules/


### PR DESCRIPTION
Some OAuth providers (e.g. HubSpot) require client credentials to be sent as POST body parameters (**client_secret_post**) instead of via HTTP Basic Auth header. The oauth2 crate defaults to BasicAuth, and rmcp had no way to honor the server's advertised auth method, causing TokenExchangeFailed errors.                    

Derive token_endpoint_auth_method from the server's authorization metadata (token_endpoint_auth_methods_supported) during configure_client. When the server advertises client_secret_post, the client is set to AuthType::RequestBody; otherwise it defaults to
  BasicAuth. No new config fields are added — the behavior is driven entirely by server metadata.

## Motivation and Context
OAuth servers advertise supported token endpoint auth methods via **token_endpoint_auth_methods_supported** in their authorization server metadata. rmcp was ignoring this field, always using Basic Auth. Servers like HubSpot that require **client_secret_post** would reject token requests.

## How Has This Been Tested?
Tested with a simple MCP client connecting to **HubSpot's remote MCP server** (`https://mcp.hubspot.com/mcp`), which requires `client_secret_post` authentication.

## Breaking Changes
No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
The TypeScript MCP SDK already implements the same `token_endpoint_auth_methods_supported` pattern:

- [`packages/core/src/shared/auth.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/core/src/shared/auth.ts) — defines `token_endpoint_auth_methods_supported` in `OAuthMetadataSchema`
- [`packages/client/src/client/auth.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/client/src/client/auth.ts) — `selectClientAuthMethod()` reads `token_endpoint_auth_methods_supported` from server metadata and picks between `client_secret_basic`, `client_secret_post`, or `none`; `applyClientAuthentication()` then sends credentials accordingly (Basic header vs POST body)

This PR aligns the Rust SDK with the TypeScript SDK's existing behavior.
