### PR TITLE
feat(auth): add RFC 8707 Resource Indicators support

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -136,7 +136,7 @@ schemars = ["dep:schemars"]
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 schemars = { version = "1.1.0", features = ["chrono04"] }
-
+urlencoding = "2.1"
 anyhow = "1.0"
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Add RFC 8707 Resource Indicators support to the OAuth implementation.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
RFC 8707 Resource Indicators defines the `resource` parameter for OAuth 2.0, allowing clients to indicate the target resource server during authorization and token requests. This enables authorization servers to issue audience-restricted access tokens, improving security by ensuring tokens are only valid for the intended MCP server.

This change adds the resource parameter to all three OAuth request methods, using the MCP server's `base_url` as the resource indicator value.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

- Added 3 unit tests for RFC 8707 resource parameter handling
- All 111 unit tests pass: `cargo test -p rmcp --features "auth,client,server"`
- Verified with `cargo clippy -p rmcp --features "auth,client,server" -- -D warnings`
- Verified with `cargo fmt -p rmcp`


## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None. The resource parameter is added transparently to existing OAuth requests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
RFC 8707: https://datatracker.ietf.org/doc/html/rfc8707
- The `resource` parameter is added to:
  - `get_authorization_url()` - authorization request
  - `exchange_code_for_token()` - token exchange request
  - `refresh_token()` - token refresh request
- Added `urlencoding` as a dev dependency for test assertions