### PR TITLE
feat(auth): add StoredCredentials::new() constructor

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -84,6 +84,23 @@ impl std::fmt::Debug for StoredCredentials {
     }
 }
 
+impl StoredCredentials {
+    /// Create a new `StoredCredentials` instance.
+    pub fn new(
+        client_id: String,
+        token_response: Option<OAuthTokenResponse>,
+        granted_scopes: Vec<String>,
+        token_received_at: Option<u64>,
+    ) -> Self {
+        Self {
+            client_id,
+            token_response,
+            granted_scopes,
+            token_received_at,
+        }
+    }
+}
+
 /// Trait for storing and retrieving OAuth2 credentials
 ///
 /// Implementations of this trait can provide custom storage backends


### PR DESCRIPTION
## Summary

- Add a `new()` constructor to `StoredCredentials`

`StoredCredentials` was marked `#[non_exhaustive]` in #715 / #768, but unlike other types in that sweep (e.g. `OAuthClientConfig`), it didn't get a constructor. External crates implementing `CredentialStore` that need to construct `StoredCredentials` in their `save()` path currently have to resort to a serde JSON roundtrip, which turns compile-time field mismatches into silent runtime failures.

Fixes #777

## Test plan

- `just check` passes
- `just test` passes — all existing tests unaffected (they construct `StoredCredentials` with struct literals inside the crate, which still works)