### PR TITLE
feat(transport): add which_command for cross-platform executable resolution

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -136,6 +136,9 @@ transport-child-process = [
   "transport-async-rw",
   "tokio/process",
   "dep:process-wrap",
+]
+which-command = [
+  "transport-child-process",
   "dep:which",
 ]
 transport-streamable-http-server = [

--- a/crates/rmcp/src/transport.rs
+++ b/crates/rmcp/src/transport.rs
@@ -83,8 +83,10 @@ pub use worker::WorkerTransport;
 
 #[cfg(feature = "transport-child-process")]
 pub mod child_process;
+#[cfg(feature = "which-command")]
+pub use child_process::which_command;
 #[cfg(feature = "transport-child-process")]
-pub use child_process::{ConfigureCommandExt, TokioChildProcess, which_command};
+pub use child_process::{ConfigureCommandExt, TokioChildProcess};
 
 #[cfg(feature = "transport-io")]
 pub mod io;

--- a/crates/rmcp/src/transport/child_process.rs
+++ b/crates/rmcp/src/transport/child_process.rs
@@ -242,7 +242,7 @@ impl ConfigureCommandExt for tokio::process::Command {
 ///
 /// # Example
 /// ```rust,no_run
-/// use rmcp::transport::child_process::{which_command, ConfigureCommandExt};
+/// use rmcp::transport::{which_command, ConfigureCommandExt};
 ///
 /// # fn example() -> std::io::Result<()> {
 /// let cmd = which_command("npx")?
@@ -252,6 +252,7 @@ impl ConfigureCommandExt for tokio::process::Command {
 /// # Ok(())
 /// # }
 /// ```
+#[cfg(feature = "which-command")]
 pub fn which_command(
     name: impl AsRef<std::ffi::OsStr>,
 ) -> std::io::Result<tokio::process::Command> {
@@ -260,6 +261,7 @@ pub fn which_command(
     Ok(tokio::process::Command::new(resolved))
 }
 
+#[cfg(feature = "which-command")]
 #[cfg(test)]
 mod tests_which {
     #[test]


### PR DESCRIPTION
## Summary

Adds a `which_command()` helper function that resolves executable paths via the [`which`](https://docs.rs/which) crate before constructing a `tokio::process::Command`. This fixes Windows failures where `.cmd` shim scripts (e.g. `npx.cmd`) are not found by `Command::new()` without a fully-qualified path.

**Changes:**
- Added `which_command(name) -> io::Result<Command>` to `child_process.rs`
- Added `which` v7 as an optional dependency, gated behind `transport-child-process` feature
- Re-exported `which_command` from `transport` module
- Added tests for known binary resolution and nonexistent binary error handling

**Usage:**
```rust
use rmcp::transport::{which_command, ConfigureCommandExt};

let cmd = which_command("npx")?
    .configure(|cmd| {
        cmd.arg("-y").arg("@modelcontextprotocol/server-everything");
    });
```

Closes #456