### PR TITLE
fix(rmcp-macros): replace deprecated *Param type aliases with *Params in task_handler

### DIFF
--- a/crates/rmcp-macros/src/lib.rs
+++ b/crates/rmcp-macros/src/lib.rs
@@ -144,7 +144,7 @@ pub fn tool_router(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// impl ServerHandler for MyToolHandler {
 ///        async fn call_tool(
 ///         &self,
-///         request: CallToolRequestParam,
+///         request: CallToolRequestParams,
 ///         context: RequestContext<RoleServer>,
 ///     ) -> Result<CallToolResult, rmcp::ErrorData> {
 ///         let tcc = ToolCallContext::new(self, request, context);
@@ -153,7 +153,7 @@ pub fn tool_router(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 ///     async fn list_tools(
 ///         &self,
-///         _request: Option<PaginatedRequestParam>,
+///         _request: Option<PaginatedRequestParams>,
 ///         _context: RequestContext<RoleServer>,
 ///     ) -> Result<ListToolsResult, rmcp::ErrorData> {
 ///         let items = self.tool_router.list_all();

--- a/crates/rmcp-macros/src/task_handler.rs
+++ b/crates/rmcp-macros/src/task_handler.rs
@@ -33,7 +33,7 @@ pub fn task_handler(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
         let list_fn = quote! {
             async fn list_tasks(
                 &self,
-                _request: Option<rmcp::model::PaginatedRequestParam>,
+                _request: Option<rmcp::model::PaginatedRequestParams>,
                 _: rmcp::service::RequestContext<rmcp::RoleServer>,
             ) -> Result<rmcp::model::ListTasksResult, McpError> {
                 let running_ids = (#processor).lock().await.list_running();
@@ -61,7 +61,7 @@ pub fn task_handler(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
         let enqueue_fn = quote! {
             async fn enqueue_task(
                 &self,
-                request: rmcp::model::CallToolRequestParam,
+                request: rmcp::model::CallToolRequestParams,
                 context: rmcp::service::RequestContext<rmcp::RoleServer>,
             ) -> Result<rmcp::model::CreateTaskResult, McpError> {
                 use rmcp::task_manager::{
@@ -116,7 +116,7 @@ pub fn task_handler(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
         let get_info_fn = quote! {
             async fn get_task_info(
                 &self,
-                request: rmcp::model::GetTaskInfoParam,
+                request: rmcp::model::GetTaskInfoParams,
                 _context: rmcp::service::RequestContext<rmcp::RoleServer>,
             ) -> Result<rmcp::model::GetTaskResult, McpError> {
                 use rmcp::task_manager::current_timestamp;
@@ -176,7 +176,7 @@ pub fn task_handler(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
         let get_result_fn = quote! {
             async fn get_task_result(
                 &self,
-                request: rmcp::model::GetTaskResultParam,
+                request: rmcp::model::GetTaskResultParams,
                 _context: rmcp::service::RequestContext<rmcp::RoleServer>,
             ) -> Result<rmcp::model::GetTaskPayloadResult, McpError> {
                 use std::time::Duration;
@@ -232,7 +232,7 @@ pub fn task_handler(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
         let cancel_fn = quote! {
             async fn cancel_task(
                 &self,
-                request: rmcp::model::CancelTaskParam,
+                request: rmcp::model::CancelTaskParams,
                 _context: rmcp::service::RequestContext<rmcp::RoleServer>,
             ) -> Result<rmcp::model::CancelTaskResult, McpError> {
                 use rmcp::task_manager::current_timestamp;


### PR DESCRIPTION
## Summary

The `#[task_handler]` macro generates code referencing deprecated type aliases (`*Param`) that were renamed to `*Params` in rmcp 0.13.0. This produces 5 deprecation warnings for every downstream crate using the macro:

```
warning: use of deprecated type alias `rmcp::model::PaginatedRequestParam`: Use PaginatedRequestParams instead
warning: use of deprecated type alias `rmcp::model::CallToolRequestParam`: Use CallToolRequestParams instead
warning: use of deprecated type alias `rmcp::model::GetTaskInfoParam`: Use GetTaskInfoParams instead
warning: use of deprecated type alias `rmcp::model::GetTaskResultParam`: Use GetTaskResultParams instead
warning: use of deprecated type alias `rmcp::model::CancelTaskParam`: Use CancelTaskParams instead
```

## Changes

**`crates/rmcp-macros/src/task_handler.rs`** — 5 renames in generated code:
- `PaginatedRequestParam` → `PaginatedRequestParams`
- `CallToolRequestParam` → `CallToolRequestParams`
- `GetTaskInfoParam` → `GetTaskInfoParams`
- `GetTaskResultParam` → `GetTaskResultParams`
- `CancelTaskParam` → `CancelTaskParams`

**`crates/rmcp-macros/src/lib.rs`** — 2 doc example fixes for consistency.

## Impact

Zero functional change — the deprecated aliases resolve to the same types. This only eliminates warnings for downstream consumers.