### PR TITLE
fix(server): remove initialized notification gate to support Streamable HTTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ __pycache__/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+node_modules/
+.DS_Store

--- a/crates/rmcp/src/service/server.rs
+++ b/crates/rmcp/src/service/server.rs
@@ -53,6 +53,13 @@ pub enum ServerInitializeError {
     #[error("expect initialized request, but received: {0:?}")]
     ExpectedInitializeRequest(Option<ClientJsonRpcMessage>),
 
+    #[deprecated(
+        since = "1.4.0",
+        note = "The server no longer gates on the initialized notification. This variant is never constructed and will be removed in a future major release."
+    )]
+    #[error("expect initialized notification, but received: {0:?}")]
+    ExpectedInitializedNotification(Option<ClientJsonRpcMessage>),
+
     #[error("connection closed: {0}")]
     ConnectionClosed(String),
 

--- a/crates/rmcp/src/service/server.rs
+++ b/crates/rmcp/src/service/server.rs
@@ -53,9 +53,6 @@ pub enum ServerInitializeError {
     #[error("expect initialized request, but received: {0:?}")]
     ExpectedInitializeRequest(Option<ClientJsonRpcMessage>),
 
-    #[error("expect initialized notification, but received: {0:?}")]
-    ExpectedInitializedNotification(Option<ClientJsonRpcMessage>),
-
     #[error("connection closed: {0}")]
     ConnectionClosed(String),
 
@@ -243,49 +240,12 @@ where
             ServerInitializeError::transport::<T>(error, "sending initialize response")
         })?;
 
-    // Wait for initialized notification. The MCP spec permits logging/setLevel and ping
-    // before initialized; VS Code sends setLevel immediately after the initialize response.
-    let notification = loop {
-        let msg = expect_next_message(&mut transport, "initialize notification").await?;
-        match msg {
-            ClientJsonRpcMessage::Notification(n)
-                if matches!(
-                    n.notification,
-                    ClientNotification::InitializedNotification(_)
-                ) =>
-            {
-                break n.notification;
-            }
-            ClientJsonRpcMessage::Request(req)
-                if matches!(
-                    req.request,
-                    ClientRequest::SetLevelRequest(_) | ClientRequest::PingRequest(_)
-                ) =>
-            {
-                transport
-                    .send(ServerJsonRpcMessage::response(
-                        ServerResult::EmptyResult(EmptyResult {}),
-                        req.id,
-                    ))
-                    .await
-                    .map_err(|error| {
-                        ServerInitializeError::transport::<T>(error, "sending pre-init response")
-                    })?;
-            }
-            other => {
-                return Err(ServerInitializeError::ExpectedInitializedNotification(
-                    Some(other),
-                ));
-            }
-        }
-    };
-    let context = NotificationContext {
-        meta: notification.get_meta().clone(),
-        extensions: notification.extensions().clone(),
-        peer: peer.clone(),
-    };
-    let _ = service.handle_notification(notification, context).await;
-    // Continue processing service
+    // Enter the main service loop immediately after sending InitializeResult.
+    // The initialized notification will be handled as a regular notification by serve_inner.
+    // This matches the TypeScript SDK behavior: no init gate, no waiting for initialized.
+    // Streamable HTTP has no ordering guarantee between POSTs, and the MCP spec uses
+    // SHOULD NOT (not MUST NOT) for pre-initialized messages, so any request arriving
+    // before initialized is processed normally.
     Ok(serve_inner(service, transport, peer, peer_rx, ct))
 }
 

--- a/crates/rmcp/tests/test_server_initialization.rs
+++ b/crates/rmcp/tests/test_server_initialization.rs
@@ -6,7 +6,6 @@ use common::handlers::TestServer;
 use rmcp::{
     ServiceExt,
     model::{ClientJsonRpcMessage, ServerJsonRpcMessage, ServerResult},
-    service::ServerInitializeError,
     transport::{IntoTransport, Transport},
 };
 
@@ -54,7 +53,7 @@ async fn do_initialize(client: &mut impl Transport<rmcp::RoleClient>) {
     let _response = client.receive().await.unwrap();
 }
 
