### PR TITLE
fix: prevent mcp-conformance from being published to crates.io

### DIFF
--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mcp-conformance"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [[bin]]
 name = "conformance-server"


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

I noticed that the Release-plz workflow has been broken since PR #687 was merged. The issue is that `cargo publish` fails when the workflow tries to publish the `mcp-conformance` crate. This PR adds `publish = false` to fix the problem.

## How Has This Been Tested?

- `cargo check -p mcp-conformance` — confirms the crate still compiles
- `cargo publish --dry-run -p mcp-conformance` — confirms it is correctly rejected with `publish = false`

## Breaking Changes

None. The conformance crate is an internal test tool and was never published to crates.io.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The Release-plz PR job on #696 also failed with a 403 Forbidden when trying to create git refs — this was a cascading failure from the broken release state and should resolve once this fix lands.
