### PR TITLE
fix(auth): pass WWW-Authenticate scopes to DCR registration request

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -5,12 +5,11 @@ use std::{
 };
 
 use async_trait::async_trait;
-use oauth2::TokenResponse;
 use oauth2::{
     AsyncHttpClient, AuthType, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken,
     EmptyExtraTokenFields, HttpClientError, HttpRequest, HttpResponse, PkceCodeChallenge,
     PkceCodeVerifier, RedirectUrl, RefreshToken, RequestTokenError, Scope, StandardTokenResponse,
-    TokenUrl,
+    TokenResponse, TokenUrl,
     basic::{BasicClient, BasicTokenType},
 };
 use reqwest::{


### PR DESCRIPTION
## Summary

When an MCP server returns a `401` with `WWW-Authenticate: Bearer scope="read write"`, the scopes are correctly parsed and stored in `AuthorizationManager.www_auth_scopes`, and used for the authorization URL. **However, they are never included in the Dynamic Client Registration (DCR) request.**

Per [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591), the DCR request should include a `scope` field so the authorization server knows what scopes the client intends to use. Servers that enforce scope-matching between registration and authorization reject the flow without this.

### Changes

- Add optional `scope` field to `ClientRegistrationRequest` with `#[serde(skip_serializing_if = "Option::is_none")]` for backward compatibility — servers that don't expect `scope` in DCR won't see it
- Update `register_client()` to accept a `scopes` parameter and include it in the DCR request body and returned `OAuthClientConfig`
- Thread scopes from `AuthorizationSession::new()` into both `register_client()` call sites
- Re-export `oauth2::TokenResponse` trait so downstream consumers (e.g., Goose) can call `.scopes()` on token responses to extract granted scopes
- Add serialization tests verifying the `scope` field is present when `Some` and absent when `None`

## Test plan

- [x] `cargo test -p rmcp --features auth --lib -- client_registration_request` — both new tests pass
- [ ] Connect to an MCP server that returns scopes in `WWW-Authenticate` and verify the DCR request includes the `scope` field (inspect via `RUST_LOG=debug`)
- [ ] Verify backward compatibility: servers that don't expect `scope` in DCR continue to work (field omitted when no scopes)