### PR TITLE
fix: Remove unnecessary doc-cfg

### DIFF
--- a/crates/rmcp/src/handler.rs
+++ b/crates/rmcp/src/handler.rs
@@ -1,6 +1,4 @@
 #[cfg(feature = "client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub mod client;
 #[cfg(feature = "server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub mod server;

--- a/crates/rmcp/src/lib.rs
+++ b/crates/rmcp/src/lib.rs
@@ -9,25 +9,18 @@ pub use error::{Error, ErrorData, RmcpError};
 /// Basic data types in MCP specification
 pub mod model;
 #[cfg(any(feature = "client", feature = "server"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "client", feature = "server"))))]
 pub mod service;
 #[cfg(feature = "client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use handler::client::ClientHandler;
 #[cfg(feature = "server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub use handler::server::ServerHandler;
 #[cfg(feature = "server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub use handler::server::wrapper::Json;
 #[cfg(any(feature = "client", feature = "server"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "client", feature = "server"))))]
 pub use service::{Peer, Service, ServiceError, ServiceExt};
 #[cfg(feature = "client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use service::{RoleClient, serve_client};
 #[cfg(feature = "server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub use service::{RoleServer, serve_server};
 
 pub mod handler;
@@ -36,17 +29,12 @@ pub mod transport;
 
 // re-export
 #[cfg(all(feature = "macros", feature = "server"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "macros", feature = "server"))))]
 pub use pastey::paste;
 #[cfg(all(feature = "macros", feature = "server"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "macros", feature = "server"))))]
 pub use rmcp_macros::*;
 #[cfg(any(feature = "macros", feature = "server"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "macros", feature = "server"))))]
 pub use schemars;
 #[cfg(feature = "macros")]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 pub use serde;
 #[cfg(feature = "macros")]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 pub use serde_json;

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -43,7 +43,6 @@ pub fn object(value: serde_json::Value) -> JsonObject {
 
 /// Use this macro just like [`serde_json::json!`]
 #[cfg(feature = "macros")]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 #[macro_export]
 macro_rules! object {
     ({$($tt:tt)*}) => {

--- a/crates/rmcp/src/service.rs
+++ b/crates/rmcp/src/service.rs
@@ -11,23 +11,17 @@ use crate::{
     transport::{DynamicTransportError, IntoTransport, Transport},
 };
 #[cfg(feature = "client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 mod client;
 #[cfg(feature = "client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use client::*;
 #[cfg(feature = "server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 mod server;
 #[cfg(feature = "server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub use server::*;
 #[cfg(feature = "tower")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tower")))]
 mod tower;
 use tokio_util::sync::{CancellationToken, DropGuard};
 #[cfg(feature = "tower")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tower")))]
 pub use tower::*;
 use tracing::{Instrument as _, instrument};
 #[derive(Error, Debug)]

--- a/crates/rmcp/src/transport.rs
+++ b/crates/rmcp/src/transport.rs
@@ -43,12 +43,10 @@
 //! #     ServiceExt, serve_server,
 //! # };
 //! #[cfg(feature = "client")]
-//! #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 //! # use rmcp::serve_client;
 //!
 //! // create transport from tcp stream
 //! #[cfg(feature = "client")]
-//! #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 //! async fn client() -> Result<(), Box<dyn std::error::Error>> {
 //!     let stream = tokio::net::TcpSocket::new_v4()?
 //!         .connect("127.0.0.1:8001".parse()?)
@@ -61,7 +59,6 @@
 //!
 //! // create transport from std io
 //! #[cfg(feature = "client")]
-//! #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 //! async fn io()  -> Result<(), Box<dyn std::error::Error>> {
 //!     let client = ().serve((tokio::io::stdin(), tokio::io::stdout())).await?;
 //!     let tools = client.peer().list_tools(Default::default()).await?;
@@ -77,35 +74,26 @@ use crate::service::{RxJsonRpcMessage, ServiceRole, TxJsonRpcMessage};
 pub mod sink_stream;
 
 #[cfg(feature = "transport-async-rw")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-async-rw")))]
 pub mod async_rw;
 
 #[cfg(feature = "transport-worker")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-worker")))]
 pub mod worker;
 #[cfg(feature = "transport-worker")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-worker")))]
 pub use worker::WorkerTransport;
 
 #[cfg(feature = "transport-child-process")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-child-process")))]
 pub mod child_process;
 #[cfg(feature = "transport-child-process")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-child-process")))]
 pub use child_process::{ConfigureCommandExt, TokioChildProcess};
 
 #[cfg(feature = "transport-io")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-io")))]
 pub mod io;
 #[cfg(feature = "transport-io")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-io")))]
 pub use io::stdio;
 
 #[cfg(feature = "auth")]
-#[cfg_attr(docsrs, doc(cfg(feature = "auth")))]
 pub mod auth;
 #[cfg(feature = "auth")]
-#[cfg_attr(docsrs, doc(cfg(feature = "auth")))]
 pub use auth::{
     AuthClient, AuthError, AuthorizationManager, AuthorizationSession, AuthorizedHttpClient,
     CredentialStore, InMemoryCredentialStore, InMemoryStateStore, ScopeUpgradeConfig, StateStore,
@@ -113,20 +101,15 @@ pub use auth::{
 };
 
 // #[cfg(feature = "transport-ws")]
-// #[cfg_attr(docsrs, doc(cfg(feature = "transport-ws")))]
 // pub mod ws;
 #[cfg(feature = "transport-streamable-http-server-session")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-streamable-http-server-session")))]
 pub mod streamable_http_server;
 #[cfg(feature = "transport-streamable-http-server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-streamable-http-server")))]
 pub use streamable_http_server::tower::{StreamableHttpServerConfig, StreamableHttpService};
 
 #[cfg(feature = "transport-streamable-http-client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-streamable-http-client")))]
 pub mod streamable_http_client;
 #[cfg(feature = "transport-streamable-http-client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-streamable-http-client")))]
 pub use streamable_http_client::StreamableHttpClientTransport;
 
 /// Common use codes

--- a/crates/rmcp/src/transport/async_rw.rs
+++ b/crates/rmcp/src/transport/async_rw.rs
@@ -68,7 +68,6 @@ where
 }
 
 #[cfg(feature = "client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 impl<R, W> AsyncRwTransport<crate::RoleClient, R, W>
 where
     R: Send + AsyncRead + Unpin,
@@ -80,7 +79,6 @@ where
 }
 
 #[cfg(feature = "server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 impl<R, W> AsyncRwTransport<crate::RoleServer, R, W>
 where
     R: Send + AsyncRead + Unpin,

--- a/crates/rmcp/src/transport/common.rs
+++ b/crates/rmcp/src/transport/common.rs
@@ -4,16 +4,13 @@ pub mod server_side_http;
 pub mod http_header;
 
 #[cfg(feature = "__reqwest")]
-#[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
 mod reqwest;
 
 // Note: This module provides SSE stream parsing and auto-reconnect utilities.
 // It's used by the streamable HTTP client (which receives SSE-formatted responses),
 // not the removed SSE transport. The name is historical.
 #[cfg(feature = "client-side-sse")]
-#[cfg_attr(docsrs, doc(cfg(feature = "client-side-sse")))]
 pub mod client_side_sse;
 
 #[cfg(feature = "auth")]
-#[cfg_attr(docsrs, doc(cfg(feature = "auth")))]
 pub mod auth;

--- a/crates/rmcp/src/transport/common/auth.rs
+++ b/crates/rmcp/src/transport/common/auth.rs
@@ -1,3 +1,2 @@
 #[cfg(feature = "transport-streamable-http-client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-streamable-http-client")))]
 mod streamable_http_client;

--- a/crates/rmcp/src/transport/common/reqwest.rs
+++ b/crates/rmcp/src/transport/common/reqwest.rs
@@ -1,3 +1,2 @@
 #[cfg(feature = "transport-streamable-http-client-reqwest")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-streamable-http-client-reqwest")))]
 mod streamable_http_client;

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -70,7 +70,6 @@ pub enum StreamableHttpError<E: std::error::Error + Send + Sync + 'static> {
     #[error("Missing session id in HTTP response")]
     MissingSessionIdInResponse,
     #[cfg(feature = "auth")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "auth")))]
     #[error("Auth error: {0}")]
     Auth(#[from] crate::transport::auth::AuthError),
     #[error("Auth required")]

--- a/crates/rmcp/src/transport/streamable_http_server.rs
+++ b/crates/rmcp/src/transport/streamable_http_server.rs
@@ -1,8 +1,6 @@
 pub mod session;
 #[cfg(feature = "transport-streamable-http-server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-streamable-http-server")))]
 pub mod tower;
 pub use session::{SessionId, SessionManager};
 #[cfg(feature = "transport-streamable-http-server")]
-#[cfg_attr(docsrs, doc(cfg(feature = "transport-streamable-http-server")))]
 pub use tower::{StreamableHttpServerConfig, StreamableHttpService};


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
After the `doc_auto_cfg` feature has been [merged into `doc_cfg` feature](https://github.com/rust-lang/rust/pull/138907), there is no need to annotate `#[cfg_attr(docsrs, doc(cfg(feature = "xxxx")))]`, it will be automatically identified and rendered in the rustdoc.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested locally with 

```shell
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --open
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
