### PR TITLE
refactor: unify IntoCallToolResult Result impls

### DIFF
--- a/crates/rmcp/src/handler/server/tool.rs
+++ b/crates/rmcp/src/handler/server/tool.rs
@@ -85,20 +85,29 @@ impl<T: IntoContents> IntoCallToolResult for T {
     }
 }
 
-impl<T: IntoContents, E: IntoContents> IntoCallToolResult for Result<T, E> {
+impl IntoCallToolResult for CallToolResult {
     fn into_call_tool_result(self) -> Result<CallToolResult, crate::ErrorData> {
-        match self {
-            Ok(value) => Ok(CallToolResult::success(value.into_contents())),
-            Err(error) => Ok(CallToolResult::error(error.into_contents())),
-        }
+        Ok(self)
     }
 }
 
-impl<T: IntoCallToolResult> IntoCallToolResult for Result<T, crate::ErrorData> {
+impl IntoCallToolResult for crate::ErrorData {
+    fn into_call_tool_result(self) -> Result<CallToolResult, crate::ErrorData> {
+        Err(self)
+    }
+}
+
+impl<T: IntoCallToolResult, E: IntoCallToolResult> IntoCallToolResult for Result<T, E> {
     fn into_call_tool_result(self) -> Result<CallToolResult, crate::ErrorData> {
         match self {
             Ok(value) => value.into_call_tool_result(),
-            Err(error) => Err(error),
+            Err(error) => match error.into_call_tool_result() {
+                Ok(mut result) => {
+                    result.is_error = Some(true);
+                    Ok(result)
+                }
+                Err(e) => Err(e),
+            },
         }
     }
 }
@@ -136,12 +145,6 @@ where
             }
             IntoCallToolResultFutProj::Ready { result } => result.poll(cx),
         }
-    }
-}
-
-impl IntoCallToolResult for Result<CallToolResult, crate::ErrorData> {
-    fn into_call_tool_result(self) -> Result<CallToolResult, crate::ErrorData> {
-        self
     }
 }
 

--- a/crates/rmcp/src/handler/server/wrapper/json.rs
+++ b/crates/rmcp/src/handler/server/wrapper/json.rs
@@ -3,10 +3,7 @@ use std::borrow::Cow;
 use schemars::JsonSchema;
 use serde::Serialize;
 
-use crate::{
-    handler::server::tool::IntoCallToolResult,
-    model::{CallToolResult, IntoContents},
-};
+use crate::{handler::server::tool::IntoCallToolResult, model::CallToolResult};
 
 /// Json wrapper for structured output
 ///
@@ -39,17 +36,5 @@ impl<T: Serialize + JsonSchema + 'static> IntoCallToolResult for Json<T> {
         })?;
 
         Ok(CallToolResult::structured(value))
-    }
-}
-
-// Implementation for Result<Json<T>, E>
-impl<T: Serialize + JsonSchema + 'static, E: IntoContents> IntoCallToolResult
-    for Result<Json<T>, E>
-{
-    fn into_call_tool_result(self) -> Result<CallToolResult, crate::ErrorData> {
-        match self {
-            Ok(value) => value.into_call_tool_result(),
-            Err(error) => Ok(CallToolResult::error(error.into_contents())),
-        }
     }
 }


### PR DESCRIPTION
Closes #440. 

## Motivation and Context

This PR replaces the three separate `Result` impls and one `Result<Json<T>, E>` impl with a single unified `impl<T: IntoCallToolResult, E: IntoCallToolResult> IntoCallToolResult for Result<T, E>`. It also adds direct impls for `CallToolResult` and `ErrorData` so they can appear in either position of a `Result`. The `Err` branch forces `is_error = Some(true)` on any `Ok(CallToolResult)` produced by the error side, which maintains backward compatibility and prevents errors from accidentally producing success results.

## How Has This Been Tested?

All existing tests pass.

## Breaking Changes

No. All previously valid return types continue to compile and behave identically. The change only widens the set of accepted error types.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed