### PR TITLE
chore: run all tests in ci without "local" feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,41 @@ jobs:
 
       - name: Run tests
         run: cargo test --all-features
-  
+
+  test-no-local:
+    name: Run Tests (no local feature)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # install nodejs
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Create venv for python
+        run: uv venv
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run tests without local feature
+        run: |
+          FEATURES=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '[.packages[] | select(.name == "rmcp") | .features | keys[]
+                      | select(startswith("__") | not)
+                      | select(. != "local")] | join(",")')
+          cargo test -p rmcp --features "$FEATURES"
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -10,6 +10,15 @@ fix: fmt
     
 test:
     cargo test --all-features
+    if command -v jq > /dev/null 2>&1; then \
+      FEATURES=$(cargo metadata --no-deps --format-version 1 \
+        | jq -r '[.packages[] | select(.name == "rmcp") | .features | keys[] \
+                  | select(startswith("__") | not) \
+                  | select(. != "local")] | join(",")') && \
+      cargo test -p rmcp --features "$FEATURES"; \
+    else \
+      echo "warning: jq not found, skipping non-local feature tests"; \
+    fi
 
 cov:
     cargo llvm-cov --lcov --output-path {{justfile_directory()}}/target/llvm-cov-target/coverage.lcov


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
There are many tests that don't run when "local" feature is enabled. These tests were not being run in CI as the tests job runs with all features including "local" and many tests have `not(feature = "local")` gate which means they don't run with `--all-features` flag.

Added an additional job:  `Run Tests (no local feature)` which runs all tests without the local feature.

There is one tests that is failing: `test_custom_client_request_reaches_server`. That needs to be fixed.

Local feature was added [here](https://github.com/modelcontextprotocol/rust-sdk/pull/740) during this PR  

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Runs in CI

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Chore

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
