### PR TITLE
docs: add McpMux to Built with rmcp section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ See [Oauth_support](docs/OAUTH_SUPPORT.md) for details.
 - [spreadsheet-mcp](https://github.com/PSU3D0/spreadsheet-mcp) - Token-efficient MCP server for spreadsheet analysis with automatic region detection, recalculation, screenshot, and editing support for LLM agents
 - [hyper-mcp](https://github.com/hyper-mcp-rs/hyper-mcp) - A fast, secure MCP server that extends its capabilities through WebAssembly (WASM) plugins
 - [rudof-mcp](https://github.com/rudof-project/rudof/tree/master/rudof_mcp) - RDF validation and data processing MCP server with ShEx/SHACL validation, SPARQL queries, and format conversion. Supports stdio and streamable HTTP transports with full MCP capabilities (tools, prompts, resources, logging, completions, tasks)
+- [McpMux](https://github.com/mcpmux/mcp-mux) - Desktop app to configure MCP servers once at McpMux, connect every AI client (Cursor, Claude Desktop, VS Code, Windsurf) through a single encrypted local gateway with Spaces for project organization, FeatureSets to switch toolsets per client, and a built-in server registry
 
 
 ## Development


### PR DESCRIPTION
## Summary
- Adds [McpMux](https://github.com/mcpmux/mcp-mux) to the "Built with `rmcp`" section in README.md
- McpMux is a desktop app and local MCP gateway that lets users configure servers once and connect every AI client through a single encrypted endpoint

## Test plan
- [x] Verify the markdown link and description render correctly
- [x] No code changes, docs-only PR