### PR TITLE
fix: use cfg-gated Send+Sync supertraits to avoid semver break

### DIFF
--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -4,8 +4,7 @@ use crate::{
     error::ErrorData as McpError,
     model::{TaskSupport, *},
     service::{
-        MaybeSend, MaybeSendFuture, NotificationContext, RequestContext, RoleServer, Service,
-        ServiceRole,
+        MaybeSendFuture, NotificationContext, RequestContext, RoleServer, Service, ServiceRole,
     },
 };
 
@@ -161,214 +160,226 @@ impl<H: ServerHandler> Service<RoleServer> for H {
     }
 }
 
-#[allow(unused_variables)]
-#[allow(
-    private_bounds,
-    reason = "MaybeSend is a sealed conditional Send + Sync alias"
-)]
-pub trait ServerHandler: Sized + MaybeSend + 'static {
-    fn enqueue_task(
-        &self,
-        _request: CallToolRequestParams,
-        _context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<CreateTaskResult, McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Err(McpError::internal_error(
-            "Task processing not implemented".to_string(),
-            None,
-        )))
-    }
-    fn ping(
-        &self,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<(), McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Ok(()))
-    }
-    // handle requests
-    fn initialize(
-        &self,
-        request: InitializeRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<InitializeResult, McpError>> + MaybeSendFuture + '_ {
-        if context.peer.peer_info().is_none() {
-            context.peer.set_peer_info(request);
+macro_rules! server_handler_methods {
+    () => {
+        fn enqueue_task(
+            &self,
+            _request: CallToolRequestParams,
+            _context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<CreateTaskResult, McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Err(McpError::internal_error(
+                "Task processing not implemented".to_string(),
+                None,
+            )))
         }
-        std::future::ready(Ok(self.get_info()))
-    }
-    fn complete(
-        &self,
-        request: CompleteRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<CompleteResult, McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Ok(CompleteResult::default()))
-    }
-    fn set_level(
-        &self,
-        request: SetLevelRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<(), McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Err(McpError::method_not_found::<SetLevelRequestMethod>()))
-    }
-    fn get_prompt(
-        &self,
-        request: GetPromptRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<GetPromptResult, McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Err(McpError::method_not_found::<GetPromptRequestMethod>()))
-    }
-    fn list_prompts(
-        &self,
-        request: Option<PaginatedRequestParams>,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<ListPromptsResult, McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Ok(ListPromptsResult::default()))
-    }
-    fn list_resources(
-        &self,
-        request: Option<PaginatedRequestParams>,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<ListResourcesResult, McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Ok(ListResourcesResult::default()))
-    }
-    fn list_resource_templates(
-        &self,
-        request: Option<PaginatedRequestParams>,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<ListResourceTemplatesResult, McpError>> + MaybeSendFuture + '_
-    {
-        std::future::ready(Ok(ListResourceTemplatesResult::default()))
-    }
-    fn read_resource(
-        &self,
-        request: ReadResourceRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<ReadResourceResult, McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Err(
-            McpError::method_not_found::<ReadResourceRequestMethod>(),
-        ))
-    }
-    fn subscribe(
-        &self,
-        request: SubscribeRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<(), McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Err(McpError::method_not_found::<SubscribeRequestMethod>()))
-    }
-    fn unsubscribe(
-        &self,
-        request: UnsubscribeRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<(), McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Err(McpError::method_not_found::<UnsubscribeRequestMethod>()))
-    }
-    fn call_tool(
-        &self,
-        request: CallToolRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<CallToolResult, McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Err(McpError::method_not_found::<CallToolRequestMethod>()))
-    }
-    fn list_tools(
-        &self,
-        request: Option<PaginatedRequestParams>,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<ListToolsResult, McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Ok(ListToolsResult::default()))
-    }
-    /// Get a tool definition by name.
-    ///
-    /// The default implementation returns `None`, which bypasses validation.
-    /// When using `#[tool_handler]`, this method is automatically implemented.
-    fn get_tool(&self, _name: &str) -> Option<Tool> {
-        None
-    }
-    fn on_custom_request(
-        &self,
-        request: CustomRequest,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<CustomResult, McpError>> + MaybeSendFuture + '_ {
-        let CustomRequest { method, .. } = request;
-        let _ = context;
-        std::future::ready(Err(McpError::new(
-            ErrorCode::METHOD_NOT_FOUND,
-            method,
-            None,
-        )))
-    }
+        fn ping(
+            &self,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<(), McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Ok(()))
+        }
+        // handle requests
+        fn initialize(
+            &self,
+            request: InitializeRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<InitializeResult, McpError>> + MaybeSendFuture + '_ {
+            if context.peer.peer_info().is_none() {
+                context.peer.set_peer_info(request);
+            }
+            std::future::ready(Ok(self.get_info()))
+        }
+        fn complete(
+            &self,
+            request: CompleteRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<CompleteResult, McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Ok(CompleteResult::default()))
+        }
+        fn set_level(
+            &self,
+            request: SetLevelRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<(), McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Err(McpError::method_not_found::<SetLevelRequestMethod>()))
+        }
+        fn get_prompt(
+            &self,
+            request: GetPromptRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<GetPromptResult, McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Err(McpError::method_not_found::<GetPromptRequestMethod>()))
+        }
+        fn list_prompts(
+            &self,
+            request: Option<PaginatedRequestParams>,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<ListPromptsResult, McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Ok(ListPromptsResult::default()))
+        }
+        fn list_resources(
+            &self,
+            request: Option<PaginatedRequestParams>,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<ListResourcesResult, McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Ok(ListResourcesResult::default()))
+        }
+        fn list_resource_templates(
+            &self,
+            request: Option<PaginatedRequestParams>,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<ListResourceTemplatesResult, McpError>>
+               + MaybeSendFuture
+               + '_ {
+            std::future::ready(Ok(ListResourceTemplatesResult::default()))
+        }
+        fn read_resource(
+            &self,
+            request: ReadResourceRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<ReadResourceResult, McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Err(
+                McpError::method_not_found::<ReadResourceRequestMethod>(),
+            ))
+        }
+        fn subscribe(
+            &self,
+            request: SubscribeRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<(), McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Err(McpError::method_not_found::<SubscribeRequestMethod>()))
+        }
+        fn unsubscribe(
+            &self,
+            request: UnsubscribeRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<(), McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Err(
+                McpError::method_not_found::<UnsubscribeRequestMethod>(),
+            ))
+        }
+        fn call_tool(
+            &self,
+            request: CallToolRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<CallToolResult, McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Err(McpError::method_not_found::<CallToolRequestMethod>()))
+        }
+        fn list_tools(
+            &self,
+            request: Option<PaginatedRequestParams>,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<ListToolsResult, McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Ok(ListToolsResult::default()))
+        }
+        /// Get a tool definition by name.
+        ///
+        /// The default implementation returns `None`, which bypasses validation.
+        /// When using `#[tool_handler]`, this method is automatically implemented.
+        fn get_tool(&self, _name: &str) -> Option<Tool> {
+            None
+        }
+        fn on_custom_request(
+            &self,
+            request: CustomRequest,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<CustomResult, McpError>> + MaybeSendFuture + '_ {
+            let CustomRequest { method, .. } = request;
+            let _ = context;
+            std::future::ready(Err(McpError::new(
+                ErrorCode::METHOD_NOT_FOUND,
+                method,
+                None,
+            )))
+        }
 
-    fn on_cancelled(
-        &self,
-        notification: CancelledNotificationParam,
-        context: NotificationContext<RoleServer>,
-    ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
-        std::future::ready(())
-    }
-    fn on_progress(
-        &self,
-        notification: ProgressNotificationParam,
-        context: NotificationContext<RoleServer>,
-    ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
-        std::future::ready(())
-    }
-    fn on_initialized(
-        &self,
-        context: NotificationContext<RoleServer>,
-    ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
-        tracing::info!("client initialized");
-        std::future::ready(())
-    }
-    fn on_roots_list_changed(
-        &self,
-        context: NotificationContext<RoleServer>,
-    ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
-        std::future::ready(())
-    }
-    fn on_custom_notification(
-        &self,
-        notification: CustomNotification,
-        context: NotificationContext<RoleServer>,
-    ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
-        let _ = (notification, context);
-        std::future::ready(())
-    }
+        fn on_cancelled(
+            &self,
+            notification: CancelledNotificationParam,
+            context: NotificationContext<RoleServer>,
+        ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
+            std::future::ready(())
+        }
+        fn on_progress(
+            &self,
+            notification: ProgressNotificationParam,
+            context: NotificationContext<RoleServer>,
+        ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
+            std::future::ready(())
+        }
+        fn on_initialized(
+            &self,
+            context: NotificationContext<RoleServer>,
+        ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
+            tracing::info!("client initialized");
+            std::future::ready(())
+        }
+        fn on_roots_list_changed(
+            &self,
+            context: NotificationContext<RoleServer>,
+        ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
+            std::future::ready(())
+        }
+        fn on_custom_notification(
+            &self,
+            notification: CustomNotification,
+            context: NotificationContext<RoleServer>,
+        ) -> impl Future<Output = ()> + MaybeSendFuture + '_ {
+            let _ = (notification, context);
+            std::future::ready(())
+        }
 
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::default()
-    }
+        fn get_info(&self) -> ServerInfo {
+            ServerInfo::default()
+        }
 
-    fn list_tasks(
-        &self,
-        request: Option<PaginatedRequestParams>,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<ListTasksResult, McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Err(McpError::method_not_found::<ListTasksMethod>()))
-    }
+        fn list_tasks(
+            &self,
+            request: Option<PaginatedRequestParams>,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<ListTasksResult, McpError>> + MaybeSendFuture + '_ {
+            std::future::ready(Err(McpError::method_not_found::<ListTasksMethod>()))
+        }
 
-    fn get_task_info(
-        &self,
-        request: GetTaskInfoParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<GetTaskResult, McpError>> + MaybeSendFuture + '_ {
-        let _ = (request, context);
-        std::future::ready(Err(McpError::method_not_found::<GetTaskInfoMethod>()))
-    }
+        fn get_task_info(
+            &self,
+            request: GetTaskInfoParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<GetTaskResult, McpError>> + MaybeSendFuture + '_ {
+            let _ = (request, context);
+            std::future::ready(Err(McpError::method_not_found::<GetTaskInfoMethod>()))
+        }
 
-    fn get_task_result(
-        &self,
-        request: GetTaskResultParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<GetTaskPayloadResult, McpError>> + MaybeSendFuture + '_ {
-        let _ = (request, context);
-        std::future::ready(Err(McpError::method_not_found::<GetTaskResultMethod>()))
-    }
+        fn get_task_result(
+            &self,
+            request: GetTaskResultParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<GetTaskPayloadResult, McpError>> + MaybeSendFuture + '_ {
+            let _ = (request, context);
+            std::future::ready(Err(McpError::method_not_found::<GetTaskResultMethod>()))
+        }
 
-    fn cancel_task(
-        &self,
-        request: CancelTaskParams,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<CancelTaskResult, McpError>> + MaybeSendFuture + '_ {
-        let _ = (request, context);
-        std::future::ready(Err(McpError::method_not_found::<CancelTaskMethod>()))
-    }
+        fn cancel_task(
+            &self,
+            request: CancelTaskParams,
+            context: RequestContext<RoleServer>,
+        ) -> impl Future<Output = Result<CancelTaskResult, McpError>> + MaybeSendFuture + '_ {
+            let _ = (request, context);
+            std::future::ready(Err(McpError::method_not_found::<CancelTaskMethod>()))
+        }
+    };
+}
+
+#[allow(unused_variables)]
+#[cfg(not(feature = "local"))]
+pub trait ServerHandler: Sized + Send + Sync + 'static {
+    server_handler_methods!();
+}
+
+#[allow(unused_variables)]
+#[cfg(feature = "local")]
+pub trait ServerHandler: Sized + 'static {
+    server_handler_methods!();
 }
 
 macro_rules! impl_server_handler_for_wrapper {

--- a/crates/rmcp/src/service.rs
+++ b/crates/rmcp/src/service.rs
@@ -128,11 +128,23 @@ pub type RxJsonRpcMessage<R> = JsonRpcMessage<
     <R as ServiceRole>::PeerNot,
 >;
 
-#[allow(
-    private_bounds,
-    reason = "MaybeSend is a sealed conditional Send + Sync alias"
-)]
-pub trait Service<R: ServiceRole>: MaybeSend + 'static {
+#[cfg(not(feature = "local"))]
+pub trait Service<R: ServiceRole>: Send + Sync + 'static {
+    fn handle_request(
+        &self,
+        request: R::PeerReq,
+        context: RequestContext<R>,
+    ) -> impl Future<Output = Result<R::Resp, McpError>> + MaybeSendFuture + '_;
+    fn handle_notification(
+        &self,
+        notification: R::PeerNot,
+        context: NotificationContext<R>,
+    ) -> impl Future<Output = Result<(), McpError>> + MaybeSendFuture + '_;
+    fn get_info(&self) -> R::Info;
+}
+
+#[cfg(feature = "local")]
+pub trait Service<R: ServiceRole>: 'static {
     fn handle_request(
         &self,
         request: R::PeerReq,
@@ -197,11 +209,23 @@ impl<R: ServiceRole> Service<R> for Box<dyn DynService<R>> {
     }
 }
 
-#[allow(
-    private_bounds,
-    reason = "MaybeSend is a sealed conditional Send + Sync alias"
-)]
-pub trait DynService<R: ServiceRole>: MaybeSend {
+#[cfg(not(feature = "local"))]
+pub trait DynService<R: ServiceRole>: Send + Sync {
+    fn handle_request(
+        &self,
+        request: R::PeerReq,
+        context: RequestContext<R>,
+    ) -> MaybeBoxFuture<'_, Result<R::Resp, McpError>>;
+    fn handle_notification(
+        &self,
+        notification: R::PeerNot,
+        context: NotificationContext<R>,
+    ) -> MaybeBoxFuture<'_, Result<(), McpError>>;
+    fn get_info(&self) -> R::Info;
+}
+
+#[cfg(feature = "local")]
+pub trait DynService<R: ServiceRole> {
     fn handle_request(
         &self,
         request: R::PeerReq,


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

PR #740 replaced `Send + Sync` supertraits on `Service`, `DynService`, and `ServerHandler` with a conditional `MaybeSend` trait for the `local` feature. This caused release-plz to treat it as a breaking change and propose a 2.0.0 bump in PR #747.

Without the `local` feature, the public API is unchanged as `MaybeSend` is equivalent to `Send + Sync`. This PR makes that more explicit by using `cfg`-gated trait definitions that keep the original `Send + Sync` supertraits when `local` is not enabled. A `server_handler_methods!()` macro shares the method bodies to avoid duplication.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

- Before

```
❯ cargo semver-checks --package rmcp --default-features
    Building rmcp v1.2.0 (current)
       Built [   1.217s] (current)
     Parsing rmcp v1.2.0 (current)
      Parsed [   0.017s] (current)
     Parsing rmcp v1.2.0 (baseline, cached)
      Parsed [   0.017s] (baseline)
    Checking rmcp v1.2.0 -> v1.2.0 (no change; assume patch)
     Checked [   0.029s] 221 checks: 220 pass, 1 fail, 0 warn, 24 skip

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait rmcp::handler::server::ServerHandler gained MaybeSend in file /Users/dale.seo/dale/rust-sdk/crates/rmcp/src/handler/server.rs:169
  trait rmcp::ServerHandler gained MaybeSend in file /Users/dale.seo/dale/rust-sdk/crates/rmcp/src/handler/server.rs:169
  trait rmcp::service::DynService gained MaybeSend in file /Users/dale.seo/dale/rust-sdk/crates/rmcp/src/service.rs:204
  trait rmcp::service::Service gained MaybeSend in file /Users/dale.seo/dale/rust-sdk/crates/rmcp/src/service.rs:135
  trait rmcp::Service gained MaybeSend in file /Users/dale.seo/dale/rust-sdk/crates/rmcp/src/service.rs:135

     Summary semver requires new major version: 1 major and 0 minor checks failed
    Finished [   1.577s] rmcp
```

- After

```
❯ cargo semver-checks --package rmcp --default-features
    Building rmcp v1.2.0 (current)
       Built [   2.125s] (current)
     Parsing rmcp v1.2.0 (current)
      Parsed [   0.017s] (current)
     Parsing rmcp v1.2.0 (baseline, cached)
      Parsed [   0.018s] (baseline)
    Checking rmcp v1.2.0 -> v1.2.0 (no change; assume patch)
     Checked [   0.031s] 221 checks: 221 pass, 24 skip
     Summary no semver update required
    Finished [   2.858s] rmcp
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
