### PR TITLE
 fix(macros): respect `local` feature in `#[prompt]` macro — omit `+ Send` bound

### DIFF
--- a/crates/rmcp-macros/src/prompt.rs
+++ b/crates/rmcp-macros/src/prompt.rs
@@ -20,6 +20,9 @@ pub struct PromptAttribute {
     pub icons: Option<Expr>,
     /// Optional metadata for the prompt
     pub meta: Option<Expr>,
+    /// When true, the generated future will not require `Send`. Useful for `!Send` handlers
+    /// (e.g. single-threaded database connections). Also enabled globally by the `local` crate feature.
+    pub local: bool,
 }
 
 pub struct ResolvedPromptAttribute {
@@ -78,6 +81,7 @@ pub fn prompt(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream>
     };
     let mut fn_item = syn::parse2::<ImplItemFn>(input.clone())?;
     let fn_ident = &fn_item.sig.ident;
+    let omit_send = cfg!(feature = "local") || attribute.local;
 
     let prompt_attr_fn_ident = format_ident!("{}_prompt_attr", fn_ident);
 
@@ -124,6 +128,7 @@ pub fn prompt(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream>
     if fn_item.sig.asyncness.is_some() {
         // 1. remove asyncness from sig
         // 2. make return type: `std::pin::Pin<Box<dyn std::future::Future<Output = #ReturnType> + Send + '_>>`
+        //    (omit `+ Send` when the `local` crate feature is active or `#[prompt(local)]` is used)
         // 3. make body: { Box::pin(async move { #body }) }
         let new_output = syn::parse2::<ReturnType>({
             let mut lt = quote! { 'static };
@@ -138,10 +143,18 @@ pub fn prompt(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream>
             }
             match &fn_item.sig.output {
                 syn::ReturnType::Default => {
-                    quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = ()> + Send + #lt>> }
+                    if omit_send {
+                        quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = ()> + #lt>> }
+                    } else {
+                        quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = ()> + Send + #lt>> }
+                    }
                 }
                 syn::ReturnType::Type(_, ty) => {
-                    quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = #ty> + Send + #lt>> }
+                    if omit_send {
+                        quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = #ty> + #lt>> }
+                    } else {
+                        quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = #ty> + Send + #lt>> }
+                    }
                 }
             }
         })?;
@@ -224,6 +237,40 @@ mod test {
         let result_str = result.to_string();
         assert!(result_str.contains("include_str"));
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_async_prompt_default_send_behavior() -> syn::Result<()> {
+        let attr = quote! {};
+        let input = quote! {
+            async fn test_prompt_default_send(&self) -> String {
+                "ok".to_string()
+            }
+        };
+        let result = prompt(attr, input)?;
+
+        let result_str = result.to_string();
+        if cfg!(feature = "local") {
+            assert!(!result_str.contains("+ Send +"));
+        } else {
+            assert!(result_str.contains("+ Send +"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_async_prompt_local_omits_send() -> syn::Result<()> {
+        let attr = quote! { local };
+        let input = quote! {
+            async fn test_prompt_local_no_send(&self) -> String {
+                "ok".to_string()
+            }
+        };
+        let result = prompt(attr, input)?;
+
+        let result_str = result.to_string();
+        assert!(!result_str.contains("+ Send +"));
         Ok(())
     }
 }

--- a/crates/rmcp-macros/src/prompt.rs
+++ b/crates/rmcp-macros/src/prompt.rs
@@ -123,7 +123,7 @@ pub fn prompt(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream>
     // Modify the input function for async support (same as tool macro)
     if fn_item.sig.asyncness.is_some() {
         // 1. remove asyncness from sig
-        // 2. make return type: `futures::future::BoxFuture<'_, #ReturnType>`
+        // 2. make return type: `std::pin::Pin<Box<dyn std::future::Future<Output = #ReturnType> + Send + '_>>`
         // 3. make body: { Box::pin(async move { #body }) }
         let new_output = syn::parse2::<ReturnType>({
             let mut lt = quote! { 'static };


### PR DESCRIPTION
# Motivation and Context

Fixes #801

The `#[tool]` macro correctly omits `+ Send` on generated handler futures when the `local` crate feature is enabled (tool.rs:341). The `#[prompt]` macro was not updated when `local` support was added in #740 — it unconditionally emits `+ Send` on all generated futures (prompt.rs:141,144).

This makes it impossible to use `!Send` types in prompt handlers even with the `local` feature enabled, despite tool handlers working correctly. The real-world use case is MCP servers wrapping platform APIs with thread-affine types (e.g., Apple EventKit's `EKEventStore`).

## How Has This Been Tested?

- Existing tests pass locally (`cargo test --workspace`)
- Verified that a server struct holding `Rc<String>` (`!Send`) with both `#[tool]` and `#[prompt]` handlers compiles with `features = ["local"]` after this change (previously only `#[tool]` compiled)

## Breaking Changes

None. This only changes behavior when the `local` feature is explicitly enabled. Default behavior (without `local`) is unchanged — `+ Send` is still emitted.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The fix mirrors the existing pattern in `tool.rs:339-341`:

```rust
let omit_send = cfg!(feature = "local") || attribute.local;
```

Applied the same `cfg!(feature = "local")` check to `prompt.rs` for both `ReturnType::Default` and `ReturnType::Type` match arms.