### PR TITLE
Upgrade reqwest to 0.13.2

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -26,7 +26,7 @@ tokio-util = { version = "0.7" }
 pin-project-lite = "0.2"
 pastey = { version = "0.2.0", optional = true }
 # oauth2 support
-oauth2 = { version = "5.0", optional = true, default-features = false, features = ["reqwest"] }
+oauth2 = { version = "5.0", optional = true, default-features = false }
 
 # for auto generate schema
 schemars = { version = "1.0", optional = true, features = ["chrono04"] }
@@ -35,7 +35,7 @@ schemars = { version = "1.0", optional = true, features = ["chrono04"] }
 base64 = { version = "0.22", optional = true }
 
 # for HTTP client
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.13.2", default-features = false, features = [
   "json",
   "stream",
 ], optional = true }
@@ -84,9 +84,9 @@ elicitation = ["dep:url"]
 # reqwest http client
 __reqwest = ["dep:reqwest"]
 
-reqwest = ["__reqwest", "reqwest?/rustls-tls"]
+reqwest = ["__reqwest", "reqwest?/rustls"]
 
-reqwest-tls-no-provider = ["__reqwest", "reqwest?/rustls-tls-no-provider"]
+reqwest-tls-no-provider = ["__reqwest", "reqwest?/rustls-no-provider"]
 
 reqwest-native-tls = ["__reqwest", "reqwest?/native-tls"]
 

--- a/examples/clients/Cargo.toml
+++ b/examples/clients/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = "1.0"
 url = "2.4"
 tower = "0.5"
 axum = "0.8"
-reqwest = "0.12"
+reqwest = "0.13.2"
 clap = { version = "4.0", features = ["derive"] }
 
 [[example]]

--- a/examples/servers/Cargo.toml
+++ b/examples/servers/Cargo.toml
@@ -35,7 +35,7 @@ futures = "0.3"
 rand = { version = "0.10", features = ["std"] }
 axum = { version = "0.8", features = ["macros"] }
 schemars = "1.0"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.13.2", features = ["json"] }
 chrono = "0.4"
 uuid = { version = "1.6", features = ["v4", "serde"] }
 serde_urlencoded = "0.7"

--- a/examples/simple-chat-client/Cargo.toml
+++ b/examples/simple-chat-client/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.13.2", features = ["json"] }
 anyhow = "1.0"
 thiserror = "2.0"
 async-trait = "0.1"

--- a/examples/transport/Cargo.toml
+++ b/examples/transport/Cargo.toml
@@ -41,7 +41,7 @@ schemars = { version = "1.0", optional = true }
 hyper = { version = "1", features = ["client", "server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 tokio-tungstenite = "0.28.0"
-reqwest = { version = "0.12" }
+reqwest = { version = "0.13.2" }
 pin-project-lite = "0.2"
 
 [[example]]


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

reqwest 0.13 ships with rustls as the default TLS backend and renames several TLS features. This PR bumps the SDK from reqwest 0.12 to 0.13.2 across the main library and all examples.

`oauth2` v5.0 depends on `reqwest ^0.12` through its built-in `reqwest` feature, which would pull in a second, incompatible copy of reqwest. To avoid that, we disable oauth2's `reqwest` feature and provide our own `OAuthReqwestClient` wrapper that implements `oauth2::AsyncHttpClient` against reqwest 0.13.

## How Has This Been Tested?

All existing tests pass.

## Breaking Changes

The user-facing TLS feature names (`reqwest`, `reqwest-native-tls`, `reqwest-tls-no-provider`) are unchanged. Users who also depend on `reqwest` directly will need to bump to `"0.13"` in their `Cargo.toml` so that types unify, but no code changes are needed.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context