### PR TITLE
chore: add #[non_exhaustive] to public enums/structs

### DIFF
--- a/crates/rmcp/src/error.rs
+++ b/crates/rmcp/src/error.rs
@@ -20,6 +20,7 @@ impl std::error::Error for ErrorData {}
 /// This is an unified error type for the errors could be returned by the service.
 #[derive(Debug, thiserror::Error)]
 #[allow(clippy::large_enum_variant)]
+#[non_exhaustive]
 pub enum RmcpError {
     #[cfg(any(feature = "client", feature = "server"))]
     #[error("Service error: {0}")]

--- a/crates/rmcp/src/handler/server/prompt.rs
+++ b/crates/rmcp/src/handler/server/prompt.rs
@@ -107,6 +107,7 @@ impl<T: IntoGetPromptResult> IntoGetPromptResult for Result<T, crate::ErrorData>
 // Future wrapper that automatically handles IntoGetPromptResult conversion
 pin_project_lite::pin_project! {
     #[project = IntoGetPromptResultFutProj]
+    #[non_exhaustive]
     pub enum IntoGetPromptResultFut<F, R> {
         Pending {
             #[pin]

--- a/crates/rmcp/src/handler/server/tool.rs
+++ b/crates/rmcp/src/handler/server/tool.rs
@@ -103,6 +103,7 @@ impl<T: IntoCallToolResult> IntoCallToolResult for Result<T, crate::ErrorData> {
 
 pin_project_lite::pin_project! {
     #[project = IntoCallToolResultFutProj]
+    #[non_exhaustive]
     pub enum IntoCallToolResultFut<F, R> {
         Pending {
             #[pin]

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -197,6 +197,7 @@ impl<'de> Deserialize<'de> for ProtocolVersion {
 /// This is commonly used for request IDs and other identifiers in JSON-RPC
 /// where the specification allows both numeric and string values.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub enum NumberOrString {
     /// A numeric identifier
     Number(i64),
@@ -420,6 +421,17 @@ pub struct JsonRpcRequest<R = Request> {
     pub request: R,
 }
 
+impl<R> JsonRpcRequest<R> {
+    /// Create a new JsonRpcRequest.
+    pub fn new(id: RequestId, request: R) -> Self {
+        Self {
+            jsonrpc: JsonRpcVersion2_0,
+            id,
+            request,
+        }
+    }
+}
+
 type DefaultResponse = JsonObject;
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -435,6 +447,17 @@ pub struct JsonRpcError {
     pub jsonrpc: JsonRpcVersion2_0,
     pub id: RequestId,
     pub error: ErrorData,
+}
+
+impl JsonRpcError {
+    /// Create a new JsonRpcError.
+    pub fn new(id: RequestId, error: ErrorData) -> Self {
+        Self {
+            jsonrpc: JsonRpcVersion2_0,
+            id,
+            error,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -468,7 +491,7 @@ impl ErrorCode {
 ///
 /// This structure follows the JSON-RPC 2.0 specification for error reporting,
 /// providing a standardized way to communicate errors between clients and servers.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ErrorData {
     /// The error type that occurred (using standard JSON-RPC error codes)
@@ -529,6 +552,7 @@ impl ErrorData {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum JsonRpcMessage<Req = Request, Resp = DefaultResponse, Noti = Notification> {
     /// A single request expecting a response
     Request(JsonRpcRequest<Req>),
@@ -758,6 +782,18 @@ pub struct InitializeRequestParams {
     pub client_info: Implementation,
 }
 
+impl InitializeRequestParams {
+    /// Create a new InitializeRequestParams.
+    pub fn new(capabilities: ClientCapabilities, client_info: Implementation) -> Self {
+        Self {
+            meta: None,
+            protocol_version: ProtocolVersion::default(),
+            capabilities,
+            client_info,
+        }
+    }
+}
+
 impl RequestParamsMeta for InitializeRequestParams {
     fn meta(&self) -> Option<&Meta> {
         self.meta.as_ref()
@@ -863,6 +899,18 @@ impl Default for Implementation {
 }
 
 impl Implementation {
+    /// Create a new Implementation.
+    pub fn new(name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            title: None,
+            version: version.into(),
+            description: None,
+            icons: None,
+            website_url: None,
+        }
+    }
+
     pub fn from_build_env() -> Self {
         Implementation {
             name: env!("CARGO_CRATE_NAME").to_owned(),
@@ -919,6 +967,18 @@ pub struct ProgressNotificationParam {
     /// An optional message describing the current progress.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+}
+
+impl ProgressNotificationParam {
+    /// Create a new ProgressNotificationParam with required fields.
+    pub fn new(progress_token: ProgressToken, progress: f64) -> Self {
+        Self {
+            progress_token,
+            progress,
+            total: None,
+            message: None,
+        }
+    }
 }
 
 pub type ProgressNotification = Notification<ProgressNotificationMethod, ProgressNotificationParam>;
@@ -1031,6 +1091,16 @@ pub struct SubscribeRequestParams {
     pub uri: String,
 }
 
+impl SubscribeRequestParams {
+    /// Create a new SubscribeRequestParams.
+    pub fn new(uri: impl Into<String>) -> Self {
+        Self {
+            meta: None,
+            uri: uri.into(),
+        }
+    }
+}
+
 impl RequestParamsMeta for SubscribeRequestParams {
     fn meta(&self) -> Option<&Meta> {
         self.meta.as_ref()
@@ -1085,6 +1155,14 @@ pub struct ResourceUpdatedNotificationParam {
     /// The URI of the resource that was updated
     pub uri: String,
 }
+
+impl ResourceUpdatedNotificationParam {
+    /// Create a new ResourceUpdatedNotificationParam.
+    pub fn new(uri: impl Into<String>) -> Self {
+        Self { uri: uri.into() }
+    }
+}
+
 /// Notification sent when a subscribed resource is updated
 pub type ResourceUpdatedNotification =
     Notification<ResourceUpdatedNotificationMethod, ResourceUpdatedNotificationParam>;
@@ -1104,7 +1182,7 @@ paginated_result!(ListPromptsResult {
 
 const_string!(GetPromptRequestMethod = "prompts/get");
 /// Parameters for retrieving a specific prompt
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct GetPromptRequestParams {
@@ -1148,6 +1226,7 @@ pub type ToolListChangedNotification = NotificationNoParam<ToolListChangedNotifi
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Copy)]
 #[serde(rename_all = "lowercase")] //match spec
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum LoggingLevel {
     Debug,
     Info,
@@ -1202,6 +1281,27 @@ pub struct LoggingMessageNotificationParam {
     /// The actual log data
     pub data: Value,
 }
+
+impl LoggingMessageNotificationParam {
+    /// Create a new LoggingMessageNotificationParam.
+    pub fn new(level: LoggingLevel, data: Value) -> Self {
+        Self {
+            level,
+            logger: None,
+            data,
+        }
+    }
+
+    /// Create with a logger name.
+    pub fn with_logger(level: LoggingLevel, logger: impl Into<String>, data: Value) -> Self {
+        Self {
+            level,
+            logger: Some(logger.into()),
+            data,
+        }
+    }
+}
+
 /// Notification containing a log message
 pub type LoggingMessageNotification =
     Notification<LoggingMessageNotificationMethod, LoggingMessageNotificationParam>;
@@ -1220,6 +1320,7 @@ pub type CreateMessageRequest = Request<CreateMessageRequestMethod, CreateMessag
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum Role {
     /// A human user or client making a request
     User,
@@ -1231,6 +1332,7 @@ pub enum Role {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum ToolChoiceMode {
     /// Model decides whether to use tools
     Auto,
@@ -1279,6 +1381,7 @@ impl ToolChoice {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum SamplingContent<T> {
     Single(T),
     Multiple(Vec<T>),
@@ -1393,6 +1496,7 @@ pub struct SamplingMessage {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum SamplingMessageContent {
     Text(RawTextContent),
     Image(RawImageContent),
@@ -1520,6 +1624,7 @@ impl TryFrom<Content> for SamplingContent<SamplingMessageContent> {
 /// should be provided to the LLM when processing sampling requests.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum ContextInclusion {
     /// Include context from all connected MCP servers
     #[serde(rename = "allServers")]
@@ -1540,7 +1645,7 @@ pub enum ContextInclusion {
 ///
 /// This implements `TaskAugmentedRequestParamsMeta` as sampling requests can be
 /// long-running and may benefit from task-based execution.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CreateMessageRequestParams {
@@ -1599,6 +1704,24 @@ impl TaskAugmentedRequestParamsMeta for CreateMessageRequestParams {
 }
 
 impl CreateMessageRequestParams {
+    /// Create a new CreateMessageRequestParams with required fields.
+    pub fn new(messages: Vec<SamplingMessage>, max_tokens: u32) -> Self {
+        Self {
+            meta: None,
+            task: None,
+            messages,
+            model_preferences: None,
+            system_prompt: None,
+            include_context: None,
+            temperature: None,
+            max_tokens,
+            stop_sequences: None,
+            metadata: None,
+            tools: None,
+            tool_choice: None,
+        }
+    }
+
     /// Validate the sampling request parameters per SEP-1577 spec requirements.
     ///
     /// Checks:
@@ -1704,16 +1827,43 @@ pub struct ModelPreferences {
     pub intelligence_priority: Option<f32>,
 }
 
+impl ModelPreferences {
+    /// Create a new default ModelPreferences.
+    pub fn new() -> Self {
+        Self {
+            hints: None,
+            cost_priority: None,
+            speed_priority: None,
+            intelligence_priority: None,
+        }
+    }
+}
+
+impl Default for ModelPreferences {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A hint suggesting a preferred model name or family.
 ///
 /// Model hints are advisory suggestions that help clients choose appropriate
 /// models. They can be specific model names or general families like "claude" or "gpt".
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ModelHint {
     /// The suggested model name or family identifier
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+}
+
+impl ModelHint {
+    /// Create a new ModelHint with a name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: Some(name.into()),
+        }
+    }
 }
 
 // =============================================================================
@@ -1883,6 +2033,7 @@ pub struct CompleteResult {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum Reference {
     #[serde(rename = "ref/resource")]
     Resource(ResourceReference),
@@ -1999,6 +2150,7 @@ const_string!(ElicitationCompletionNotificationMethod = "notifications/elicitati
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum ElicitationAction {
     /// User accepts the request and provides the requested information
     Accept,
@@ -2110,6 +2262,7 @@ impl TryFrom<CreateElicitationRequestParamDeserializeHelper> for CreateElicitati
     try_from = "CreateElicitationRequestParamDeserializeHelper"
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum CreateElicitationRequestParams {
     #[serde(rename = "form", rename_all = "camelCase")]
     FormElicitationParams {
@@ -2181,16 +2334,43 @@ pub struct CreateElicitationResult {
     pub content: Option<Value>,
 }
 
+impl CreateElicitationResult {
+    /// Create a new CreateElicitationResult.
+    pub fn new(action: ElicitationAction) -> Self {
+        Self {
+            action,
+            content: None,
+        }
+    }
+
+    /// Create with content.
+    pub fn with_content(action: ElicitationAction, content: Value) -> Self {
+        Self {
+            action,
+            content: Some(content),
+        }
+    }
+}
+
 /// Request type for creating an elicitation to gather user input
 pub type CreateElicitationRequest =
     Request<ElicitationCreateRequestMethod, CreateElicitationRequestParams>;
 
 /// Notification parameters for an url elicitation completion notification.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ElicitationResponseNotificationParam {
     pub elicitation_id: String,
+}
+
+impl ElicitationResponseNotificationParam {
+    /// Create a new ElicitationResponseNotificationParam.
+    pub fn new(elicitation_id: impl Into<String>) -> Self {
+        Self {
+            elicitation_id: elicitation_id.into(),
+        }
+    }
 }
 
 /// Notification sent when an url elicitation process is completed.
@@ -2205,7 +2385,7 @@ pub type ElicitationCompletionNotification =
 ///
 /// Contains the content returned by the tool execution and an optional
 /// flag indicating whether the operation resulted in an error.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CallToolResult {
@@ -2337,7 +2517,7 @@ const_string!(CallToolRequestMethod = "tools/call");
 ///
 /// This implements `TaskAugmentedRequestParamsMeta` as tool calls can be
 /// long-running and may benefit from task-based execution.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CallToolRequestParams {
@@ -2399,6 +2579,15 @@ pub struct CreateMessageResult {
 }
 
 impl CreateMessageResult {
+    /// Create a new CreateMessageResult with required fields.
+    pub fn new(message: SamplingMessage, model: String) -> Self {
+        Self {
+            message,
+            model,
+            stop_reason: None,
+        }
+    }
+
     pub const STOP_REASON_END_TURN: &str = "endTurn";
     pub const STOP_REASON_END_SEQUENCE: &str = "stopSequence";
     pub const STOP_REASON_END_MAX_TOKEN: &str = "maxTokens";
@@ -2413,13 +2602,23 @@ impl CreateMessageResult {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct GetPromptResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub messages: Vec<PromptMessage>,
+}
+
+impl GetPromptResult {
+    /// Create a new GetPromptResult with required fields.
+    pub fn new(messages: Vec<PromptMessage>) -> Self {
+        Self {
+            description: None,
+            messages,
+        }
+    }
 }
 
 // =============================================================================

--- a/crates/rmcp/src/model/content.rs
+++ b/crates/rmcp/src/model/content.rs
@@ -38,6 +38,17 @@ pub struct RawEmbeddedResource {
     pub meta: Option<super::Meta>,
     pub resource: ResourceContents,
 }
+
+impl RawEmbeddedResource {
+    /// Create a new RawEmbeddedResource.
+    pub fn new(resource: ResourceContents) -> Self {
+        Self {
+            meta: None,
+            resource,
+        }
+    }
+}
+
 pub type EmbeddedResource = Annotated<RawEmbeddedResource>;
 
 impl EmbeddedResource {
@@ -132,6 +143,7 @@ impl ToolResultContent {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum RawContent {
     Text(RawTextContent),
     Image(RawImageContent),

--- a/crates/rmcp/src/model/elicitation_schema.rs
+++ b/crates/rmcp/src/model/elicitation_schema.rs
@@ -49,6 +49,7 @@ const_string!(ArrayTypeConst = "array");
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum PrimitiveSchema {
     /// Enum property (explicit enum schema)
     Enum(EnumSchema),
@@ -70,6 +71,7 @@ pub enum PrimitiveSchema {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum StringFormat {
     /// Email address format
     Email,
@@ -513,6 +515,16 @@ pub struct ConstTitle {
     pub title: String,
 }
 
+impl ConstTitle {
+    /// Create a new ConstTitle.
+    pub fn new(const_: impl Into<String>, title: impl Into<String>) -> Self {
+        Self {
+            const_: const_.into(),
+            title: title.into(),
+        }
+    }
+}
+
 /// Legacy enum schema, keep for backward compatibility
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -563,10 +575,24 @@ pub struct TitledSingleSelectEnumSchema {
     pub default: Option<String>,
 }
 
+impl TitledSingleSelectEnumSchema {
+    /// Create a new TitledSingleSelectEnumSchema.
+    pub fn new(one_of: Vec<ConstTitle>) -> Self {
+        Self {
+            type_: StringTypeConst,
+            title: None,
+            description: None,
+            one_of,
+            default: None,
+        }
+    }
+}
+
 /// Combined single-select
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum SingleSelectEnumSchema {
     Untitled(UntitledSingleSelectEnumSchema),
     Titled(TitledSingleSelectEnumSchema),
@@ -590,6 +616,13 @@ pub struct TitledItems {
     // Alias "oneOf" for compatibility with schemars
     #[serde(rename = "anyOf", alias = "oneOf")]
     pub any_of: Vec<ConstTitle>,
+}
+
+impl TitledItems {
+    /// Create a new TitledItems.
+    pub fn new(any_of: Vec<ConstTitle>) -> Self {
+        Self { any_of }
+    }
 }
 
 /// Multi-select untitled options
@@ -632,10 +665,26 @@ pub struct TitledMultiSelectEnumSchema {
     pub default: Option<Vec<String>>,
 }
 
+impl TitledMultiSelectEnumSchema {
+    /// Create a new TitledMultiSelectEnumSchema.
+    pub fn new(items: TitledItems) -> Self {
+        Self {
+            type_: ArrayTypeConst,
+            title: None,
+            description: None,
+            min_items: None,
+            max_items: None,
+            items,
+            default: None,
+        }
+    }
+}
+
 /// Multi-select enum options
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum MultiSelectEnumSchema {
     Untitled(UntitledMultiSelectEnumSchema),
     Titled(TitledMultiSelectEnumSchema),
@@ -659,6 +708,7 @@ pub enum MultiSelectEnumSchema {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum EnumSchema {
     Single(SingleSelectEnumSchema),
     Multi(MultiSelectEnumSchema),

--- a/crates/rmcp/src/model/prompt.rs
+++ b/crates/rmcp/src/model/prompt.rs
@@ -7,7 +7,7 @@ use super::{
 };
 
 /// A prompt that can be used to generate text from a model
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Prompt {
@@ -52,7 +52,7 @@ impl Prompt {
 }
 
 /// Represents a prompt argument that can be passed to customize the prompt
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PromptArgument {
     /// The name of the argument
@@ -72,6 +72,7 @@ pub struct PromptArgument {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum PromptMessageRole {
     User,
     Assistant,
@@ -81,6 +82,7 @@ pub enum PromptMessageRole {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum PromptMessageContent {
     /// Plain text content
     Text { text: String },

--- a/crates/rmcp/src/model/resource.rs
+++ b/crates/rmcp/src/model/resource.rs
@@ -58,6 +58,7 @@ pub type ResourceTemplate = Annotated<RawResourceTemplate>;
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum ResourceContents {
     #[serde(rename_all = "camelCase")]
     TextResourceContents {

--- a/crates/rmcp/src/model/task.rs
+++ b/crates/rmcp/src/model/task.rs
@@ -7,6 +7,7 @@ use super::Meta;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum TaskStatus {
     /// The receiver accepted the request and is currently working on it.
     #[default]

--- a/crates/rmcp/src/model/tool.rs
+++ b/crates/rmcp/src/model/tool.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use super::{Icon, JsonObject, Meta};
 
 /// A tool that can be used by a model.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Tool {
@@ -50,6 +50,7 @@ pub struct Tool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
 pub enum TaskSupport {
     /// Clients MUST NOT invoke this tool as a task (default behavior).
     #[default]

--- a/crates/rmcp/src/service.rs
+++ b/crates/rmcp/src/service.rs
@@ -566,6 +566,7 @@ impl RunningServiceCancellationToken {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum QuitReason {
     Cancelled,
     Closed,
@@ -582,6 +583,19 @@ pub struct RequestContext<R: ServiceRole> {
     pub extensions: Extensions,
     /// An interface to fetch the remote client or server
     pub peer: Peer<R>,
+}
+
+impl<R: ServiceRole> RequestContext<R> {
+    /// Create a new RequestContext.
+    pub fn new(id: RequestId, peer: Peer<R>) -> Self {
+        Self {
+            ct: CancellationToken::new(),
+            id,
+            meta: Meta::default(),
+            extensions: Extensions::default(),
+            peer,
+        }
+    }
 }
 
 /// Request execution context

--- a/crates/rmcp/src/service/client.rs
+++ b/crates/rmcp/src/service/client.rs
@@ -25,6 +25,7 @@ use crate::{
 ///
 /// if you want to handle the error, you can use `serve_client_with_ct` or `serve_client` with `Result<RunningService<RoleClient, S>, ClientError>`
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ClientInitializeError {
     #[error("expect initialized response, but received: {0:?}")]
     ExpectedInitResponse(Option<ServerJsonRpcMessage>),

--- a/crates/rmcp/src/service/server.rs
+++ b/crates/rmcp/src/service/server.rs
@@ -47,6 +47,7 @@ impl ServiceRole for RoleServer {
 ///
 /// if you want to handle the error, you can use `serve_server_with_ct` or `serve_server` with `Result<RunningService<RoleServer, S>, ServerError>`
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ServerInitializeError {
     #[error("expect initialized request, but received: {0:?}")]
     ExpectedInitializeRequest(Option<ClientJsonRpcMessage>),
@@ -457,6 +458,7 @@ impl Peer<RoleServer> {
 /// Errors that can occur during typed elicitation operations
 #[cfg(feature = "elicitation")]
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ElicitationError {
     /// The elicitation request failed at the service level
     #[error("Service error: {0}")]
@@ -544,6 +546,7 @@ macro_rules! elicit_safe {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum ElicitationMode {
     Form,
     Url,
@@ -808,6 +811,7 @@ impl Peer<RoleServer> {
     ///     ElicitationAction::Cancel => {
     ///         println!("User cancelled/dismissed the request");
     ///     }
+    ///     _ => {}
     ///  }
     ///  Ok(())
     /// }
@@ -858,6 +862,7 @@ impl Peer<RoleServer> {
     ///     ElicitationAction::Cancel => {
     ///         println!("User cancelled/dismissed the request");
     ///     }
+    ///     _ => {}
     ///  }
     ///  Ok(())
     /// }

--- a/crates/rmcp/src/transport.rs
+++ b/crates/rmcp/src/transport.rs
@@ -148,6 +148,7 @@ where
     fn into_transport(self) -> impl Transport<R, Error = E> + 'static;
 }
 
+#[non_exhaustive]
 pub enum TransportAdapterIdentity {}
 impl<R, T, E> IntoTransport<R, E, TransportAdapterIdentity> for T
 where

--- a/crates/rmcp/src/transport/async_rw.rs
+++ b/crates/rmcp/src/transport/async_rw.rs
@@ -16,6 +16,7 @@ use tokio_util::{
 use super::{IntoTransport, Transport};
 use crate::service::{RxJsonRpcMessage, ServiceRole, TxJsonRpcMessage};
 
+#[non_exhaustive]
 pub enum TransportAdapterAsyncRW {}
 
 impl<Role, R, W> IntoTransport<Role, std::io::Error, TransportAdapterAsyncRW> for (R, W)
@@ -29,6 +30,7 @@ where
     }
 }
 
+#[non_exhaustive]
 pub enum TransportAdapterAsyncCombinedRW {}
 impl<Role, S> IntoTransport<Role, std::io::Error, TransportAdapterAsyncCombinedRW> for S
 where
@@ -277,6 +279,7 @@ fn try_parse_with_compatibility<T: serde::de::DeserializeOwned>(
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum JsonRpcMessageCodecError {
     #[error("max line length exceeded")]
     MaxLineLengthExceeded,

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -240,6 +240,7 @@ impl<C> AuthClient<C> {
 
 /// Auth error
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum AuthError {
     #[error("OAuth authorization required")]
     AuthorizationRequired,
@@ -1600,6 +1601,7 @@ impl AuthorizedHttpClient {
 /// OAuth state machine
 /// Use the OAuthState to manage the OAuth client is more recommend
 /// But also you can use the AuthorizationManager,AuthorizationSession,AuthorizedHttpClient directly
+#[non_exhaustive]
 pub enum OAuthState {
     /// the AuthorizationManager
     Unauthorized(AuthorizationManager),

--- a/crates/rmcp/src/transport/common/client_side_sse.rs
+++ b/crates/rmcp/src/transport/common/client_side_sse.rs
@@ -169,6 +169,7 @@ impl<E: std::error::Error + Send> SseAutoReconnectStream<NeverReconnect<E>> {
 
 pin_project_lite::pin_project! {
     #[project = SseAutoReconnectStreamStateProj]
+    #[non_exhaustive]
     pub enum SseAutoReconnectStreamState<F> {
         Connected {
             #[pin]

--- a/crates/rmcp/src/transport/sink_stream.rs
+++ b/crates/rmcp/src/transport/sink_stream.rs
@@ -50,6 +50,7 @@ where
     }
 }
 
+#[non_exhaustive]
 pub enum TransportAdapterSinkStream {}
 
 impl<Role, Si, St> IntoTransport<Role, Si::Error, TransportAdapterSinkStream> for (Si, St)
@@ -64,6 +65,7 @@ where
     }
 }
 
+#[non_exhaustive]
 pub enum TransportAdapterAsyncCombinedRW {}
 impl<Role, S> IntoTransport<Role, S::Error, TransportAdapterAsyncCombinedRW> for S
 where

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -44,6 +44,7 @@ impl InsufficientScopeError {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum StreamableHttpError<E: std::error::Error + Send + Sync + 'static> {
     #[error("SSE error: {0}")]
     Sse(#[from] SseError),
@@ -81,12 +82,14 @@ pub enum StreamableHttpError<E: std::error::Error + Send + Sync + 'static> {
 }
 
 #[derive(Debug, Clone, Error)]
+#[non_exhaustive]
 pub enum StreamableHttpProtocolError {
     #[error("Missing session id in response")]
     MissingSessionIdInResponse,
 }
 
 #[allow(clippy::large_enum_variant)]
+#[non_exhaustive]
 pub enum StreamableHttpPostResponse {
     Accepted,
     Json(ServerJsonRpcMessage, Option<String>),

--- a/crates/rmcp/src/transport/streamable_http_server/session/local.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/local.rs
@@ -35,6 +35,7 @@ pub struct LocalSessionManager {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum LocalSessionManagerError {
     #[error("Session not found: {0}")]
     SessionNotFound(SessionId),
@@ -148,6 +149,7 @@ impl std::fmt::Display for EventId {
 }
 
 #[derive(Debug, Clone, Error)]
+#[non_exhaustive]
 pub enum EventIdParseError {
     #[error("Invalid index: {0}")]
     InvalidIndex(ParseIntError),
@@ -310,6 +312,7 @@ impl LocalSessionWorker {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SessionError {
     #[error("Invalid request id: {0}")]
     DuplicatedRequestId(HttpRequestId),
@@ -657,6 +660,7 @@ impl LocalSessionWorker {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum SessionEvent {
     ClientMessage {
         message: ClientJsonRpcMessage,
@@ -688,6 +692,7 @@ pub enum SessionEvent {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum SessionQuitReason {
     ServiceTerminated,
     ClientTerminated,
@@ -880,6 +885,7 @@ pub type SessionTransport = WorkerTransport<LocalSessionWorker>;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum LocalSessionWorkerError {
     #[error("transport terminated")]
     TransportTerminated,

--- a/crates/rmcp/src/transport/streamable_http_server/session/never.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/never.rs
@@ -13,6 +13,7 @@ use crate::{
 pub struct ErrorSessionManagementNotSupported;
 #[derive(Debug, Clone, Default)]
 pub struct NeverSessionManager {}
+#[non_exhaustive]
 pub enum NeverTransport {}
 impl Transport<RoleServer> for NeverTransport {
     type Error = ErrorSessionManagementNotSupported;

--- a/crates/rmcp/src/transport/worker.rs
+++ b/crates/rmcp/src/transport/worker.rs
@@ -7,6 +7,7 @@ use super::{IntoTransport, Transport};
 use crate::service::{RxJsonRpcMessage, ServiceRole, TxJsonRpcMessage};
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum WorkerQuitReason<E> {
     #[error("Join error {0}")]
     Join(#[from] tokio::task::JoinError),
@@ -78,6 +79,7 @@ impl Default for WorkerConfig {
         }
     }
 }
+#[non_exhaustive]
 pub enum WorkerAdapter {}
 
 impl<W: Worker> IntoTransport<W::Role, W::Error, WorkerAdapter> for W {

--- a/crates/rmcp/tests/test_elicitation.rs
+++ b/crates/rmcp/tests/test_elicitation.rs
@@ -964,6 +964,7 @@ async fn test_elicitation_actions_compliance() {
                 assert_eq!(json["action"], "cancel");
                 assert!(json.get("content").is_none() || json["content"].is_null());
             }
+            _ => panic!("unexpected elicitation action variant"),
         }
     }
 }
@@ -1581,6 +1582,7 @@ async fn test_elicitation_action_error_mapping() {
                 let error = ElicitationError::UserCancelled;
                 assert!(format!("{}", error).contains("cancelled/dismissed"));
             }
+            _ => panic!("unexpected elicitation action variant"),
         }
     }
 }


### PR DESCRIPTION
In preparation for a 1.0 release, we should use `#[non_exaustive]` for *most* public structs/enums to help reduce backwards-incompatible changes.

It may not be appropriate in every case.

## Motivation and Context
This will prevent clients from writing code that will break and require updates in future versions.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
