### PR TITLE
fix: prevent CallToolResult from shadowing CustomResult in untagged enum deserialization

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -2691,7 +2691,7 @@ pub type ElicitationCompletionNotification =
 ///
 /// Contains the content returned by the tool execution and an optional
 /// flag indicating whether the operation resulted in an error.
-#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Default, Debug, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
@@ -2708,6 +2708,48 @@ pub struct CallToolResult {
     /// Optional protocol-level metadata for this result
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,
+}
+
+// Custom Deserialize implementation that:
+// 1. Defaults `content` to `[]` when the field is missing (lenient per Postel's law)
+// 2. Requires at least one known field to be present, so that `CallToolResult` doesn't
+//    greedily match arbitrary JSON objects when used inside `#[serde(untagged)]` enums
+//    (e.g. `ServerResult`), which would shadow `CustomResult`.
+impl<'de> Deserialize<'de> for CallToolResult {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Helper {
+            content: Option<Vec<Content>>,
+            structured_content: Option<Value>,
+            is_error: Option<bool>,
+            #[serde(rename = "_meta")]
+            meta: Option<Meta>,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+
+        if helper.content.is_none()
+            && helper.structured_content.is_none()
+            && helper.is_error.is_none()
+            && helper.meta.is_none()
+        {
+            return Err(serde::de::Error::custom(
+                "expected at least one known CallToolResult field \
+                 (content, structuredContent, isError, or _meta)",
+            ));
+        }
+
+        Ok(CallToolResult {
+            content: helper.content.unwrap_or_default(),
+            structured_content: helper.structured_content,
+            is_error: helper.is_error,
+            meta: helper.meta,
+        })
+    }
 }
 
 impl CallToolResult {

--- a/crates/rmcp/src/model/task.rs
+++ b/crates/rmcp/src/model/task.rs
@@ -123,7 +123,7 @@ pub struct GetTaskResult {
 /// (e.g., `CallToolResult` for `tools/call`). This is represented as
 /// an open object. The payload is the original request's result
 /// serialized as a JSON value.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct GetTaskPayloadResult(pub Value);
@@ -132,6 +132,25 @@ impl GetTaskPayloadResult {
     /// Create a new GetTaskPayloadResult with the given value.
     pub fn new(value: Value) -> Self {
         Self(value)
+    }
+}
+
+// Custom Deserialize that always fails, so that `GetTaskPayloadResult` is skipped
+// during `#[serde(untagged)]` enum deserialization (e.g. `ServerResult`).
+// The payload has the same JSON shape as `CustomResult(Value)`, so they are
+// indistinguishable.  `CustomResult` acts as the catch-all instead.
+// `GetTaskPayloadResult` should be constructed programmatically via `::new()`.
+impl<'de> serde::Deserialize<'de> for GetTaskPayloadResult {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Consume the value so the deserializer state stays consistent.
+        serde::de::IgnoredAny::deserialize(deserializer)?;
+        Err(serde::de::Error::custom(
+            "GetTaskPayloadResult cannot be deserialized directly; \
+             use CustomResult as the catch-all",
+        ))
     }
 }
 


### PR DESCRIPTION
## Motivation and Context

After #752 added `#[serde(default)]` to `CallToolResult.content`, all fields became optional. This made `CallToolResult` greedily match any JSON object in the `#[serde(untagged)]` `ServerResult` enum, preventing `CustomResult` from ever being reached. `GetTaskPayloadResult(Value)` had the same problem — both it and `CustomResult` wrap `Value`, so whichever comes first wins.

Fix: replace derived `Deserialize` with custom impls.
- `CallToolResult` now requires at least one known field, still defaults `content` to `[]` when missing.
- `GetTaskPayloadResult` always fails deserialization (indistinguishable from `CustomResult` in JSON; construct via `::new()`).

Discovered via #761 (`test_custom_client_request_reaches_server` failing without the `local` feature).

## How Has This Been Tested?

All the existing tests have passed.

```sh
cargo test --features server,client --test test_custom_request -- --nocapture
cargo test --features server,client --test test_structured_output -- --nocapture
cargo test --all-features
```

Before this fix, the first command panicked:

```sh
---- test_custom_client_request_reaches_server stdout ----

thread 'test_custom_client_request_reaches_server' panicked at crates/rmcp/tests/test_custom_request.rs:82:18:
Expected custom result, got: CallToolResult(CallToolResult { content: [], structured_content: None, is_error: None, meta: None })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_custom_client_request_reaches_server

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

## Breaking Changes

No. `CallToolResult` still accepts all valid payloads (including missing `content`). `GetTaskPayloadResult` can no longer be deserialized from JSON directly — construct via `::new()` instead.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
