### PR TITLE
fix(auth): redact secrets in Debug output for StoredCredentials and StoredAuthorizationState

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2817,7 +2817,7 @@ mod tests {
     #[test]
     fn test_stored_credentials_debug_redacts_token_response() {
         use oauth2::{AccessToken, basic::BasicTokenType};
-        
+
         use super::{OAuthTokenResponse, StoredCredentials};
 
         let token_response = OAuthTokenResponse::new(


### PR DESCRIPTION
## Summary

Fixes #741.

`StoredCredentials` and `StoredAuthorizationState` both derived `#[derive(Debug)]`, causing secret fields — OAuth access/refresh tokens, PKCE verifiers, and CSRF tokens — to be printed in plaintext via any `{:?}` formatter, including log calls and `anyhow`/`thiserror` error chains.

- Removes `Debug` from the derive macros on both types
- Implements `Debug` manually, printing `[REDACTED]` for sensitive fields and leaving non-secret fields (e.g. `client_id`, `created_at`) visible
- Adds regression tests asserting that `{:?}` formatting does not emit plaintext secrets

## Approach notes

`OAuthTokenResponse` comes from the `oauth2` crate and cannot be wrapped directly, so `StoredCredentials` uses a manual `Debug` impl that redacts the entire `token_response` field.

The `secrecy` crate was considered for `StoredAuthorizationState` (wrapping `pkce_verifier`/`csrf_token` in `SecretString`), but `secrecy` intentionally blocks `Serialize` on `Secret<T>` unless the inner type implements the `SerializableSecret` marker trait — which `String` does not, and orphan rules prevent adding it. Since both types are `Serialize + Deserialize` for use with custom `CredentialStore`/`StateStore` backends, field-type changes would break serialization. Manual `Debug` impls are the correct approach for both types.

## Known scope limitation

The fields `pkce_verifier: String` and `csrf_token: String` on `StoredAuthorizationState` remain `pub`. This fix protects against accidentally formatting the *struct* via `{:?}`, but not against a caller extracting the field and formatting it directly (e.g. `format!("{:?}", state.pkce_verifier)`). This is an inherent limitation of the manual-Debug approach vs. type-level wrapping, and is noted here for reviewer awareness.

## Test plan

- [x] `cargo test -p rmcp --features auth` passes
- [x] `cargo clippy -p rmcp --features auth` clean (pre-existing unused import warning unrelated to this change)
- [x] `test_stored_authorization_state_debug_redacts_secrets` — asserts `{:?}` output does not contain raw verifier/csrf values and does contain `[REDACTED]`
- [x] `test_stored_credentials_debug_redacts_token_response` — asserts `{:?}` output does not contain raw access token and does contain `[REDACTED]`

