### PR TITLE
Gate optional dependencies behind feature flags

### DIFF
--- a/crates/rmcp/src/lib.rs
+++ b/crates/rmcp/src/lib.rs
@@ -24,7 +24,9 @@ pub use service::{RoleClient, serve_client};
 pub use service::{RoleServer, serve_server};
 
 pub mod handler;
+#[cfg(feature = "server")]
 pub mod task_manager;
+#[cfg(any(feature = "client", feature = "server"))]
 pub mod transport;
 
 // re-export
@@ -32,7 +34,7 @@ pub mod transport;
 pub use pastey::paste;
 #[cfg(all(feature = "macros", feature = "server"))]
 pub use rmcp_macros::*;
-#[cfg(any(feature = "macros", feature = "server"))]
+#[cfg(any(feature = "server", feature = "schemars"))]
 pub use schemars;
 #[cfg(feature = "macros")]
 pub use serde;

--- a/crates/rmcp/src/model/capabilities.rs
+++ b/crates/rmcp/src/model/capabilities.rs
@@ -1,5 +1,8 @@
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::collections::BTreeMap;
+#[cfg(any(feature = "server", feature = "macros"))]
+use std::marker::PhantomData;
 
+#[cfg(any(feature = "server", feature = "macros"))]
 use pastey::paste;
 use serde::{Deserialize, Serialize};
 
@@ -300,6 +303,7 @@ pub struct ServerCapabilities {
     pub tasks: Option<TasksCapability>,
 }
 
+#[cfg(any(feature = "server", feature = "macros"))]
 macro_rules! builder {
     ($Target: ident {$($f: ident: $T: ty),* $(,)?}) => {
         paste! {
@@ -405,6 +409,7 @@ macro_rules! builder {
     }
 }
 
+#[cfg(any(feature = "server", feature = "macros"))]
 builder! {
     ServerCapabilities {
         experimental: ExperimentalCapabilities,
@@ -418,6 +423,7 @@ builder! {
     }
 }
 
+#[cfg(any(feature = "server", feature = "macros"))]
 impl<
     const E: bool,
     const EXT: bool,
@@ -436,6 +442,7 @@ impl<
     }
 }
 
+#[cfg(any(feature = "server", feature = "macros"))]
 impl<
     const E: bool,
     const EXT: bool,
@@ -454,6 +461,7 @@ impl<
     }
 }
 
+#[cfg(any(feature = "server", feature = "macros"))]
 impl<
     const E: bool,
     const EXT: bool,
@@ -479,6 +487,7 @@ impl<
     }
 }
 
+#[cfg(any(feature = "server", feature = "macros"))]
 builder! {
     ClientCapabilities{
         experimental: ExperimentalCapabilities,
@@ -490,6 +499,7 @@ builder! {
     }
 }
 
+#[cfg(any(feature = "server", feature = "macros"))]
 impl<const E: bool, const EXT: bool, const S: bool, const EL: bool, const TASKS: bool>
     ClientCapabilitiesBuilder<ClientCapabilitiesBuilderState<E, EXT, true, S, EL, TASKS>>
 {
@@ -501,6 +511,7 @@ impl<const E: bool, const EXT: bool, const S: bool, const EL: bool, const TASKS:
     }
 }
 
+#[cfg(any(feature = "server", feature = "macros"))]
 impl<const E: bool, const EXT: bool, const R: bool, const EL: bool, const TASKS: bool>
     ClientCapabilitiesBuilder<ClientCapabilitiesBuilderState<E, EXT, R, true, EL, TASKS>>
 {
@@ -521,7 +532,7 @@ impl<const E: bool, const EXT: bool, const R: bool, const EL: bool, const TASKS:
     }
 }
 
-#[cfg(feature = "elicitation")]
+#[cfg(all(feature = "elicitation", any(feature = "server", feature = "macros")))]
 impl<const E: bool, const EXT: bool, const R: bool, const S: bool, const TASKS: bool>
     ClientCapabilitiesBuilder<ClientCapabilitiesBuilderState<E, EXT, R, S, true, TASKS>>
 {
@@ -539,6 +550,7 @@ impl<const E: bool, const EXT: bool, const R: bool, const S: bool, const TASKS: 
 }
 
 #[cfg(test)]
+#[cfg(any(feature = "server", feature = "macros"))]
 mod test {
     use super::*;
     #[test]

--- a/crates/rmcp/src/model/tool.rs
+++ b/crates/rmcp/src/model/tool.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
+#[cfg(feature = "server")]
 use schemars::JsonSchema;
 /// Tools represent a routine that a server can execute
 /// Tool calls represent requests from the client to execute one
@@ -240,6 +241,7 @@ impl Tool {
     /// # Panics
     ///
     /// Panics if the generated schema does not have root type "object" as required by MCP specification.
+    #[cfg(feature = "server")]
     pub fn with_output_schema<T: JsonSchema + 'static>(mut self) -> Self {
         let schema = crate::handler::server::tool::schema_for_output::<T>()
             .unwrap_or_else(|e| panic!("Invalid output schema for tool '{}': {}", self.name, e));
@@ -248,6 +250,7 @@ impl Tool {
     }
 
     /// Set the input schema using a type that implements JsonSchema
+    #[cfg(feature = "server")]
     pub fn with_input_schema<T: JsonSchema + 'static>(mut self) -> Self {
         self.input_schema = crate::handler::server::tool::schema_for_type::<T>();
         self

--- a/crates/rmcp/src/service.rs
+++ b/crates/rmcp/src/service.rs
@@ -1,12 +1,14 @@
 use futures::{FutureExt, future::BoxFuture};
 use thiserror::Error;
 
+#[cfg(feature = "server")]
+use crate::model::ServerJsonRpcMessage;
 use crate::{
     error::ErrorData as McpError,
     model::{
         CancelledNotification, CancelledNotificationParam, Extensions, GetExtensions, GetMeta,
         JsonRpcError, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, Meta,
-        NumberOrString, ProgressToken, RequestId, ServerJsonRpcMessage,
+        NumberOrString, ProgressToken, RequestId,
     },
     transport::{DynamicTransportError, IntoTransport, Transport},
 };


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Fixes #625

## Motivation and Context

The crate failed to compile when built without default features because code in the `model`, `task_manager`, and `transport` modules used optional dependencies (`pastey`, `schemars`) and server-only types unconditionally. This adds the missing `#[cfg]` gates so every valid feature combination compiles.

## How Has This Been Tested?

Before:

```sh
$ cargo check -p rmcp --no-default-features -F client
   Compiling rmcp v0.16.0 (/Users/dale.seo/work/rust-sdk/crates/rmcp)
error[E0432]: unresolved import `crate::RoleServer`
  --> crates/rmcp/src/task_manager.rs:10:5
   |
10 |     RoleServer,
   |     ^^^^^^^^^^ no `RoleServer` in the root
   |
note: found an item that was configured out
  --> crates/rmcp/src/lib.rs:24:19
   |
23 | #[cfg(feature = "server")]
   |       ------------------ the item is gated behind the `server` feature
24 | pub use service::{RoleServer, serve_server};
   |                   ^^^^^^^^^^

error[E0432]: unresolved import `schemars`
 --> crates/rmcp/src/model/tool.rs:3:5
  |
3 | use schemars::JsonSchema;
  |     ^^^^^^^^ use of unresolved module or unlinked crate `schemars`
  |
  = help: if you wanted to use a crate named `schemars`, use `cargo add schemars` to add it to your `Cargo.toml`

error[E0432]: unresolved import `pastey`
 --> crates/rmcp/src/model/capabilities.rs:3:5
  |
3 | use pastey::paste;
  |     ^^^^^^ use of unresolved module or unlinked crate `pastey`
  |
  = help: if you wanted to use a crate named `pastey`, use `cargo add pastey` to add it to your `Cargo.toml`

error[E0433]: failed to resolve: could not find `server` in `handler`
   --> crates/rmcp/src/model/tool.rs:244:38
    |
244 |         let schema = crate::handler::server::tool::schema_for_output::<T>()
    |                                      ^^^^^^ could not find `server` in `handler`
    |
note: found an item that was configured out
   --> crates/rmcp/src/handler.rs:4:9
    |
  3 | #[cfg(feature = "server")]
    |       ------------------ the item is gated behind the `server` feature
  4 | pub mod server;
    |         ^^^^^^

error[E0433]: failed to resolve: could not find `server` in `handler`
   --> crates/rmcp/src/model/tool.rs:252:45
    |
252 |         self.input_schema = crate::handler::server::tool::schema_for_type::<T>();
    |                                             ^^^^^^ could not find `server` in `handler`
    |
note: found an item that was configured out
   --> crates/rmcp/src/handler.rs:4:9
    |
  3 | #[cfg(feature = "server")]
    |       ------------------ the item is gated behind the `server` feature
  4 | pub mod server;
    |         ^^^^^^

error[E0412]: cannot find type `ServerCapabilitiesBuilder` in this scope
   --> crates/rmcp/src/model/capabilities.rs:429:3
    |
280 | pub struct ServerCapabilities {
    | ----------------------------- similarly named struct `ServerCapabilities` defined here
...
429 | > ServerCapabilitiesBuilder<ServerCapabilitiesBuilderState<E, EXT, L, C, P, R, true, TASKS>>
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ServerCapabilities`

error[E0412]: cannot find type `ServerCapabilitiesBuilderState` in this scope
   --> crates/rmcp/src/model/capabilities.rs:429:29
    |
429 | > ServerCapabilitiesBuilder<ServerCapabilitiesBuilderState<E, EXT, L, C, P, R, true, TASKS>>
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope

error[E0412]: cannot find type `ServerCapabilitiesBuilder` in this scope
   --> crates/rmcp/src/model/capabilities.rs:447:3
    |
280 | pub struct ServerCapabilities {
    | ----------------------------- similarly named struct `ServerCapabilities` defined here
...
447 | > ServerCapabilitiesBuilder<ServerCapabilitiesBuilderState<E, EXT, L, C, true, R, T, TASKS>>
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ServerCapabilities`

error[E0412]: cannot find type `ServerCapabilitiesBuilderState` in this scope
   --> crates/rmcp/src/model/capabilities.rs:447:29
    |
447 | > ServerCapabilitiesBuilder<ServerCapabilitiesBuilderState<E, EXT, L, C, true, R, T, TASKS>>
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope

error[E0412]: cannot find type `ServerCapabilitiesBuilder` in this scope
   --> crates/rmcp/src/model/capabilities.rs:465:3
    |
280 | pub struct ServerCapabilities {
    | ----------------------------- similarly named struct `ServerCapabilities` defined here
...
465 | > ServerCapabilitiesBuilder<ServerCapabilitiesBuilderState<E, EXT, L, C, P, true, T, TASKS>>
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ServerCapabilities`

error[E0412]: cannot find type `ServerCapabilitiesBuilderState` in this scope
   --> crates/rmcp/src/model/capabilities.rs:465:29
    |
465 | > ServerCapabilitiesBuilder<ServerCapabilitiesBuilderState<E, EXT, L, C, P, true, T, TASKS>>
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope

error[E0412]: cannot find type `ClientCapabilitiesBuilder` in this scope
   --> crates/rmcp/src/model/capabilities.rs:494:5
    |
243 | pub struct ClientCapabilities {
    | ----------------------------- similarly named struct `ClientCapabilities` defined here
...
494 |     ClientCapabilitiesBuilder<ClientCapabilitiesBuilderState<E, EXT, true, S, EL, TASKS>>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ClientCapabilities`

error[E0412]: cannot find type `ClientCapabilitiesBuilderState` in this scope
   --> crates/rmcp/src/model/capabilities.rs:494:31
    |
494 |     ClientCapabilitiesBuilder<ClientCapabilitiesBuilderState<E, EXT, true, S, EL, TASKS>>
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope

error[E0412]: cannot find type `ClientCapabilitiesBuilder` in this scope
   --> crates/rmcp/src/model/capabilities.rs:505:5
    |
243 | pub struct ClientCapabilities {
    | ----------------------------- similarly named struct `ClientCapabilities` defined here
...
505 |     ClientCapabilitiesBuilder<ClientCapabilitiesBuilderState<E, EXT, R, true, EL, TASKS>>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ClientCapabilities`

error[E0412]: cannot find type `ClientCapabilitiesBuilderState` in this scope
   --> crates/rmcp/src/model/capabilities.rs:505:31
    |
505 |     ClientCapabilitiesBuilder<ClientCapabilitiesBuilderState<E, EXT, R, true, EL, TASKS>>
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope

warning: unused import: `marker::PhantomData`
 --> crates/rmcp/src/model/capabilities.rs:1:34
  |
1 | use std::{collections::BTreeMap, marker::PhantomData};
  |                                  ^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `ServerJsonRpcMessage`
 --> crates/rmcp/src/service.rs:9:51
  |
9 |         NumberOrString, ProgressToken, RequestId, ServerJsonRpcMessage,
  |                                                   ^^^^^^^^^^^^^^^^^^^^

Some errors have detailed explanations: E0412, E0432, E0433.
For more information about an error, try `rustc --explain E0412`.
warning: `rmcp` (lib) generated 2 warnings
error: could not compile `rmcp` (lib) due to 15 previous errors; 2 warnings emitted
...
error: could not compile `rmcp` (lib) due to 15 previous errors
```

After:

```
$ cargo check -p rmcp --no-default-features -F client
   Compiling rmcp v0.16.0 (/Users/dale.seo/work/rust-sdk/crates/rmcp)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.51s
```

Also verified that all other feature combinations compile.

## Breaking Changes

None for the common case (default features). Users who were relying on `ServerCapabilitiesBuilder` or `ClientCapabilitiesBuilder` without enabling `server` or `macros` would not have been able to compile before this change either, so the new `cfg` gates only formalize what was already required.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The three files changed:

- **`crates/rmcp/src/lib.rs`** — Gate `task_manager` behind `server`, `transport` behind `client | server`, fix `schemars` re-export to `any(server, schemars)`.
- **`crates/rmcp/src/model/capabilities.rs`** — Gate `pastey` import, `builder!` macro, builder invocations, all builder `impl` blocks, and tests behind `any(server, macros)`.
- **`crates/rmcp/src/model/tool.rs`** — Gate `schemars::JsonSchema` import, `with_output_schema`, and `with_input_schema` behind `server`.
