### PR TITLE
Send and validate MCP-Protocol-Version header on Streamable HTTP transport

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -155,6 +155,15 @@ impl ProtocolVersion {
     pub const V_2024_11_05: Self = Self(Cow::Borrowed("2024-11-05"));
     //  Keep LATEST at 2025-03-26 until full 2025-06-18 compliance and automated testing are in place.
     pub const LATEST: Self = Self::V_2025_03_26;
+
+    /// All protocol versions known to this SDK.
+    pub const KNOWN_VERSIONS: &[Self] =
+        &[Self::V_2024_11_05, Self::V_2025_03_26, Self::V_2025_06_18];
+
+    /// Returns the string representation of this protocol version.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl Serialize for ProtocolVersion {

--- a/crates/rmcp/src/transport/common/auth/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/auth/streamable_http_client.rs
@@ -17,13 +17,14 @@ where
         uri: std::sync::Arc<str>,
         session_id: std::sync::Arc<str>,
         mut auth_token: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
     ) -> Result<(), crate::transport::streamable_http_client::StreamableHttpError<Self::Error>>
     {
         if auth_token.is_none() {
             auth_token = Some(self.get_access_token().await?);
         }
         self.http_client
-            .delete_session(uri, session_id, auth_token)
+            .delete_session(uri, session_id, auth_token, custom_headers)
             .await
     }
 
@@ -33,6 +34,7 @@ where
         session_id: std::sync::Arc<str>,
         last_event_id: Option<String>,
         mut auth_token: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
     ) -> Result<
         futures::stream::BoxStream<'static, Result<sse_stream::Sse, sse_stream::Error>>,
         crate::transport::streamable_http_client::StreamableHttpError<Self::Error>,
@@ -41,7 +43,7 @@ where
             auth_token = Some(self.get_access_token().await?);
         }
         self.http_client
-            .get_stream(uri, session_id, last_event_id, auth_token)
+            .get_stream(uri, session_id, last_event_id, auth_token, custom_headers)
             .await
     }
 


### PR DESCRIPTION
Closes #587

## Motivation and Context

<img width="1458" height="830" alt="2026-02-20 at 17 30 50" src="https://github.com/user-attachments/assets/76adaab2-7468-4a98-a61c-ccaa495f8679" />

The [MCP 2025-06-18 spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#protocol-version-header) requires clients to send an `MCP-Protocol-Version` header containing the negotiated protocol version on every HTTP request after initialization. Servers must return `400 Bad Request` if the header contains an unsupported value. Neither side currently handles this header, which is one of the blockers for 2025-06-18 compliance.

On the client side, the worker now extracts the negotiated version from the `initialize` response and injects it as an `MCP-Protocol-Version` header into every subsequent POST, GET, and DELETE request. On the server side, `StreamableHttpService` validates the header on all non-initialization requests and rejects unsupported values with a 400 response. Requests without the header are accepted for backwards compatibility with older clients, per the spec.

## How Has This Been Tested?

Added integration tests to cover the changes, and all the existing tests are still passing.

## Breaking Changes

The `StreamableHttpClient` trait now requires a `custom_headers: HashMap<HeaderName, HeaderValue>` parameter on `get_stream` and `delete_session`. This is a breaking change for anyone implementing the trait directly, but `post_message` already had this parameter so the update is straightforward. The public `StreamableHttpClientTransport` API is unchanged.

```rust
fn get_stream(
    &self,
    uri: Arc<str>,
    session_id: Arc<str>,
    last_event_id: Option<String>,
    auth_header: Option<String>,
    custom_headers: HashMap<HeaderName, HeaderValue>, // new
) -> ...;

fn delete_session(
    &self,
    uri: Arc<str>,
    session_id: Arc<str>,
    auth_header: Option<String>,
    custom_headers: HashMap<HeaderName, HeaderValue>, // new
) -> ...;
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
