### PR TITLE
fix: default session keep_alive to 5 minutes

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/session/local.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/local.rs
@@ -1069,19 +1069,30 @@ impl Worker for LocalSessionWorker {
 pub struct SessionConfig {
     /// the capacity of the channel for the session. Default is 16.
     pub channel_capacity: usize,
-    /// if set, the session will be closed after this duration of inactivity.
+    /// The session will be closed after this duration of inactivity.
+    ///
+    /// This serves as a safety net for cleaning up sessions whose HTTP
+    /// connections have silently dropped (e.g., due to an HTTP/2
+    /// `RST_STREAM`). Without a timeout, such sessions become zombies:
+    /// the session worker keeps running indefinitely because the session
+    /// handle's sender is still held in the session manager, preventing
+    /// the worker's event channel from closing.
+    ///
+    /// Defaults to 5 minutes. Set to `None` to disable (not recommended
+    /// for long-running servers behind proxies).
     pub keep_alive: Option<Duration>,
 }
 
 impl SessionConfig {
     pub const DEFAULT_CHANNEL_CAPACITY: usize = 16;
+    pub const DEFAULT_KEEP_ALIVE: Duration = Duration::from_secs(300);
 }
 
 impl Default for SessionConfig {
     fn default() -> Self {
         Self {
             channel_capacity: Self::DEFAULT_CHANNEL_CAPACITY,
-            keep_alive: None,
+            keep_alive: Some(Self::DEFAULT_KEEP_ALIVE),
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

When an HTTP/2 connection silently drops (e.g., an Envoy sidecar sending RST_STREAM with NO_ERROR), the `LocalSessionManager` still holds the session handle, keeping the worker's event channel open. The session worker never detects the disconnect and runs indefinitely as a zombie. Over time these zombies accumulate and can block servers that iterate over sessions during notifications, eventually causing the server to become unresponsive.

This changes the default `SessionConfig::keep_alive` from `None` (infinite) to 5 minutes. After 5 minutes of inactivity, the session worker exits, the transport closes, and downstream servers can detect the peer as closed. Users can still set `keep_alive: None` to restore the old behavior if needed.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

2. Verify the default is applied by checking the `SessionConfig::default()` value:

```rust
use rmcp::transport::streamable_http_server::session::local::SessionConfig;
let config = SessionConfig::default();
assert_eq!(config.keep_alive, Some(std::time::Duration::from_secs(300)));
```

3. To manually verify zombie cleanup, start an MCP server using `LocalSessionManager::default()`, initialize a session via curl, Ctrl+C the curl (creating a zombie), and wait 5 minutes. The server logs should show `"keep alive timeout after 300000ms"` and the session worker should exit.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None. No API signatures changed.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
