### PR TITLE
docs: add systemprompt-template to Built with rmcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,6 +990,7 @@ See [Oauth_support](docs/OAUTH_SUPPORT.md) for details.
 - [hyper-mcp](https://github.com/hyper-mcp-rs/hyper-mcp) - A fast, secure MCP server that extends its capabilities through WebAssembly (WASM) plugins
 - [rudof-mcp](https://github.com/rudof-project/rudof/tree/master/rudof_mcp) - RDF validation and data processing MCP server with ShEx/SHACL validation, SPARQL queries, and format conversion. Supports stdio and streamable HTTP transports with full MCP capabilities (tools, prompts, resources, logging, completions, tasks)
 - [McpMux](https://github.com/mcpmux/mcp-mux) - Desktop app to configure MCP servers once at McpMux, connect every AI client (Cursor, Claude Desktop, VS Code, Windsurf) through a single encrypted local gateway with Spaces for project organization, FeatureSets to switch toolsets per client, and a built-in server registry
+- [systemprompt-template](https://github.com/systempromptio/systemprompt-template) - Single-binary Rust runtime providing MCP governance — authentication, authorisation, rate-limiting, audit trails, and cost tracking for AI agents. Self-hosted, air-gap capable, 3,300+ req/s with sub-5ms governance overhead
 
 
 ## Development


### PR DESCRIPTION
## Summary

Adds [systemprompt-template](https://github.com/systempromptio/systemprompt-template) to the "Built with rmcp" section.

systemprompt-template is a production AI governance runtime built on rmcp. It uses rmcp v1.1 with full server, client, and auth features (`transport-streamable-http-server`, `transport-streamable-http-client`, `macros`, `auth`) to provide a complete governance layer for MCP tool calls:

- Authentication and authorisation (OAuth 2.0, scoped permissions)
- Rate-limiting and secret detection
- Append-only audit trail (PostgreSQL via sqlx)
- Cost tracking across AI providers (Anthropic, OpenAI, Gemini)
- 3,300+ req/s throughput, sub-5ms governance overhead
- Self-hosted, single binary, air-gap capable

The template is MIT licensed with a 42-script runnable demo suite.