### PR TITLE
fix: exclude local feature from docs.rs build

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -14,7 +14,32 @@ exhaustive_structs = "warn"
 exhaustive_enums = "warn"
 
 [package.metadata.docs.rs]
-all-features = true
+features = [
+  "auth",
+  "auth-client-credentials-jwt",
+  "base64",
+  "client",
+  "client-side-sse",
+  "elicitation",
+  "macros",
+  "reqwest",
+  "reqwest-native-tls",
+  "reqwest-tls-no-provider",
+  "schemars",
+  "server",
+  "server-side-http",
+  "tower",
+  "transport-async-rw",
+  "transport-child-process",
+  "transport-io",
+  "transport-streamable-http-client",
+  "transport-streamable-http-client-reqwest",
+  "transport-streamable-http-client-unix-socket",
+  "transport-streamable-http-server",
+  "transport-streamable-http-server-session",
+  "transport-worker",
+  "uuid",
+]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]


### PR DESCRIPTION
Fixes #781

`all-features = true` in `[package.metadata.docs.rs]` enables the `local` feature, which relaxes `Send+Sync` bounds. Items gated behind `cfg(not(feature = "local"))` then get excluded from the generated docs on docs.rs.

Replaced `all-features = true` with an explicit feature list that includes everything except `local`. The list was computed from `cargo metadata`, filtering out `local`, `default`, and internal `__`-prefixed features (same approach as the `test-no-local` CI job from #761).