### PR TITLE
feat: add missing constructors for non-exhaustive model types

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1262,6 +1262,16 @@ pub struct UnsubscribeRequestParams {
     pub uri: String,
 }
 
+impl UnsubscribeRequestParams {
+    /// Creates a new `UnsubscribeRequestParams` for the given URI.
+    pub fn new(uri: impl Into<String>) -> Self {
+        Self {
+            meta: None,
+            uri: uri.into(),
+        }
+    }
+}
+
 impl RequestParamsMeta for UnsubscribeRequestParams {
     fn meta(&self) -> Option<&Meta> {
         self.meta.as_ref()
@@ -2354,6 +2364,22 @@ pub struct PromptReference {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+}
+
+impl PromptReference {
+    /// Creates a new `PromptReference` with the given name. `title` defaults to `None`.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            title: None,
+        }
+    }
+
+    /// Sets the human-readable title for this prompt reference.
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
 }
 
 const_string!(CompleteRequestMethod = "completion/complete");


### PR DESCRIPTION
Closes #734

## Motivation and Context

Several `#[non_exhaustive]` structs in `model.rs` were missing public constructors. This made it difficult to create them in downstream crates without using workarounds like `serde_json::from_value`. The affected structs are `Root`, `ListRootsResult`, `UnsubscribeRequestParams`, and `PromptReference`. These are all structs that someone implementing a `ClientHandler` would typically need to create directly, like when implementing `list_roots`.

## How Has This Been Tested?

All tests pass.

## Breaking Changes

None. This is a purely additive change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
