### PR TITLE
docs(readme): add -p mcp-server-examples to build command

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 1. **Build the Server (Counter Example)**
 
    ```sh
-   cargo build --release --example servers_counter_stdio
+   cargo build --release -p mcp-server-examples --example servers_counter_stdio
    ```
 
    This builds a standard input/output MCP server binary.


### PR DESCRIPTION
docs: modify build command in README

Updated the build command to specify the package for the MCP server examples.

## Motivation and Context
The cargo build --release --example servers_counter_stdio command in the README failed when run from either the workspace root or the examples/ directory. This is because the workspace's default-members only includes crates/rmcp and crates/rmcp-macros, so Cargo cannot resolve the example without an explicit package target. The fix adds -p mcp-server-examples to correctly scope the build command.

## How Has This Been Tested?
Ran the original command (cargo build --release --example servers_counter_stdio) from both the workspace root and examples/ — confirmed it fails with error: no example target named.
Ran the updated command (cargo build --release -p mcp-server-examples --example servers_counter_stdio) from the workspace root — confirmed it builds successfully and produces the binary at target/release/examples/servers_counter_stdio.

## Breaking Changes
NA

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
NA