### PR TITLE
fix: treat resource metadata JSON parse failure as soft error

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -1609,12 +1609,13 @@ impl AuthorizationManager {
             return Ok(None);
         }
 
-        let metadata = response
-            .json::<ResourceServerMetadata>()
-            .await
-            .map_err(|e| {
-                AuthError::MetadataError(format!("Failed to parse resource metadata: {}", e))
-            })?;
+        let metadata = match response.json::<ResourceServerMetadata>().await {
+            Ok(metadata) => metadata,
+            Err(e) => {
+                debug!("failed to parse resource metadata as JSON: {}", e);
+                return Ok(None);
+            }
+        };
         Ok(Some(metadata))
     }
 


### PR DESCRIPTION
## Summary

`fetch_resource_metadata_from_url` returns a fatal `AuthError::MetadataError` when the resource metadata response body cannot be parsed as JSON. This prevents `discover_metadata()` from falling through to direct `.well-known/oauth-authorization-server` discovery (Strategy B).

## Problem

MCP servers that return HTTP 200 with non-JSON content (e.g. HTML) at their base URL cause the resource metadata probe to "succeed" at the HTTP level (200 = "this is the metadata URL"), but then the JSON deserialization fails fatally. The OAuth flow aborts entirely even though the server has a valid `.well-known/oauth-authorization-server` endpoint.

Users see "Auth required" with no OAuth browser flow ever opening.

## Fix

Treat JSON parse errors as a soft failure — return `Ok(None)` with a `debug!` log — consistent with how HTTP errors (non-200 status codes) are already handled in the same function. This allows `discover_metadata()` to continue and attempt direct authorization server metadata discovery.

## Test plan

- Verified the project compiles with `cargo check -p rmcp --features auth`
- Existing tests continue to pass
- Servers returning valid resource metadata JSON are unaffected (happy path unchanged)
- Servers returning non-JSON at their base URL now correctly fall through to `.well-known/oauth-authorization-server` discovery instead of aborting