### PR TITLE
chore: add release-plz config to include conformance server/client in considering changes

### DIFF
--- a/conformance/CHANGELOG.md
+++ b/conformance/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0](https://github.com/modelcontextprotocol/rust-sdk/releases/tag/mcp-conformance-v1.1.0) - 2026-03-05
+
+### Added
+
+- mcp sdk conformance ([#687](https://github.com/modelcontextprotocol/rust-sdk/pull/687))
+
+### Fixed
+
+- conformance syntax changes ([#723](https://github.com/modelcontextprotocol/rust-sdk/pull/723))
+- prevent mcp-conformance from being published to crates.io ([#701](https://github.com/modelcontextprotocol/rust-sdk/pull/701))

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "mcp-conformance"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+license-file = { workspace = true }
+repository = { workspace = true }
 
 [[bin]]
 name = "conformance-server"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,8 @@
+[workspace]
+changelog_update = true
+
+[[package]]
+name = "mcp-conformance"
+git_release_enable = false
+git_tag_enable = false
+changelog_update = true


### PR DESCRIPTION
This makes it so `release-plz` will track and manage the `conformance` server and client as if they were released packages without them actually being published to crates.io