### PR TITLE
fix: example clients_everything_stdio

### DIFF
--- a/examples/clients/src/everything_stdio.rs
+++ b/examples/clients/src/everything_stdio.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
         .await?;
     tracing::info!("Prompt - simple: {prompt:#?}");
 
-    // Get complex prompt (returns text & image)
+    // Get prompt with arguments
     let prompt = client
         .get_prompt(
             GetPromptRequestParams::new("args-prompt")


### PR DESCRIPTION
This change fixes #769

## Motivation and Context
Very simple fix that resolves the execution of the example Full-Featured Standard I/O Client (everything_stdio.rs)

## How Has This Been Tested?
Just running the example locally:
Full-Featured Standard I/O Client (everything_stdio.rs)

## Breaking Changes
No

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling (Not required)
- [ ] I have added or updated documentation as needed (not required

## Additional context

