### PR TITLE
feat: add default value support to string, number, and integer schemas

### DIFF
--- a/crates/rmcp/src/model/elicitation_schema.rs
+++ b/crates/rmcp/src/model/elicitation_schema.rs
@@ -113,6 +113,10 @@ pub struct StringSchema {
     /// String format - limited to: "email", "uri", "date", "date-time"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<StringFormat>,
+
+    /// Default value
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
 }
 
 impl Default for StringSchema {
@@ -124,6 +128,7 @@ impl Default for StringSchema {
             min_length: None,
             max_length: None,
             format: None,
+            default: None,
         }
     }
 }
@@ -213,6 +218,12 @@ impl StringSchema {
         self.format = Some(format);
         self
     }
+
+    /// Set default value
+    pub fn with_default(mut self, default: impl Into<String>) -> Self {
+        self.default = Some(default.into());
+        self
+    }
 }
 
 // =============================================================================
@@ -246,6 +257,10 @@ pub struct NumberSchema {
     /// Maximum value (inclusive)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum: Option<f64>,
+
+    /// Default value
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<f64>,
 }
 
 impl Default for NumberSchema {
@@ -256,6 +271,7 @@ impl Default for NumberSchema {
             description: None,
             minimum: None,
             maximum: None,
+            default: None,
         }
     }
 }
@@ -307,6 +323,12 @@ impl NumberSchema {
         self.description = Some(description.into());
         self
     }
+
+    /// Set default value
+    pub fn with_default(mut self, default: f64) -> Self {
+        self.default = Some(default);
+        self
+    }
 }
 
 // =============================================================================
@@ -340,6 +362,10 @@ pub struct IntegerSchema {
     /// Maximum value (inclusive)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum: Option<i64>,
+
+    /// Default value
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<i64>,
 }
 
 impl Default for IntegerSchema {
@@ -350,6 +376,7 @@ impl Default for IntegerSchema {
             description: None,
             minimum: None,
             maximum: None,
+            default: None,
         }
     }
 }
@@ -399,6 +426,12 @@ impl IntegerSchema {
     /// Set description
     pub fn description(mut self, description: impl Into<Cow<'static, str>>) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    /// Set default value
+    pub fn with_default(mut self, default: i64) -> Self {
+        self.default = Some(default);
         self
     }
 }

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -1186,6 +1186,14 @@
       "description": "Schema definition for integer properties.\n\nCompliant with MCP 2025-06-18 specification for elicitation schemas.\nSupports only the fields allowed by the MCP spec.",
       "type": "object",
       "properties": {
+        "default": {
+          "description": "Default value",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
         "description": {
           "description": "Human-readable description",
           "type": [
@@ -1763,6 +1771,14 @@
       "description": "Schema definition for number properties (floating-point).\n\nCompliant with MCP 2025-06-18 specification for elicitation schemas.\nSupports only the fields allowed by the MCP spec.",
       "type": "object",
       "properties": {
+        "default": {
+          "description": "Default value",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
         "description": {
           "description": "Human-readable description",
           "type": [
@@ -2869,6 +2885,13 @@
       "description": "Schema definition for string properties.\n\nCompliant with MCP 2025-06-18 specification for elicitation schemas.\nSupports only the fields allowed by the MCP spec:\n- format limited to: \"email\", \"uri\", \"date\", \"date-time\"",
       "type": "object",
       "properties": {
+        "default": {
+          "description": "Default value",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "description": {
           "description": "Human-readable description",
           "type": [

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -1186,6 +1186,14 @@
       "description": "Schema definition for integer properties.\n\nCompliant with MCP 2025-06-18 specification for elicitation schemas.\nSupports only the fields allowed by the MCP spec.",
       "type": "object",
       "properties": {
+        "default": {
+          "description": "Default value",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
         "description": {
           "description": "Human-readable description",
           "type": [
@@ -1763,6 +1771,14 @@
       "description": "Schema definition for number properties (floating-point).\n\nCompliant with MCP 2025-06-18 specification for elicitation schemas.\nSupports only the fields allowed by the MCP spec.",
       "type": "object",
       "properties": {
+        "default": {
+          "description": "Default value",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
         "description": {
           "description": "Human-readable description",
           "type": [
@@ -2869,6 +2885,13 @@
       "description": "Schema definition for string properties.\n\nCompliant with MCP 2025-06-18 specification for elicitation schemas.\nSupports only the fields allowed by the MCP spec:\n- format limited to: \"email\", \"uri\", \"date\", \"date-time\"",
       "type": "object",
       "properties": {
+        "default": {
+          "description": "Default value",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "description": {
           "description": "Human-readable description",
           "type": [


### PR DESCRIPTION
Closes #521

## Motivation and Context

The MCP SEP-1034 specification extends elicitation by adding `default` value support to all primitive schema types. `BooleanSchema` and `EnumSchema` already had `default` fields, but `StringSchema`, `NumberSchema`, and `IntegerSchema` did not. This caused the conformance test `elicitation-sep1034-defaults` to fail because these three types could not deserialize a `default` field from JSON.

## How Has This Been Tested?

Updated the JSON schema snapshot to reflect the new fields

## Breaking Changes

None. All new fields are `Option<T>` with `#[serde(skip_serializing_if = "Option::is_none")]`, so existing code that constructs these schemas without a `default` value continues to work unchanged.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context