### PR TITLE
fix(auth): current_scopes read to async

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -999,10 +999,10 @@ impl AuthorizationManager {
             .await
             .map_err(|e| AuthError::TokenRefreshFailed(e.to_string()))?;
 
-        let granted_scopes: Vec<String> = token_result
-            .scopes()
-            .map(|scopes| scopes.iter().map(|s| s.to_string()).collect())
-            .unwrap_or_else(|| self.current_scopes.blocking_read().clone());
+        let granted_scopes: Vec<String> = match token_result.scopes() {
+            Some(scopes) => scopes.iter().map(|s| s.to_string()).collect(),
+            None => self.current_scopes.read().await.clone(),
+        };
 
         *self.current_scopes.write().await = granted_scopes.clone();
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
I got a panick when performing token refresh and the token endpoint didn't return scopes. The cause is a call to `blocking_read()` which cannot be called from within a Tokio async runtime. 

Here is the message I received:
```
thread 'tokio-runtime-worker' (67286162) panicked at /Users/glicht/dev/binahm/rust-sdk/crates/rmcp/src/transport/auth.rs:1005:52:
Cannot block the current thread from within a runtime. This happens because a function attempted to block the current thread while the thread is being used to drive asynchronous tasks.
```

Bug seems to have been introduced recently here: https://github.com/modelcontextprotocol/rust-sdk/pull/651 
@wdawson FYI

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested locally with a client which connects to an mcp server which doesn't return scopes. After performing the fix it works fine.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
