### PR TITLE
fix: handle ping requests sent before initialize handshake

### DIFF
--- a/crates/rmcp/src/service/server.rs
+++ b/crates/rmcp/src/service/server.rs
@@ -131,22 +131,6 @@ where
         .ok_or_else(|| ServerInitializeError::ConnectionClosed(context.to_string()))
 }
 
-/// Helper function to expect a request from the stream
-async fn expect_request<T>(
-    transport: &mut T,
-    context: &str,
-) -> Result<(ClientRequest, RequestId), ServerInitializeError>
-where
-    T: Transport<RoleServer>,
-{
-    let msg = expect_next_message(transport, context).await?;
-    let msg_clone = msg.clone();
-    msg.into_request()
-        .ok_or(ServerInitializeError::ExpectedInitializeRequest(Some(
-            msg_clone,
-        )))
-}
-
 pub async fn serve_server_with_ct<S, T, E, A>(
     service: S,
     transport: T,
@@ -177,8 +161,35 @@ where
     let mut transport = transport.into_transport();
     let id_provider = <Arc<AtomicU32RequestIdProvider>>::default();
 
-    // Get initialize request
-    let (request, id) = expect_request(&mut transport, "initialized request").await?;
+    // Get initialize request; the MCP spec permits ping before initialize.
+    // See: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization
+    let (request, id) = loop {
+        let msg = expect_next_message(&mut transport, "initialize request").await?;
+        match msg {
+            ClientJsonRpcMessage::Request(req)
+                if matches!(req.request, ClientRequest::PingRequest(_)) =>
+            {
+                transport
+                    .send(ServerJsonRpcMessage::response(
+                        ServerResult::EmptyResult(EmptyResult {}),
+                        req.id,
+                    ))
+                    .await
+                    .map_err(|error| {
+                        ServerInitializeError::transport::<T>(
+                            error,
+                            "sending pre-init ping response",
+                        )
+                    })?;
+            }
+            ClientJsonRpcMessage::Request(req) => break (req.request, req.id),
+            other => {
+                return Err(ServerInitializeError::ExpectedInitializeRequest(Some(
+                    other,
+                )));
+            }
+        }
+    };
 
     let ClientRequest::InitializeRequest(peer_info) = &request else {
         return Err(ServerInitializeError::ExpectedInitializeRequest(Some(

--- a/crates/rmcp/tests/test_server_initialization.rs
+++ b/crates/rmcp/tests/test_server_initialization.rs
@@ -96,6 +96,47 @@ async fn server_init_succeeds_after_set_level_before_initialized() {
     result.unwrap().cancel().await.unwrap();
 }
 
+// Server responds with EmptyResult to ping received before initialize request.
+#[tokio::test]
+async fn server_init_ping_response_is_empty_result_before_initialize() {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+    let _server = tokio::spawn(async move { TestServer::new().serve(server_transport).await });
+    let mut client = IntoTransport::<rmcp::RoleClient, _, _>::into_transport(client_transport);
+
+    client.send(ping_request(1)).await.unwrap();
+
+    let response = client.receive().await.unwrap();
+    assert!(
+        matches!(
+            response,
+            ServerJsonRpcMessage::Response(ref r)
+                if matches!(r.result, ServerResult::EmptyResult(_))
+        ),
+        "expected EmptyResult for pre-initialize ping, got: {response:?}"
+    );
+}
+
+// Server initializes successfully when ping is sent before the initialize request.
+#[tokio::test]
+async fn server_init_succeeds_after_ping_before_initialize() {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+    let server_handle =
+        tokio::spawn(async move { TestServer::new().serve(server_transport).await });
+    let mut client = IntoTransport::<rmcp::RoleClient, _, _>::into_transport(client_transport);
+
+    client.send(ping_request(1)).await.unwrap();
+    let _pong = client.receive().await.unwrap();
+    do_initialize(&mut client).await;
+    client.send(initialized_notification()).await.unwrap();
+
+    let result = server_handle.await.unwrap();
+    assert!(
+        result.is_ok(),
+        "server should initialize successfully after pre-initialize ping"
+    );
+    result.unwrap().cancel().await.unwrap();
+}
+
 // Server responds with EmptyResult to ping received before initialized.
 #[tokio::test]
 async fn server_init_ping_response_is_empty_result() {


### PR DESCRIPTION
Closes #488

## Motivation and Context

<img width="1456" height="136" alt="2026-03-11 at 09 29 26" src="https://github.com/user-attachments/assets/4cd67739-0992-42bc-9d02-77e417c40717" />

The MCP spec [explicitly permits](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization) clients to send `ping` before the `initialize` request, but the Rust SDK was rejecting any such message with an `ExpectedInitializeRequest` error. This caused cross-SDK incompatibility with the TypeScript SDK, which probes connectivity with a ping before starting the handshake.

## How Has This Been Tested?

Two new integration tests were added.

## Breaking Changes

None. The server now accepts an additional valid message sequence that was previously rejected in error.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed