### PR TITLE
fix: allow deserializing notifications without params field

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -3834,4 +3834,15 @@ mod tests {
         });
         assert_eq!(json_url, expected_url_json);
     }
+
+    #[test]
+    fn notification_without_params_should_deserialize_as_bare_jsonrpc_message() {
+        let payload = b"{\"method\":\"notifications/initialized\",\"jsonrpc\":\"2.0\"}";
+        let result: Result<JsonRpcMessage, _> = serde_json::from_slice(payload);
+        assert!(
+            matches!(result, Ok(JsonRpcMessage::Notification(_))),
+            "Expected Ok(Notification), got: {:?}",
+            result
+        );
+    }
 }

--- a/crates/rmcp/src/model/serde_impl.rs
+++ b/crates/rmcp/src/model/serde_impl.rs
@@ -246,8 +246,19 @@ where
     where
         D: serde::Deserializer<'de>,
     {
-        let body = Proxy::deserialize(deserializer)?;
-        let _meta = body.params._meta.map(|m| m.into_owned());
+        let body = ProxyOptionalParam::<'_, _, R>::deserialize(deserializer)?;
+        let (_meta, params) = match body.params {
+            Some(with_meta) => {
+                let meta = with_meta._meta.map(|m| m.into_owned());
+                (meta, with_meta._rest)
+            }
+            None => {
+                // JSON-RPC 2.0: params is optional. Treat absent params as {}.
+                let empty = serde_json::Value::Object(serde_json::Map::new());
+                let r = R::deserialize(empty).map_err(serde::de::Error::custom)?;
+                (None, r)
+            }
+        };
         let mut extensions = Extensions::new();
         if let Some(meta) = _meta {
             extensions.insert(meta);
@@ -255,7 +266,7 @@ where
         Ok(Notification {
             extensions,
             method: body.method,
-            params: body.params._rest,
+            params,
         })
     }
 }


### PR DESCRIPTION
Fixes #703

## Motivation and Context

The JSON-RPC 2.0 spec makes `params` optional in notifications, but `Notification::deserialize` was using `Proxy`, which requires that field to be present. This led to users getting an untagged enum deserialization error when calling `serde_json::from_slice::<JsonRpcMessage>(&body)` with the bare `JsonRpcMessage` type on notifications that didn't include `params`, like `notifications/initialized`. The typed aliases, such as `ClientJsonRpcMessage`, weren't affected because they go through `NotificationNoParam` for notifications without parameters.

To fix this, we switched `Notification::deserialize` to use the existing `ProxyOptionalParam`. Now, when `params` is missing, it treats it as an empty object `{}` before deserializing into `R`.

## How Has This Been Tested?

Added a regression test

## Breaking Changes

None. This is a pure bug fix. Previously failing parses now succeed, and all existing behaviour for notifications with `params` is unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
