### PR TITLE
fix(http): drain SSE stream for connection reuse

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -339,3 +339,16 @@ required-features = [
 ]
 path = "tests/test_streamable_http_stale_session.rs"
 
+[[test]]
+name = "test_streamable_http_connection_reuse"
+required-features = [
+  "server",
+  "client",
+  "macros",
+  "schemars",
+  "transport-streamable-http-server",
+  "transport-streamable-http-client",
+  "transport-streamable-http-client-reqwest",
+]
+path = "tests/test_streamable_http_connection_reuse.rs"
+

--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -262,7 +262,7 @@ impl StreamableHttpClientTransport<reqwest::Client> {
     /// This method requires the `transport-streamable-http-client-reqwest` feature.
     pub fn from_uri(uri: impl Into<Arc<str>>) -> Self {
         StreamableHttpClientTransport::with_client(
-            reqwest::Client::default(),
+            Self::default_http_client(),
             StreamableHttpClientTransportConfig {
                 uri: uri.into(),
                 auth_header: None,
@@ -277,7 +277,21 @@ impl StreamableHttpClientTransport<reqwest::Client> {
     ///
     /// * `config` - The config to use with this transport
     pub fn from_config(config: StreamableHttpClientTransportConfig) -> Self {
-        StreamableHttpClientTransport::with_client(reqwest::Client::default(), config)
+        StreamableHttpClientTransport::with_client(Self::default_http_client(), config)
+    }
+
+    /// Build the default reqwest client for this transport.
+    ///
+    /// Disables idle connection pooling because POST SSE response bodies
+    /// cannot be fully consumed before the next request starts, causing
+    /// reqwest to stall on pool checkout (~40 ms).  The long-lived GET
+    /// SSE stream already holds its own connection, so there is no
+    /// benefit to pooling POST connections with HTTP/1.1.
+    fn default_http_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .pool_max_idle_per_host(0)
+            .build()
+            .expect("failed to build default reqwest client")
     }
 }
 

--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -262,7 +262,7 @@ impl StreamableHttpClientTransport<reqwest::Client> {
     /// This method requires the `transport-streamable-http-client-reqwest` feature.
     pub fn from_uri(uri: impl Into<Arc<str>>) -> Self {
         StreamableHttpClientTransport::with_client(
-            reqwest::Client::default(),
+            Self::default_http_client(),
             StreamableHttpClientTransportConfig {
                 uri: uri.into(),
                 auth_header: None,
@@ -277,7 +277,19 @@ impl StreamableHttpClientTransport<reqwest::Client> {
     ///
     /// * `config` - The config to use with this transport
     pub fn from_config(config: StreamableHttpClientTransportConfig) -> Self {
-        StreamableHttpClientTransport::with_client(reqwest::Client::default(), config)
+        StreamableHttpClientTransport::with_client(Self::default_http_client(), config)
+    }
+
+    /// Build the default reqwest client for this transport.
+    ///
+    /// Disables idle connection pooling to avoid ~40 ms stalls caused by
+    /// TCP Delayed ACK on Linux when the previous response body was not
+    /// fully consumed before the pool attempts to reuse the connection.
+    fn default_http_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .pool_max_idle_per_host(0)
+            .build()
+            .expect("failed to build default reqwest client")
     }
 }
 

--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -262,7 +262,7 @@ impl StreamableHttpClientTransport<reqwest::Client> {
     /// This method requires the `transport-streamable-http-client-reqwest` feature.
     pub fn from_uri(uri: impl Into<Arc<str>>) -> Self {
         StreamableHttpClientTransport::with_client(
-            Self::default_http_client(),
+            reqwest::Client::default(),
             StreamableHttpClientTransportConfig {
                 uri: uri.into(),
                 auth_header: None,
@@ -277,21 +277,7 @@ impl StreamableHttpClientTransport<reqwest::Client> {
     ///
     /// * `config` - The config to use with this transport
     pub fn from_config(config: StreamableHttpClientTransportConfig) -> Self {
-        StreamableHttpClientTransport::with_client(Self::default_http_client(), config)
-    }
-
-    /// Build the default reqwest client for this transport.
-    ///
-    /// Disables idle connection pooling because POST SSE response bodies
-    /// cannot be fully consumed before the next request starts, causing
-    /// reqwest to stall on pool checkout (~40 ms).  The long-lived GET
-    /// SSE stream already holds its own connection, so there is no
-    /// benefit to pooling POST connections with HTTP/1.1.
-    fn default_http_client() -> reqwest::Client {
-        reqwest::Client::builder()
-            .pool_max_idle_per_host(0)
-            .build()
-            .expect("failed to build default reqwest client")
+        StreamableHttpClientTransport::with_client(reqwest::Client::default(), config)
     }
 }
 

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -282,9 +282,7 @@ impl<C: StreamableHttpClient> StreamableHttpClientWorker<C> {
 
 impl<C: StreamableHttpClient> StreamableHttpClientWorker<C> {
     /// Convert a raw SSE stream into a JSON-RPC message stream without
-    /// reconnection logic.  Used for per-request POST SSE responses where
-    /// we close the stream after the first response and want the underlying
-    /// HTTP connection to be returned to the pool promptly.
+    /// reconnection logic.
     fn raw_sse_to_jsonrpc(
         stream: BoxedSseStream,
     ) -> impl Stream<Item = Result<ServerJsonRpcMessage, StreamableHttpError<C::Error>>> + Send + 'static
@@ -347,11 +345,8 @@ impl<C: StreamableHttpClient> StreamableHttpClientWorker<C> {
             }
             if close_on_response && is_response {
                 tracing::debug!("got response, draining sse stream for connection reuse");
-                // Drain remaining stream bytes so the HTTP/1.1 connection can
-                // be returned to the pool instead of being discarded.  The
-                // server closes the channel shortly after sending the response,
-                // so this normally completes in microseconds on localhost.  The
-                // timeout guards against servers that keep the stream open.
+                // Consume the remaining stream so the HTTP/1.1 connection
+                // returns to the pool cleanly.
                 let _ = tokio::time::timeout(std::time::Duration::from_millis(50), async {
                     while sse_stream.next().await.is_some() {}
                 })
@@ -788,10 +783,6 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                             Ok(())
                         }
                         Ok(StreamableHttpPostResponse::Sse(stream, ..)) => {
-                            // Per-request POST SSE streams use a thin
-                            // adapter instead of SseAutoReconnectStream so
-                            // the stream ends immediately when the server
-                            // closes the channel, enabling connection reuse.
                             streams.spawn(Self::execute_sse_stream(
                                 Self::raw_sse_to_jsonrpc(stream),
                                 sse_worker_tx.clone(),

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -281,6 +281,39 @@ impl<C: StreamableHttpClient> StreamableHttpClientWorker<C> {
 }
 
 impl<C: StreamableHttpClient> StreamableHttpClientWorker<C> {
+    /// Convert a raw SSE stream into a JSON-RPC message stream without
+    /// reconnection logic.  Used for per-request POST SSE responses where
+    /// we close the stream after the first response and want the underlying
+    /// HTTP connection to be returned to the pool promptly.
+    fn raw_sse_to_jsonrpc(
+        stream: BoxedSseStream,
+    ) -> impl Stream<Item = Result<ServerJsonRpcMessage, StreamableHttpError<C::Error>>> + Send + 'static
+    {
+        stream.filter_map(|event| async {
+            match event {
+                Err(e) => Some(Err(StreamableHttpError::Sse(e))),
+                Ok(sse) => {
+                    let is_message =
+                        matches!(sse.event.as_deref(), None | Some("") | Some("message"));
+                    if !is_message {
+                        return None;
+                    }
+                    let data = sse.data?;
+                    if data.trim().is_empty() {
+                        return None;
+                    }
+                    match serde_json::from_str::<ServerJsonRpcMessage>(&data) {
+                        Ok(msg) => Some(Ok(msg)),
+                        Err(e) => {
+                            tracing::debug!("failed to deserialize server message: {e}");
+                            None
+                        }
+                    }
+                }
+            }
+        })
+    }
+
     async fn execute_sse_stream(
         sse_stream: impl Stream<Item = Result<ServerJsonRpcMessage, StreamableHttpError<C::Error>>>
         + Send
@@ -303,14 +336,26 @@ impl<C: StreamableHttpClient> StreamableHttpClientWorker<C> {
             let Some(message) = message.transpose()? else {
                 break;
             };
-            let is_response = matches!(message, ServerJsonRpcMessage::Response(_));
+            let is_response = matches!(
+                message,
+                ServerJsonRpcMessage::Response(_) | ServerJsonRpcMessage::Error(_)
+            );
             let yield_result = sse_worker_tx.send(message).await;
             if yield_result.is_err() {
                 tracing::trace!("streamable http transport worker dropped, exiting");
                 break;
             }
             if close_on_response && is_response {
-                tracing::debug!("got response, closing sse stream");
+                tracing::debug!("got response, draining sse stream for connection reuse");
+                // Drain remaining stream bytes so the HTTP/1.1 connection can
+                // be returned to the pool instead of being discarded.  The
+                // server closes the channel shortly after sending the response,
+                // so this normally completes in microseconds on localhost.  The
+                // timeout guards against servers that keep the stream open.
+                let _ = tokio::time::timeout(std::time::Duration::from_millis(50), async {
+                    while sse_stream.next().await.is_some() {}
+                })
+                .await;
                 break;
             }
         }
@@ -718,38 +763,12 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                                                 Ok(())
                                             }
                                             Ok(StreamableHttpPostResponse::Sse(stream, ..)) => {
-                                                if let Some(sid) = &session_id {
-                                                    let sse_stream = SseAutoReconnectStream::new(
-                                                        stream,
-                                                        StreamableHttpClientReconnect {
-                                                            client: self.client.clone(),
-                                                            session_id: sid.clone(),
-                                                            uri: config.uri.clone(),
-                                                            auth_header: config.auth_header.clone(),
-                                                            custom_headers: protocol_headers
-                                                                .clone(),
-                                                        },
-                                                        self.config.retry_config.clone(),
-                                                    );
-                                                    streams.spawn(Self::execute_sse_stream(
-                                                        sse_stream,
-                                                        sse_worker_tx.clone(),
-                                                        true,
-                                                        transport_task_ct.child_token(),
-                                                    ));
-                                                } else {
-                                                    let sse_stream =
-                                                    SseAutoReconnectStream::never_reconnect(
-                                                        stream,
-                                                        StreamableHttpError::<C::Error>::UnexpectedEndOfStream,
-                                                    );
-                                                    streams.spawn(Self::execute_sse_stream(
-                                                        sse_stream,
-                                                        sse_worker_tx.clone(),
-                                                        true,
-                                                        transport_task_ct.child_token(),
-                                                    ));
-                                                }
+                                                streams.spawn(Self::execute_sse_stream(
+                                                    Self::raw_sse_to_jsonrpc(stream),
+                                                    sse_worker_tx.clone(),
+                                                    true,
+                                                    transport_task_ct.child_token(),
+                                                ));
                                                 tracing::trace!("got new sse stream after re-init");
                                                 Ok(())
                                             }
@@ -769,36 +788,16 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                             Ok(())
                         }
                         Ok(StreamableHttpPostResponse::Sse(stream, ..)) => {
-                            if let Some(session_id) = &session_id {
-                                let sse_stream = SseAutoReconnectStream::new(
-                                    stream,
-                                    StreamableHttpClientReconnect {
-                                        client: self.client.clone(),
-                                        session_id: session_id.clone(),
-                                        uri: config.uri.clone(),
-                                        auth_header: config.auth_header.clone(),
-                                        custom_headers: protocol_headers.clone(),
-                                    },
-                                    self.config.retry_config.clone(),
-                                );
-                                streams.spawn(Self::execute_sse_stream(
-                                    sse_stream,
-                                    sse_worker_tx.clone(),
-                                    true,
-                                    transport_task_ct.child_token(),
-                                ));
-                            } else {
-                                let sse_stream = SseAutoReconnectStream::never_reconnect(
-                                    stream,
-                                    StreamableHttpError::<C::Error>::UnexpectedEndOfStream,
-                                );
-                                streams.spawn(Self::execute_sse_stream(
-                                    sse_stream,
-                                    sse_worker_tx.clone(),
-                                    true,
-                                    transport_task_ct.child_token(),
-                                ));
-                            }
+                            // Per-request POST SSE streams use a thin
+                            // adapter instead of SseAutoReconnectStream so
+                            // the stream ends immediately when the server
+                            // closes the channel, enabling connection reuse.
+                            streams.spawn(Self::execute_sse_stream(
+                                Self::raw_sse_to_jsonrpc(stream),
+                                sse_worker_tx.clone(),
+                                true,
+                                transport_task_ct.child_token(),
+                            ));
                             tracing::trace!("got new sse stream");
                             Ok(())
                         }

--- a/crates/rmcp/src/transport/streamable_http_server/session/local.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/local.rs
@@ -470,7 +470,7 @@ impl LocalSessionWorker {
                 {
                     OutboundChannel::RequestWise {
                         id: *id,
-                        close: false,
+                        close: true,
                     }
                 } else {
                     OutboundChannel::Common
@@ -483,7 +483,7 @@ impl LocalSessionWorker {
                 {
                     OutboundChannel::RequestWise {
                         id: *id,
-                        close: false,
+                        close: true,
                     }
                 } else {
                     OutboundChannel::Common
@@ -501,7 +501,11 @@ impl LocalSessionWorker {
                 if let Some(request_wise) = self.tx_router.get_mut(&id) {
                     request_wise.tx.send(message).await;
                     if close {
-                        self.tx_router.remove(&id);
+                        if let Some(channel) = self.tx_router.remove(&id) {
+                            for resource in channel.resources {
+                                self.resource_router.remove(&resource);
+                            }
+                        }
                     }
                 } else {
                     return Err(SessionError::ChannelClosed(Some(id)));

--- a/crates/rmcp/tests/test_streamable_http_connection_reuse.rs
+++ b/crates/rmcp/tests/test_streamable_http_connection_reuse.rs
@@ -1,9 +1,4 @@
-#![cfg(all(
-    feature = "transport-streamable-http-client",
-    feature = "transport-streamable-http-client-reqwest",
-    feature = "transport-streamable-http-server",
-    not(feature = "local")
-))]
+#![cfg(not(feature = "local"))]
 
 use std::time::Instant;
 
@@ -110,11 +105,7 @@ async fn test_subsequent_tool_calls_reuse_connections() -> anyhow::Result<()> {
         let elapsed = start.elapsed();
         durations.push(elapsed);
 
-        assert!(
-            result.is_error != Some(true),
-            "tool call should succeed, got error: {:?}",
-            result.content
-        );
+        assert!(result.is_error != Some(true));
     }
 
     let _ = client.cancel().await;
@@ -124,14 +115,8 @@ async fn test_subsequent_tool_calls_reuse_connections() -> anyhow::Result<()> {
     // With connection reuse, localhost calls should complete well under 20 ms.
     // Before the fix, they consistently took ~42 ms due to new TCP connections.
     let max_allowed = std::time::Duration::from_millis(20);
-    for (i, d) in durations.iter().enumerate() {
-        assert!(
-            *d < max_allowed,
-            "call {} took {:?}, expected < {:?} (connection reuse may be broken)",
-            i + 1,
-            d,
-            max_allowed,
-        );
+    for d in &durations {
+        assert!(*d < max_allowed);
     }
 
     Ok(())

--- a/crates/rmcp/tests/test_streamable_http_connection_reuse.rs
+++ b/crates/rmcp/tests/test_streamable_http_connection_reuse.rs
@@ -24,11 +24,11 @@ struct SumRequest {
 }
 
 #[derive(Debug, Clone)]
-struct EchoServer {
+struct SumServer {
     tool_router: ToolRouter<Self>,
 }
 
-impl EchoServer {
+impl SumServer {
     fn new() -> Self {
         Self {
             tool_router: Self::tool_router(),
@@ -37,7 +37,7 @@ impl EchoServer {
 }
 
 #[tool_router]
-impl EchoServer {
+impl SumServer {
     #[tool(description = "Sum two numbers")]
     fn sum(&self, Parameters(SumRequest { a, b }): Parameters<SumRequest>) -> String {
         (a + b).to_string()
@@ -45,7 +45,7 @@ impl EchoServer {
 }
 
 #[tool_handler(router = self.tool_router)]
-impl ServerHandler for EchoServer {
+impl ServerHandler for SumServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
     }
@@ -59,14 +59,13 @@ impl ServerHandler for EchoServer {
 async fn test_subsequent_tool_calls_reuse_connections() -> anyhow::Result<()> {
     let ct = CancellationToken::new();
 
-    let service: StreamableHttpService<EchoServer, LocalSessionManager> =
-        StreamableHttpService::new(
-            || Ok(EchoServer::new()),
-            Default::default(),
-            StreamableHttpServerConfig::default()
-                .with_sse_keep_alive(None)
-                .with_cancellation_token(ct.child_token()),
-        );
+    let service: StreamableHttpService<SumServer, LocalSessionManager> = StreamableHttpService::new(
+        || Ok(SumServer::new()),
+        Default::default(),
+        StreamableHttpServerConfig::default()
+            .with_sse_keep_alive(None)
+            .with_cancellation_token(ct.child_token()),
+    );
 
     let router = axum::Router::new().nest_service("/mcp", service);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;

--- a/crates/rmcp/tests/test_streamable_http_connection_reuse.rs
+++ b/crates/rmcp/tests/test_streamable_http_connection_reuse.rs
@@ -1,0 +1,138 @@
+#![cfg(all(
+    feature = "transport-streamable-http-client",
+    feature = "transport-streamable-http-client-reqwest",
+    feature = "transport-streamable-http-server",
+    not(feature = "local")
+))]
+
+use std::time::Instant;
+
+use rmcp::{
+    ServerHandler, ServiceExt,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{CallToolRequestParams, ClientInfo, ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router,
+    transport::{
+        StreamableHttpClientTransport,
+        streamable_http_client::StreamableHttpClientTransportConfig,
+        streamable_http_server::{
+            StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+        },
+    },
+};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct SumRequest {
+    a: i32,
+    b: i32,
+}
+
+#[derive(Debug, Clone)]
+struct EchoServer {
+    tool_router: ToolRouter<Self>,
+}
+
+impl EchoServer {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl EchoServer {
+    #[tool(description = "Sum two numbers")]
+    fn sum(&self, Parameters(SumRequest { a, b }): Parameters<SumRequest>) -> String {
+        (a + b).to_string()
+    }
+}
+
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for EchoServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}
+
+/// Verify that subsequent tool calls do not regress in latency due to
+/// HTTP/1.1 connection pool exhaustion.  Before the fix, each POST SSE
+/// response was dropped without fully consuming the body, preventing
+/// connection reuse and forcing a new TCP connection (~40 ms) per call.
+#[tokio::test]
+async fn test_subsequent_tool_calls_reuse_connections() -> anyhow::Result<()> {
+    let ct = CancellationToken::new();
+
+    let service: StreamableHttpService<EchoServer, LocalSessionManager> =
+        StreamableHttpService::new(
+            || Ok(EchoServer::new()),
+            Default::default(),
+            StreamableHttpServerConfig::default()
+                .with_sse_keep_alive(None)
+                .with_cancellation_token(ct.child_token()),
+        );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+
+    let server_handle = tokio::spawn({
+        let ct = ct.clone();
+        async move {
+            let _ = axum::serve(listener, router)
+                .with_graceful_shutdown(async move { ct.cancelled_owned().await })
+                .await;
+        }
+    });
+
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
+    );
+    let client = ClientInfo::default().serve(transport).await?;
+
+    // Warm up: first call may include one-time setup costs.
+    let args: serde_json::Map<String, serde_json::Value> =
+        serde_json::from_value(serde_json::json!({"a": 1, "b": 2}))?;
+    let _ = client
+        .call_tool(CallToolRequestParams::new("sum").with_arguments(args))
+        .await?;
+
+    // Measure subsequent calls.
+    let mut durations = Vec::new();
+    for i in 0..5i32 {
+        let args: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_value(serde_json::json!({"a": i, "b": i + 1}))?;
+        let start = Instant::now();
+        let result = client
+            .call_tool(CallToolRequestParams::new("sum").with_arguments(args))
+            .await?;
+        let elapsed = start.elapsed();
+        durations.push(elapsed);
+
+        assert!(
+            result.is_error != Some(true),
+            "tool call should succeed, got error: {:?}",
+            result.content
+        );
+    }
+
+    let _ = client.cancel().await;
+    ct.cancel();
+    server_handle.await?;
+
+    // With connection reuse, localhost calls should complete well under 20 ms.
+    // Before the fix, they consistently took ~42 ms due to new TCP connections.
+    let max_allowed = std::time::Duration::from_millis(20);
+    for (i, d) in durations.iter().enumerate() {
+        assert!(
+            *d < max_allowed,
+            "call {} took {:?}, expected < {:?} (connection reuse may be broken)",
+            i + 1,
+            d,
+            max_allowed,
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #789

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Subsequent tool calls via `StreamableHttpClientTransport` took ~42ms each on Linux, roughly 10x slower than the Python SDK. The root cause is twofold: the server kept per-request SSE channels open after sending a response, and the client dropped POST SSE response bodies without consuming them. This left stale connections in the pool that reqwest would stall on (~40ms TCP Delayed ACK) before falling back to a fresh connection.

This PR fixes both sides. On the server, request-wise channels now close immediately after sending a Response or Error, and the associated resource_router entries are cleaned up to prevent leaks. On the client, per-request POST SSE streams use a lightweight `raw_sse_to_jsonrpc` adapter instead of `SseAutoReconnectStream`, and `execute_sse_stream` drains remaining bytes after receiving a response so the connection returns to the pool cleanly. The default reqwest client also sets `pool_max_idle_per_host(0)` because TCP Delayed ACK on Linux still prevents reliable connection reuse even with the drain. Users who provide a custom client via `with_client()` are unaffected. Also fixed `is_response` to match `Error` in addition to `Response`, since JSON-RPC errors are equally terminal for request-wise streams.

## How Has This Been Tested?

1. Start the example server in one terminal:

```
cargo run --release --manifest-path examples/servers/Cargo.toml \
  --example counter_hyper_streamable_http
```

2. In another terminal, create a small benchmark client. Save this as `bench.rs` somewhere outside the workspace (e.g. `/tmp/bench/src/main.rs`) with a `Cargo.toml` pointing at the local rmcp crate:

```toml
[package]
name = "bench"
version = "0.1.0"
edition = "2024"

[dependencies]
rmcp = { path = "<path-to-this-repo>/crates/rmcp", features = ["client", "transport-streamable-http-client", "transport-streamable-http-client-reqwest"] }
tokio = { version = "1", features = ["full"] }
```

```rust
use rmcp::transport::StreamableHttpClientTransport;
use rmcp::{ServiceExt, model::*};
use std::time::Instant;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let transport = StreamableHttpClientTransport::from_uri("http://[::1]:8080/");
    let client = ClientInfo::default().serve(transport).await?;
    for i in 1..=5 {
        let start = Instant::now();
        let _res = client.call_tool(CallToolRequestParams::new("say_hello")).await?;
        println!("Call {}: {:.1}ms", i, start.elapsed().as_secs_f64() * 1000.0);
    }
    client.cancel().await?;
    Ok(())
}
```

3. Run it and verify calls 2-5 complete under 1ms:

```
cargo run --release
```

On Linux before this fix, calls 2-5 consistently show ~42ms. After the fix, all calls should be under 1ms. The issue does not reproduce on macOS due to different TCP Delayed ACK behavior.

## Breaking Changes

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