-// Server responds with EmptyResult to setLevel received before initialized.
+// Server handles setLevel sent before initialized notification (processed by serve_inner).
 #[tokio::test]
 async fn server_init_set_level_response_is_empty_result() {
     let (server_transport, client_transport) = tokio::io::duplex(4096);
@@ -64,7 +63,14 @@ async fn server_init_set_level_response_is_empty_result() {
     do_initialize(&mut client).await;
     client.send(set_level_request(2)).await.unwrap();
 
-    let response = client.receive().await.unwrap();
+    // The handler may send logging notifications before the response;
+    // skip notifications to find the EmptyResult response.
+    let response = loop {
+        let msg = client.receive().await.unwrap();
+        if matches!(msg, ServerJsonRpcMessage::Response(_)) {
+            break msg;
+        }
+    };
     assert!(
         matches!(
             response,
@@ -85,7 +91,13 @@ async fn server_init_succeeds_after_set_level_before_initialized() {
 
     do_initialize(&mut client).await;
     client.send(set_level_request(2)).await.unwrap();
-    let _response = client.receive().await.unwrap();
+    // Skip notifications until we get the response
+    loop {
+        let msg = client.receive().await.unwrap();
+        if matches!(msg, ServerJsonRpcMessage::Response(_)) {
+            break;
+        }
+    }
     client.send(initialized_notification()).await.unwrap();
 
     let result = server_handle.await.unwrap();
@@ -179,23 +191,66 @@ async fn server_init_succeeds_after_ping_before_initialized() {
     result.unwrap().cancel().await.unwrap();
 }
 
-// Server returns ExpectedInitializedNotification for any other message before initialized.
+// Server buffers tools/list sent before initialized and processes it after initialization.
 #[tokio::test]
-async fn server_init_rejects_unexpected_message_before_initialized() {
+async fn server_init_buffers_request_before_initialized() {
     let (server_transport, client_transport) = tokio::io::duplex(4096);
     let server_handle =
         tokio::spawn(async move { TestServer::new().serve(server_transport).await });
     let mut client = IntoTransport::<rmcp::RoleClient, _, _>::into_transport(client_transport);
 
     do_initialize(&mut client).await;
+    // Send tools/list before initialized notification
     client.send(list_tools_request(2)).await.unwrap();
+    // Now send initialized notification
+    client.send(initialized_notification()).await.unwrap();
+
+    // The buffered tools/list should be processed — expect a response
+    let response = client.receive().await.unwrap();
+    assert!(
+        matches!(response, ServerJsonRpcMessage::Response(_)),
+        "expected response for buffered tools/list, got: {response:?}"
+    );
 
     let result = server_handle.await.unwrap();
     assert!(
-        matches!(
-            result,
-            Err(ServerInitializeError::ExpectedInitializedNotification(_))
-        ),
-        "expected ExpectedInitializedNotification error"
+        result.is_ok(),
+        "server should initialize successfully when buffering pre-init messages"
     );
+    result.unwrap().cancel().await.unwrap();
+}
+
+// Server buffers multiple requests before initialized and processes them in order.
+#[tokio::test]
+async fn server_init_buffers_multiple_requests_before_initialized() {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+    let server_handle =
+        tokio::spawn(async move { TestServer::new().serve(server_transport).await });
+    let mut client = IntoTransport::<rmcp::RoleClient, _, _>::into_transport(client_transport);
+
+    do_initialize(&mut client).await;
+    // Send two requests before initialized
+    client.send(list_tools_request(2)).await.unwrap();
+    client.send(ping_request(3)).await.unwrap();
+    // Now send initialized notification
+    client.send(initialized_notification()).await.unwrap();
+
+    // Both buffered messages should get responses
+    let response1 = client.receive().await.unwrap();
+    let response2 = client.receive().await.unwrap();
+    assert!(
+        matches!(response1, ServerJsonRpcMessage::Response(_)),
+        "expected response for first buffered message, got: {response1:?}"
+    );
+    assert!(
+        matches!(response2, ServerJsonRpcMessage::Response(_)),
+        "expected response for second buffered message, got: {response2:?}"
+    );
+
+    let result = server_handle.await.unwrap();
+    assert!(
+        result.is_ok(),
+        "server should initialize successfully with multiple buffered messages"
+    );
+    result.unwrap().cancel().await.unwrap();
 }


### PR DESCRIPTION
## Summary

- Remove the ~40-line `initialized` notification wait loop that fatally rejected any request arriving before `notifications/initialized`
- Enter `serve_inner` immediately after sending `InitializeResult`, letting the main service loop handle all messages including `initialized`
- Remove the now-unreachable `ExpectedInitializedNotification` error variant from `ServerInitializeError`

## Motivation

Streamable HTTP requires each JSON-RPC message as a separate POST request. The transport layer cannot guarantee delivery order, so `tools/list` can easily arrive before `notifications/initialized`, causing a fatal HTTP 500 error.

The MCP spec uses **SHOULD NOT** (RFC 2119), not **MUST NOT**, for pre-initialized messages — allowing exceptions in specific circumstances like HTTP's lack of ordering guarantees.

This aligns with the TypeScript SDK's behavior, which processes requests immediately after `initialize` without gating on `initialized` (validated in modelcontextprotocol/typescript-sdk#578).

## Test plan

- [x] Updated `server_init_set_level_response_is_empty_result` to handle notifications from `serve_inner` dispatch
- [x] Updated `server_init_succeeds_after_set_level_before_initialized` similarly
- [x] Replaced `server_init_rejects_unexpected_message_before_initialized` with `server_init_buffers_request_before_initialized` — verifies `tools/list` before `initialized` is processed successfully
- [x] Added `server_init_buffers_multiple_requests_before_initialized` — verifies multiple pre-init messages are all processed

Closes #783
