### PR TITLE
ci: use release-plz fork with semver_check_features

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,10 +25,12 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Run release-plz
-        uses: release-plz/action@v0.5
-        with:
-          command: release
+      # Using fork until semver_check_features support is released upstream.
+      # See: https://github.com/release-plz/release-plz/pull/2757
+      - name: Install release-plz from fork
+        run: cargo install --git https://github.com/DaleSeo/release-plz --branch feat/semver-check-features release-plz
+      - name: Run release-plz release
+        run: release-plz release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -51,10 +53,12 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Run release-plz
-        uses: release-plz/action@v0.5
-        with:
-          command: release-pr
+      # Using fork until semver_check_features support is released upstream.
+      # See: https://github.com/release-plz/release-plz/pull/2757
+      - name: Install release-plz from fork
+        run: cargo install --git https://github.com/DaleSeo/release-plz --branch feat/semver-check-features release-plz
+      - name: Run release-plz release-pr
+        run: release-plz release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,5 @@
+[[package]]
+name = "rmcp"
+# Only check default features for semver compatibility.
+# The `local` feature intentionally changes the API surface.
+semver_check_features = ["default"]


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

This PR adds a `release-plz.toml` with `semver_check_features = ["default"]` so release-plz only checks the default feature set for semver compatibility, and updates the workflow to install release-plz from a fork that supports this config option. Once upstream ships https://github.com/release-plz/release-plz/pull/2757, we can switch back to the official action.

## How Has This Been Tested?

Install release-plz from the fork that implements `semver_check_features`:

```
cargo +stable install --git https://github.com/DaleSeo/release-plz --branch feat/semver-check-features release-plz
```

Then run `release-plz update -p rmcp` in the rust-sdk repo:

```
❯ release-plz update
2026-03-25T20:55:01.903559Z  INFO using release-plz config file release-plz.toml
2026-03-25T20:55:01.931376Z  WARN no upstream configured for branch ci/release-plz-fork
2026-03-25T20:55:01.943701Z  INFO downloading packages from cargo registry crates.io
    Updating crates.io index
2026-03-25T20:55:03.111154Z  WARN no upstream configured for branch ci/release-plz-fork
2026-03-25T20:55:03.156279Z  INFO determining next version for rmcp-macros 1.2.0
2026-03-25T20:55:03.264296Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpWHZ4uy/rust-sdk/crates/rmcp-macros
2026-03-25T20:55:03.412205Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpWHZ4uy/rust-sdk/crates/rmcp-macros
2026-03-25T20:55:03.590865Z  INFO determining next version for rmcp 1.2.0
2026-03-25T20:55:03.699220Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpWHZ4uy/rust-sdk/crates/rmcp
2026-03-25T20:55:03.834641Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpWHZ4uy/rust-sdk/crates/rmcp
2026-03-25T20:55:03.969380Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpWHZ4uy/rust-sdk/crates/rmcp
2026-03-25T20:55:04.102573Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpWHZ4uy/rust-sdk/crates/rmcp
2026-03-25T20:55:04.235126Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpWHZ4uy/rust-sdk/crates/rmcp
2026-03-25T20:55:04.365835Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpWHZ4uy/rust-sdk/crates/rmcp
2026-03-25T20:55:04.506730Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpWHZ4uy/rust-sdk/crates/rmcp
2026-03-25T20:55:04.648640Z  INFO Getting packaged files for crate at /var/folders/v2/5j2zr9qs7c76ph0yxn53d_9r0000gp/T/.tmpWHZ4uy/rust-sdk/crates/rmcp
2026-03-25T20:55:04.845396Z  INFO Checking API compatibility with cargo-semver-checks...
2026-03-25T20:55:19.511118Z  INFO rmcp-macros: next version is 1.3.0
2026-03-25T20:55:19.513573Z  INFO rmcp: next version is 1.3.0 (✓ API compatible changes)
2026-03-25T20:55:19.891889Z  WARN no upstream configured for branch ci/release-plz-fork

* `rmcp-macros`: 1.2.0 -> 1.3.0
* `rmcp`: 1.2.0 -> 1.3.0 (✓ API compatible changes)
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
