### PR TITLE
feat(auth): support returning extra fields from token exchange

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -138,7 +138,7 @@ pub struct StoredAuthorizationState {
 ///
 /// # Accessing extra fields
 ///
-/// Extra fields are available through [`OAuthTokenResponse::extra_fields`], which returns a
+/// Extra fields are available through [`StandardTokenResponse::extra_fields()`], which returns a
 /// reference to this struct. Use the inner map (`.0`) to look up individual fields by name:
 ///
 /// ```rust,ignore
@@ -380,7 +380,7 @@ type OAuthErrorResponse = oauth2::StandardErrorResponse<oauth2::basic::BasicErro
 ///
 /// # Accessing vendor-specific fields
 ///
-/// Call [`extra_fields()`][oauth2::TokenResponse::extra_fields] to obtain a reference to the
+/// Call [`extra_fields()`][OAuthTokenResponse::extra_fields] to obtain a reference to the
 /// [`VendorExtraTokenFields`] wrapper, then index into its inner map.
 pub type OAuthTokenResponse = StandardTokenResponse<VendorExtraTokenFields, BasicTokenType>;
 type OAuthTokenIntrospection =


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Added `VendorExtraTokenFields` to be used with `StandardTokenResponse` to expose any vendor-specific fields the authorization server may have included in the JSON response body for token generation.

`exchange_code_for_token` and `refresh_token` now return a `StandardTokenResponse` which includes any additional fields which might have been sent by the authorization server.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Some vendors return additional fields as part of the token API. I've experienced this specifically with HubSpot MCP Server which includes additional fields in it's response. It wasn't possible to access these fields when calling `exchange_code_for_token`.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested locally with HubSpot's MCP server.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Return type of `exchange_code_for_token` and `refresh_token` has changed and may require code changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
