### PR TITLE
fix: default CallToolResult content to empty vec on missing field

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -2697,6 +2697,7 @@ pub type ElicitationCompletionNotification =
 #[non_exhaustive]
 pub struct CallToolResult {
     /// The content returned by the tool (text, images, etc.)
+    #[serde(default)]
     pub content: Vec<Content>,
     /// An optional JSON object that represents the structured result of the tool call
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3247,16 +3248,16 @@ ts_union!(
     | ListResourcesResult
     | ListResourceTemplatesResult
     | ReadResourceResult
-    | CallToolResult
     | ListToolsResult
     | CreateElicitationResult
-    | EmptyResult
     | CreateTaskResult
     | ListTasksResult
     | GetTaskResult
     | CancelTaskResult
-    | CustomResult
+    | CallToolResult
     | GetTaskPayloadResult
+    | EmptyResult
+    | CustomResult
     ;
 );
 

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -388,6 +388,7 @@
         "content": {
           "description": "The content returned by the tool (text, images, etc.)",
           "type": "array",
+          "default": [],
           "items": {
             "$ref": "#/definitions/Annotated"
           }
@@ -402,10 +403,7 @@
         "structuredContent": {
           "description": "An optional JSON object that represents the structured result of the tool call"
         }
-      },
-      "required": [
-        "content"
-      ]
+      }
     },
     "CancelTaskResult": {
       "description": "Response to a `tasks/cancel` request.\n\nPer spec, `CancelTaskResult = allOf[Result, Task]` — same shape as `GetTaskResult`.",
@@ -2814,16 +2812,10 @@
           "$ref": "#/definitions/ReadResourceResult"
         },
         {
-          "$ref": "#/definitions/CallToolResult"
-        },
-        {
           "$ref": "#/definitions/ListToolsResult"
         },
         {
           "$ref": "#/definitions/CreateElicitationResult"
-        },
-        {
-          "$ref": "#/definitions/EmptyObject"
         },
         {
           "$ref": "#/definitions/CreateTaskResult"
@@ -2838,10 +2830,16 @@
           "$ref": "#/definitions/CancelTaskResult"
         },
         {
-          "$ref": "#/definitions/CustomResult"
+          "$ref": "#/definitions/CallToolResult"
         },
         {
           "$ref": "#/definitions/GetTaskPayloadResult"
+        },
+        {
+          "$ref": "#/definitions/EmptyObject"
+        },
+        {
+          "$ref": "#/definitions/CustomResult"
         }
       ]
     },

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -388,6 +388,7 @@
         "content": {
           "description": "The content returned by the tool (text, images, etc.)",
           "type": "array",
+          "default": [],
           "items": {
             "$ref": "#/definitions/Annotated"
           }
@@ -402,10 +403,7 @@
         "structuredContent": {
           "description": "An optional JSON object that represents the structured result of the tool call"
         }
-      },
-      "required": [
-        "content"
-      ]
+      }
     },
     "CancelTaskResult": {
       "description": "Response to a `tasks/cancel` request.\n\nPer spec, `CancelTaskResult = allOf[Result, Task]` — same shape as `GetTaskResult`.",
@@ -2814,16 +2812,10 @@
           "$ref": "#/definitions/ReadResourceResult"
         },
         {
-          "$ref": "#/definitions/CallToolResult"
-        },
-        {
           "$ref": "#/definitions/ListToolsResult"
         },
         {
           "$ref": "#/definitions/CreateElicitationResult"
-        },
-        {
-          "$ref": "#/definitions/EmptyObject"
         },
         {
           "$ref": "#/definitions/CreateTaskResult"
@@ -2838,10 +2830,16 @@
           "$ref": "#/definitions/CancelTaskResult"
         },
         {
-          "$ref": "#/definitions/CustomResult"
+          "$ref": "#/definitions/CallToolResult"
         },
         {
           "$ref": "#/definitions/GetTaskPayloadResult"
+        },
+        {
+          "$ref": "#/definitions/EmptyObject"
+        },
+        {
+          "$ref": "#/definitions/CustomResult"
         }
       ]
     },

--- a/crates/rmcp/tests/test_structured_output.rs
+++ b/crates/rmcp/tests/test_structured_output.rs
@@ -298,18 +298,20 @@ async fn test_empty_content_array_with_is_error() {
     assert_eq!(result.is_error, Some(false));
 }
 
-#[tokio::test]
-async fn test_missing_content_is_rejected() {
+#[test]
+fn test_missing_content_defaults_to_empty() {
     let raw = json!({ "isError": false });
-    let result: Result<CallToolResult, _> = serde_json::from_value(raw);
-    assert!(result.is_err());
+    let result: CallToolResult = serde_json::from_value(raw).unwrap();
+    assert!(result.content.is_empty());
+    assert_eq!(result.is_error, Some(false));
 }
 
-#[tokio::test]
-async fn test_missing_content_with_structured_content_is_rejected() {
+#[test]
+fn test_missing_content_with_structured_content_deserializes() {
     let raw = json!({ "structuredContent": {"key": "value"}, "isError": false });
-    let result: Result<CallToolResult, _> = serde_json::from_value(raw);
-    assert!(result.is_err());
+    let result: CallToolResult = serde_json::from_value(raw).unwrap();
+    assert!(result.content.is_empty());
+    assert_eq!(result.structured_content.unwrap()["key"], "value");
 }
 
 #[tokio::test]
@@ -332,4 +334,14 @@ async fn test_empty_content_roundtrip() {
     assert_eq!(v["content"], json!([]));
     let deserialized: CallToolResult = serde_json::from_value(v).unwrap();
     assert_eq!(deserialized, result);
+}
+
+#[test]
+fn test_call_tool_result_deserialize_without_content() {
+    let json = json!({
+        "structuredContent": {"message": "Hello"}
+    });
+    let result: CallToolResult = serde_json::from_value(json).unwrap();
+    assert!(result.content.is_empty());
+    assert!(result.structured_content.is_some());
 }


### PR DESCRIPTION
Closes #750.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

This PR restores lenient deserialization by adds `#[serde(default)]` to the `content` field of the `CallToolResult` construct.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Existing and new tests cover the change.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None. This is strictly more permissive. JSON payloads that previously deserialized successfully continue to work identically. Only payloads that previously failed (missing `content`) now succeed.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
