### PR TITLE
fix: remove default type param from StreamableHttpService

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -185,7 +185,7 @@ fn validate_protocol_version_header(headers: &http::HeaderMap) -> Result<(), Box
 ///     # todo!()
 /// }
 /// ```
-pub struct StreamableHttpService<S, M = super::session::local::LocalSessionManager> {
+pub struct StreamableHttpService<S, M> {
     pub config: StreamableHttpServerConfig,
     session_manager: Arc<M>,
     service_factory: Arc<dyn Fn() -> Result<S, std::io::Error> + Send + Sync>,


### PR DESCRIPTION
Fixes #756

## Motivation and Context

This PR removes the default type param from `StreamableHttpService<S, M>` so that Rust can infer `M` from the constructor arguments, allowing any `SessionManager` implementation to work.

## How Has This Been Tested?

All existing tests pass.

## Breaking Changes

No. Every existing usage either explicitly specifies both type parameters or lets the compiler infer `M` from the constructor argument.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
