### PR TITLE
fix: sort list_all() output in ToolRouter and PromptRouter for deterministic ordering

### DIFF
--- a/crates/rmcp/src/handler/server/router/prompt.rs
+++ b/crates/rmcp/src/handler/server/router/prompt.rs
@@ -187,7 +187,9 @@ where
     }
 
     pub fn list_all(&self) -> Vec<crate::model::Prompt> {
-        self.map.values().map(|item| item.attr.clone()).collect()
+        let mut prompts: Vec<_> = self.map.values().map(|item| item.attr.clone()).collect();
+        prompts.sort_by(|a, b| a.name.cmp(&b.name));
+        prompts
     }
 }
 

--- a/crates/rmcp/src/handler/server/router/tool.rs
+++ b/crates/rmcp/src/handler/server/router/tool.rs
@@ -252,7 +252,9 @@ where
     }
 
     pub fn list_all(&self) -> Vec<crate::model::Tool> {
-        self.map.values().map(|item| item.attr.clone()).collect()
+        let mut tools: Vec<_> = self.map.values().map(|item| item.attr.clone()).collect();
+        tools.sort_by(|a, b| a.name.cmp(&b.name));
+        tools
     }
 
     /// Get a tool definition by name.

--- a/crates/rmcp/tests/test_prompt_routers.rs
+++ b/crates/rmcp/tests/test_prompt_routers.rs
@@ -103,3 +103,39 @@ fn test_prompt_router() {
     let prompts = test_prompt_router.list_all();
     assert_eq!(prompts.len(), 4);
 }
+
+#[test]
+fn test_prompt_router_list_all_is_sorted() {
+    let router = TestHandler::<()>::test_router()
+        .with_route(rmcp::handler::server::router::prompt::PromptRoute::new_dyn(
+            async_function_prompt_attr(),
+            |mut context| {
+                Box::pin(async move {
+                    use rmcp::handler::server::{
+                        common::FromContextPart, prompt::IntoGetPromptResult,
+                    };
+                    let params = Parameters::<Request>::from_context_part(&mut context)?;
+                    let result = async_function(params).await;
+                    result.into_get_prompt_result()
+                })
+            },
+        ))
+        .with_route(rmcp::handler::server::router::prompt::PromptRoute::new_dyn(
+            async_function2_prompt_attr(),
+            |context| {
+                Box::pin(async move {
+                    use rmcp::handler::server::prompt::IntoGetPromptResult;
+                    let result = async_function2(context.server).await;
+                    result.into_get_prompt_result()
+                })
+            },
+        ));
+    let prompts = router.list_all();
+    let names: Vec<&str> = prompts.iter().map(|p| p.name.as_ref()).collect();
+    let mut sorted = names.clone();
+    sorted.sort();
+    assert_eq!(
+        names, sorted,
+        "list_all() should return prompts sorted alphabetically by name"
+    );
+}

--- a/crates/rmcp/tests/test_tool_routers.rs
+++ b/crates/rmcp/tests/test_tool_routers.rs
@@ -66,3 +66,20 @@ where
     H: CallToolHandler<S, A>,
 {
 }
+
+#[test]
+fn test_tool_router_list_all_is_sorted() {
+    let router: ToolRouter<TestHandler<()>> = ToolRouter::<TestHandler<()>>::new()
+        .with_route((async_function_tool_attr(), async_function))
+        .with_route((async_function2_tool_attr(), async_function2))
+        + TestHandler::<()>::test_router_1()
+        + TestHandler::<()>::test_router_2();
+    let tools = router.list_all();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    let mut sorted = names.clone();
+    sorted.sort();
+    assert_eq!(
+        names, sorted,
+        "list_all() should return tools sorted alphabetically by name"
+    );
+}


### PR DESCRIPTION
`ToolRouter::list_all()` and `PromptRouter::list_all()` iterate over a `HashMap`, which returns items in non-deterministic order. Since `list_all()` backs the `tools/list` and `prompts/list` MCP protocol
responses, this causes MCP clients to receive differently-ordered results across calls and process restarts, leading to suspected intermittent tool discovery failures.

This pull request sorts the output alphabetically by name to guarantee stable ordering.

## Motivation and Context

MCP servers with more than a handful of tools can experience intermittent tool discovery failures in clients (e.g. Claude Code, Claude Desktop). The root cause is that `HashMap` iteration order is
randomized across process restarts (and potentially within a process), so every `tools/list` or `prompts/list` response returns the same set of items but in a different order. 

This causes:
- Client-side caching/diffing to see spurious diffs, triggering unnecessary tool catalog rebuilds
- LLM tool selection instability when the tool list is re-injected into context in a different order
- Difficult debugging since the same server behaves differently across restarts

Related: [anthropics/claude-code#2682](https://github.com/anthropics/claude-code/issues/2682)

## How Has This Been Tested?

- Added `test_tool_router_list_all_is_sorted` and `test_prompt_router_list_all_is_sorted` tests
- Verified both tests fail without the fix (ran 10 iterations each to account for non-determinism — tool router test failed 9/10, prompt router test failed 10/10)
- Verified both tests pass consistently with the fix (10/10 each)
- All existing tests continue to pass

## Breaking Changes

None. The output type and contents of `list_all()` are unchanged — only the ordering is now guaranteed to be sorted alphabetically by name.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The fix sorts the collected `Vec` by name before returning. This is preferred over switching to `IndexMap` (insertion-order) because it provides a canonical alphabetical ordering regardless of how
tools/prompts are registered, with negligible performance cost for typical tool counts.

The `IntoIterator` impl on both routers also uses `HashMap` iteration, but it is not used in any protocol-facing context, so it was left unchanged to avoid a breaking API change.
