### PR TITLE
chore: make pre-commit do formatting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+cargo +nightly fmt --all
+
+# stage any formatting changes
+git add -u


### PR DESCRIPTION
Makes it so `pre-commit` will automatically format the code, cutting down on back-and-forth with PR submitters