### PR TITLE
fix(docs): use correct Parameters<T> syntax in tool examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,13 @@ Tools let servers expose callable functions to clients. Each tool has a name, de
 The `#[tool]`, `#[tool_router]`, and `#[tool_handler]` macros handle all the wiring. For a tools-only server you can use `#[tool_router(server_handler)]` to skip the separate `ServerHandler` impl:
 
 ```rust,ignore
-use rmcp::{tool, tool_router, ServiceExt, transport::stdio};
+use rmcp::{handler::server::wrapper::Parameters, schemars, tool, tool_router, ServiceExt, transport::stdio};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct AddParams {
+    a: i32,
+    b: i32,
+}
 
 #[derive(Clone)]
 struct Calculator;
@@ -149,7 +155,7 @@ struct Calculator;
 #[tool_router(server_handler)]
 impl Calculator {
     #[tool(description = "Add two numbers")]
-    fn add(&self, #[tool(param)] a: i32, #[tool(param)] b: i32) -> String {
+    fn add(&self, Parameters(AddParams { a, b }): Parameters<AddParams>) -> String {
         (a + b).to_string()
     }
 }
@@ -165,7 +171,13 @@ async fn main() -> anyhow::Result<()> {
 When you need custom server metadata or multiple capabilities (tools + prompts), use explicit `#[tool_handler]`:
 
 ```rust,ignore
-use rmcp::{tool, tool_router, tool_handler, ServerHandler, ServiceExt};
+use rmcp::{handler::server::wrapper::Parameters, schemars, tool, tool_router, tool_handler, ServerHandler, ServiceExt};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct AddParams {
+    a: i32,
+    b: i32,
+}
 
 #[derive(Clone)]
 struct Calculator;
@@ -173,7 +185,7 @@ struct Calculator;
 #[tool_router]
 impl Calculator {
     #[tool(description = "Add two numbers")]
-    fn add(&self, #[tool(param)] a: i32, #[tool(param)] b: i32) -> String {
+    fn add(&self, Parameters(AddParams { a, b }): Parameters<AddParams>) -> String {
         (a + b).to_string()
     }
 }

--- a/docs/readme/README.zh-cn.md
+++ b/docs/readme/README.zh-cn.md
@@ -141,7 +141,13 @@ let quit_reason = server.cancel().await?;
 `#[tool]`、`#[tool_router]` 和 `#[tool_handler]` 宏负责所有连接工作。对于纯工具服务端，可以使用 `#[tool_router(server_handler)]` 来省略单独的 `ServerHandler` 实现：
 
 ```rust,ignore
-use rmcp::{tool, tool_router, ServiceExt, transport::stdio};
+use rmcp::{handler::server::wrapper::Parameters, schemars, tool, tool_router, ServiceExt, transport::stdio};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct AddParams {
+    a: i32,
+    b: i32,
+}
 
 #[derive(Clone)]
 struct Calculator;
@@ -149,7 +155,7 @@ struct Calculator;
 #[tool_router(server_handler)]
 impl Calculator {
     #[tool(description = "Add two numbers")]
-    fn add(&self, #[tool(param)] a: i32, #[tool(param)] b: i32) -> String {
+    fn add(&self, Parameters(AddParams { a, b }): Parameters<AddParams>) -> String {
         (a + b).to_string()
     }
 }
@@ -165,7 +171,13 @@ async fn main() -> anyhow::Result<()> {
 当需要自定义服务端元数据或多种能力（工具 + 提示词）时，使用显式的 `#[tool_handler]`：
 
 ```rust,ignore
-use rmcp::{tool, tool_router, tool_handler, ServerHandler, ServiceExt};
+use rmcp::{handler::server::wrapper::Parameters, schemars, tool, tool_router, tool_handler, ServerHandler, ServiceExt};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct AddParams {
+    a: i32,
+    b: i32,
+}
 
 #[derive(Clone)]
 struct Calculator;
@@ -173,7 +185,7 @@ struct Calculator;
 #[tool_router]
 impl Calculator {
     #[tool(description = "Add two numbers")]
-    fn add(&self, #[tool(param)] a: i32, #[tool(param)] b: i32) -> String {
+    fn add(&self, Parameters(AddParams { a, b }): Parameters<AddParams>) -> String {
         (a + b).to_string()
     }
 }


### PR DESCRIPTION
The README examples used `#[tool(param)]` on function parameters, which is not a supported syntax and fails to compile. Replace with the `Parameters<T>` wrapper pattern that the macros actually expect.

Closes #812

## Motivation and Context

 Users copying the README tool examples get a compile error:
 ```
 error: expected non-macro attribute, found attribute macro `tool`
 ```
 The `#[tool(param)]` attribute on function parameters was never implemented. The correct pattern is `Parameters<T>`
 with a struct deriving `JsonSchema`, as used in `examples/servers/src/common/calculator.rs`.

 ## How Has This Been Tested?

 - Copied the old README example into a standalone project - confirmed the compile error from #812
 - Copied the fixed example - compiles clean with `cargo check`
 - Verified the pattern matches the existing calculator example in `examples/servers/src/common/calculator.rs`

 ## Breaking Changes

 None

 ## Types of changes

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [x] Documentation update

 ## Checklist

 - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
 - [x] My code follows the repository's style guidelines
 - [x] New and existing tests pass locally
 - [x] I have added appropriate error handling
 - [x] I have added or updated documentation as needed

 ## Additional context

 Both the English (`README.md`) and Chinese (`docs/readme/README.zh-cn.md`) READMEs contained the same incorrect
 examples - both are fixed in this PR.