### PR TITLE
ci: add semver check job and disable release-plz semver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,24 @@ jobs:
       - name: Run cargo-audit
         run: cargo audit
 
+  semver:
+    name: Semver Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-semver-checks
+        run: cargo install cargo-semver-checks@0.46.0
+
+      # Run with --default-features to avoid false positives
+      - name: Check semver (rmcp)
+        run: cargo semver-checks --package rmcp --default-features
+
   doc:
     name: Generate Documentation
     runs-on: ubuntu-latest

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,5 @@
+[[package]]
+name = "rmcp"
+# Non-default features can cause false-positive semver breaks.
+# A separate CI job handles semver checking instead.
+semver_check = false


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

Follow-up to #757. release-plz runs its semver analysis with all features enabled, which includes the `local` feature. Since `local` intentionally changes the API surface (relaxing Send + Sync bounds), this causes false-positive breaking-change detections and forces a major version bump (see #747).

This PR disables release-plz's built-in semver check via `release-plz.toml` and adds a dedicated CI job that runs `cargo semver-checks --default-features` instead. This way, real breaking changes in the default API are still caught in CI, while the intentional `local` feature changes don't trigger false alarms.

There's an open issue to support feature selection in release-plz (https://github.com/release-plz/release-plz/issues/2291), which would make this workaround unnecessary.

## How Has This Been Tested?

- Before

```sh
❯ release-plz update
2026-03-21T22:47:22.117639Z  INFO release-plz config file not found, using default configuration
2026-03-21T22:47:22.170966Z  INFO downloading packages from cargo registry crates.io
    Updating crates.io index
2026-03-21T22:47:23.236402Z  INFO determining next version for rmcp-macros 1.2.0
2026-03-21T22:47:23.329625Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpnB5alv/rust-sdk/crates/rmcp-macros
2026-03-21T22:47:23.467754Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpnB5alv/rust-sdk/crates/rmcp-macros
2026-03-21T22:47:23.637035Z  INFO determining next version for rmcp 1.2.0
2026-03-21T22:47:23.739673Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpnB5alv/rust-sdk/crates/rmcp
2026-03-21T22:47:23.869127Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpnB5alv/rust-sdk/crates/rmcp
2026-03-21T22:47:23.995122Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpnB5alv/rust-sdk/crates/rmcp
2026-03-21T22:47:24.120005Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpnB5alv/rust-sdk/crates/rmcp
2026-03-21T22:47:24.244825Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpnB5alv/rust-sdk/crates/rmcp
2026-03-21T22:47:24.369571Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpnB5alv/rust-sdk/crates/rmcp
2026-03-21T22:47:24.499764Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpnB5alv/rust-sdk/crates/rmcp
2026-03-21T22:47:24.633546Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpnB5alv/rust-sdk/crates/rmcp
2026-03-21T22:47:25.223515Z  INFO Checking API compatibility with cargo-semver-checks...
2026-03-21T22:48:02.265882Z  INFO rmcp-macros: next version is 2.0.0
2026-03-21T22:48:02.267297Z  INFO rmcp: next version is 2.0.0 (⚠️ API breaking changes)

* `rmcp-macros`: 1.2.0 -> 2.0.0
* `rmcp`: 1.2.0 -> 2.0.0 (⚠️ API breaking changes)
```

- After

```sh
❯ release-plz update
2026-03-21T22:46:27.915372Z  INFO using release-plz config file release-plz.toml
2026-03-21T22:46:27.962563Z  WARN no upstream configured for branch ci/semver-check-config
2026-03-21T22:46:27.978997Z  INFO downloading packages from cargo registry crates.io
    Updating crates.io index
2026-03-21T22:46:28.966033Z  WARN no upstream configured for branch ci/semver-check-config
2026-03-21T22:46:29.011790Z  INFO determining next version for rmcp-macros 1.2.0
2026-03-21T22:46:29.111822Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpqW4bwn/rust-sdk/crates/rmcp-macros
2026-03-21T22:46:29.247878Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpqW4bwn/rust-sdk/crates/rmcp-macros
2026-03-21T22:46:29.413410Z  INFO determining next version for rmcp 1.2.0
2026-03-21T22:46:29.510939Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpqW4bwn/rust-sdk/crates/rmcp
2026-03-21T22:46:29.641886Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpqW4bwn/rust-sdk/crates/rmcp
2026-03-21T22:46:29.777040Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpqW4bwn/rust-sdk/crates/rmcp
2026-03-21T22:46:29.903724Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpqW4bwn/rust-sdk/crates/rmcp
2026-03-21T22:46:30.029825Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpqW4bwn/rust-sdk/crates/rmcp
2026-03-21T22:46:30.157314Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpqW4bwn/rust-sdk/crates/rmcp
2026-03-21T22:46:30.281391Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpqW4bwn/rust-sdk/crates/rmcp
2026-03-21T22:46:30.414393Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpqW4bwn/rust-sdk/crates/rmcp
2026-03-21T22:46:30.592173Z  INFO rmcp-macros: next version is 1.3.0
2026-03-21T22:46:30.593722Z  INFO rmcp: next version is 1.3.0
2026-03-21T22:46:30.951146Z  WARN no upstream configured for branch ci/semver-check-config

* `rmcp-macros`: 1.2.0 -> 1.3.0
* `rmcp`: 1.2.0 -> 1.3.0
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
