### PR TITLE
Fix/issue 817 idle timeout log level

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/session/local.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/local.rs
@@ -928,8 +928,6 @@ pub enum LocalSessionWorkerError {
     FailToSendInitializeRequest(SessionError),
     #[error("fail to handle message: {0}")]
     FailToHandleMessage(SessionError),
-    #[error("keep alive timeout after {}ms", _0.as_millis())]
-    KeepAliveTimeout(Duration),
     #[error("Transport closed")]
     TransportClosed,
     #[error("Tokio join error {0}")]
@@ -1008,7 +1006,7 @@ impl Worker for LocalSessionWorker {
                     return Err(WorkerQuitReason::Cancelled)
                 }
                 _ = keep_alive_timeout => {
-                    return Err(WorkerQuitReason::fatal(LocalSessionWorkerError::KeepAliveTimeout(keep_alive), "poll next session event"))
+                    return Err(WorkerQuitReason::IdleTimeout(keep_alive))
                 }
             };
             match event {

--- a/crates/rmcp/src/transport/streamable_http_server/session/local.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/local.rs
@@ -66,9 +66,16 @@ impl SessionManager for LocalSessionManager {
         Ok(response)
     }
     async fn close_session(&self, id: &SessionId) -> Result<(), Self::Error> {
-        let mut sessions = self.sessions.write().await;
-        if let Some(handle) = sessions.remove(id) {
-            handle.close().await?;
+        let handle = {
+            let mut sessions = self.sessions.write().await;
+            sessions.remove(id)
+        };
+        if let Some(handle) = handle {
+            match handle.close().await {
+                // Worker already exited — nothing left to clean up.
+                Ok(()) | Err(SessionError::SessionServiceTerminated) => {}
+                Err(e) => return Err(e.into()),
+            }
         }
         Ok(())
     }

--- a/crates/rmcp/src/transport/streamable_http_server/session/local.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/local.rs
@@ -935,6 +935,9 @@ pub enum LocalSessionWorkerError {
     FailToSendInitializeRequest(SessionError),
     #[error("fail to handle message: {0}")]
     FailToHandleMessage(SessionError),
+    #[deprecated(note = "idle timeout now surfaces as WorkerQuitReason::IdleTimeout")]
+    #[error("keep alive timeout after {}ms", _0.as_millis())]
+    KeepAliveTimeout(Duration),
     #[error("Transport closed")]
     TransportClosed,
     #[error("Tokio join error {0}")]

--- a/crates/rmcp/src/transport/worker.rs
+++ b/crates/rmcp/src/transport/worker.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, time::Duration};
 
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Level};
@@ -22,6 +22,8 @@ pub enum WorkerQuitReason<E> {
     TransportClosed,
     #[error("Handler terminated")]
     HandlerTerminated,
+    #[error("Worker idle timeout ({}ms)", _0.as_millis())]
+    IdleTimeout(Duration),
 }
 
 impl<E: std::error::Error + Send + 'static> WorkerQuitReason<E> {
@@ -122,7 +124,8 @@ impl<W: Worker> WorkerTransport<W> {
                 .inspect_err(|e| match e {
                     WorkerQuitReason::Cancelled
                     | WorkerQuitReason::TransportClosed
-                    | WorkerQuitReason::HandlerTerminated => {
+                    | WorkerQuitReason::HandlerTerminated
+                    | WorkerQuitReason::IdleTimeout(_) => {
                         tracing::debug!("worker quit with reason: {:?}", e);
                     }
                     WorkerQuitReason::Join(e) => {

--- a/crates/rmcp/src/transport/worker.rs
+++ b/crates/rmcp/src/transport/worker.rs
@@ -22,7 +22,7 @@ pub enum WorkerQuitReason<E> {
     TransportClosed,
     #[error("Handler terminated")]
     HandlerTerminated,
-    #[error("Worker idle timeout ({}ms)", _0.as_millis())]
+    #[error("Worker idle timeout after {}ms", _0.as_millis())]
     IdleTimeout(Duration),
 }
 

--- a/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
+++ b/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
@@ -10,15 +10,14 @@ use std::{
 };
 
 use rmcp::transport::streamable_http_server::{
-    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    StreamableHttpServerConfig, StreamableHttpService,
+    session::{SessionManager, local::LocalSessionManager},
 };
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::layer::SubscriberExt;
 
 mod common;
 use common::calculator::Calculator;
-
-// Issue #817: keep-alive timeout emits tracing::error! for normal idle reaping.
 
 struct CapturedEvent {
     level: tracing::Level,
@@ -92,7 +91,6 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
 
     let client = reqwest::Client::new();
 
-    // Initialize session
     let response = client
         .post(format!("http://{addr}/mcp"))
         .header("Content-Type", "application/json")
@@ -107,7 +105,6 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
         .unwrap()
         .to_string();
 
-    // Complete handshake
     client
         .post(format!("http://{addr}/mcp"))
         .header("Content-Type", "application/json")
@@ -119,19 +116,37 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
         .await
         .unwrap();
 
-    // Wait for keep_alive timeout (200ms) plus margin
     tokio::time::sleep(Duration::from_millis(400)).await;
+
+    // Wait until close_session() has completed so all logs are captured.
+    let session_id_parsed: Arc<str> = Arc::from(session_id.as_str());
+    for _ in 0..20 {
+        if !session_manager
+            .has_session(&session_id_parsed)
+            .await
+            .unwrap()
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        !session_manager
+            .has_session(&session_id_parsed)
+            .await
+            .unwrap(),
+        "session should have been removed after idle reap"
+    );
 
     let captured = events.lock().unwrap();
 
     let error_events: Vec<_> = captured
         .iter()
         .filter(|e| e.level == tracing::Level::ERROR)
-        .filter(|e| e.message.contains("keep alive timeout") || e.message.contains("IdleTimeout"))
         .collect();
     assert!(
         error_events.is_empty(),
-        "keep-alive timeout should not produce ERROR logs, found {}: {:?}",
+        "idle reap should not produce any ERROR logs, found {}: {:?}",
         error_events.len(),
         error_events.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
@@ -143,6 +158,88 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
     assert!(
         !debug_events.is_empty(),
         "expected a DEBUG log with IdleTimeout, but found none"
+    );
+
+    ct.cancel();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_explicit_close_on_live_session_succeeds() {
+    let ct = CancellationToken::new();
+    let mut session_manager = LocalSessionManager::default();
+    session_manager.session_config.keep_alive = Some(Duration::from_secs(60));
+    let session_manager = Arc::new(session_manager);
+
+    let service = StreamableHttpService::new(
+        || Ok(Calculator::new()),
+        session_manager.clone(),
+        StreamableHttpServerConfig::default()
+            .with_sse_keep_alive(None)
+            .with_cancellation_token(ct.child_token()),
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = tcp_listener.local_addr().unwrap();
+
+    tokio::spawn({
+        let ct = ct.clone();
+        async move {
+            let _ = axum::serve(tcp_listener, router)
+                .with_graceful_shutdown(async move { ct.cancelled_owned().await })
+                .await;
+        }
+    });
+
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("http://{addr}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let session_id = response.headers()["mcp-session-id"]
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    client
+        .post(format!("http://{addr}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .header("Mcp-Protocol-Version", "2025-06-18")
+        .body(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let session_id_parsed: Arc<str> = Arc::from(session_id.as_str());
+
+    assert!(
+        session_manager
+            .has_session(&session_id_parsed)
+            .await
+            .unwrap(),
+        "session should exist before explicit close"
+    );
+
+    let result = session_manager.close_session(&session_id_parsed).await;
+    assert!(
+        result.is_ok(),
+        "close_session on a live worker should succeed: {result:?}"
+    );
+
+    assert!(
+        !session_manager
+            .has_session(&session_id_parsed)
+            .await
+            .unwrap(),
+        "session should not exist after explicit close"
     );
 
     ct.cancel();

--- a/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
+++ b/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
@@ -1,0 +1,149 @@
+#![cfg(all(
+    feature = "transport-streamable-http-server",
+    feature = "transport-streamable-http-client-reqwest",
+    not(feature = "local")
+))]
+
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
+use tokio_util::sync::CancellationToken;
+use tracing_subscriber::layer::SubscriberExt;
+
+mod common;
+use common::calculator::Calculator;
+
+// Issue #817: keep-alive timeout emits tracing::error! for normal idle reaping.
+
+struct CapturedEvent {
+    level: tracing::Level,
+    message: String,
+}
+
+struct CapturingLayer {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturingLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut visitor = MessageVisitor(String::new());
+        event.record(&mut visitor);
+        self.events.lock().unwrap().push(CapturedEvent {
+            level: *event.metadata().level(),
+            message: visitor.0,
+        });
+    }
+}
+
+struct MessageVisitor(String);
+
+impl tracing::field::Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.0 = format!("{:?}", value);
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_keep_alive_timeout_does_not_emit_error_log() {
+    let events = Arc::new(Mutex::new(Vec::<CapturedEvent>::new()));
+
+    let subscriber = tracing_subscriber::registry().with(CapturingLayer {
+        events: events.clone(),
+    });
+
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let ct = CancellationToken::new();
+    let mut session_manager = LocalSessionManager::default();
+    session_manager.session_config.keep_alive = Some(Duration::from_millis(200));
+    let session_manager = Arc::new(session_manager);
+
+    let service = StreamableHttpService::new(
+        || Ok(Calculator::new()),
+        session_manager.clone(),
+        StreamableHttpServerConfig::default()
+            .with_sse_keep_alive(None)
+            .with_cancellation_token(ct.child_token()),
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = tcp_listener.local_addr().unwrap();
+
+    tokio::spawn({
+        let ct = ct.clone();
+        async move {
+            let _ = axum::serve(tcp_listener, router)
+                .with_graceful_shutdown(async move { ct.cancelled_owned().await })
+                .await;
+        }
+    });
+
+    let client = reqwest::Client::new();
+
+    // Initialize session
+    let response = client
+        .post(format!("http://{addr}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let session_id = response.headers()["mcp-session-id"]
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // Complete handshake
+    client
+        .post(format!("http://{addr}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .header("Mcp-Protocol-Version", "2025-06-18")
+        .body(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Wait for keep_alive timeout (200ms) plus margin
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let captured = events.lock().unwrap();
+
+    let error_events: Vec<_> = captured
+        .iter()
+        .filter(|e| e.level == tracing::Level::ERROR)
+        .filter(|e| e.message.contains("keep alive timeout") || e.message.contains("IdleTimeout"))
+        .collect();
+    assert!(
+        error_events.is_empty(),
+        "keep-alive timeout should not produce ERROR logs, found {}: {:?}",
+        error_events.len(),
+        error_events.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+
+    let debug_events: Vec<_> = captured
+        .iter()
+        .filter(|e| e.level == tracing::Level::DEBUG && e.message.contains("IdleTimeout"))
+        .collect();
+    assert!(
+        !debug_events.is_empty(),
+        "expected a DEBUG log with IdleTimeout, but found none"
+    );
+
+    ct.cancel();
+}

--- a/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
+++ b/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
@@ -21,6 +21,7 @@ use common::calculator::Calculator;
 
 struct CapturedEvent {
     level: tracing::Level,
+    target: String,
     message: String,
 }
 
@@ -38,6 +39,7 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturingLayer {
         event.record(&mut visitor);
         self.events.lock().unwrap().push(CapturedEvent {
             level: *event.metadata().level(),
+            target: event.metadata().target().to_string(),
             message: visitor.0,
         });
     }
@@ -142,7 +144,7 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
 
     let error_events: Vec<_> = captured
         .iter()
-        .filter(|e| e.level == tracing::Level::ERROR)
+        .filter(|e| e.level == tracing::Level::ERROR && e.target.starts_with("rmcp"))
         .collect();
     assert!(
         error_events.is_empty(),
@@ -153,7 +155,11 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
 
     let debug_events: Vec<_> = captured
         .iter()
-        .filter(|e| e.level == tracing::Level::DEBUG && e.message.contains("IdleTimeout"))
+        .filter(|e| {
+            e.level == tracing::Level::DEBUG
+                && e.target.starts_with("rmcp")
+                && e.message.contains("IdleTimeout")
+        })
         .collect();
     assert!(
         !debug_events.is_empty(),


### PR DESCRIPTION
Idle keep-alive timeout is normal zombie-session cleanup, not a transport failure. This PR stops it from producing `ERROR`-level log lines that are indistinguishable from real transport fatals.

 ## Motivation and Context

 When `LocalSessionWorker` hits its configured keep-alive timeout (default 5 min), it returns `WorkerQuitReason::Fatal`, which the transport worker logs at `tracing::error!`. The `SessionConfig::keep_alive` docstring explicitly
 frames this as a safety net for silently-dropped HTTP connections — normal lifecycle cleanup, not an error condition.

 This causes every idle reap to emit:
 ```
 ERROR rmcp::transport::worker: worker quit with fatal: keep alive timeout after 300000ms, when poll next session event
 ```

 Operators who wire ERROR-level alerts get paged on something that is normal by design. Downstream consumers cannot filter idle reaps without also silencing real transport fatals.

 Additionally, the post-exit cleanup path in `close_session` could fail with `SessionServiceTerminated` when the worker had already exited due to idle timeout, producing a second spurious error.

 Closes #817

 ## How Has This Been Tested?

 - Added an integration test (`test_keep_alive_timeout_does_not_emit_error_log`) that spins up a Streamable HTTP server with a 200ms keep-alive, connects a client, waits for idle reap, and asserts: no ERROR-level logs are
 emitted, and a DEBUG log with `IdleTimeout` is present.
 - Added a second integration test (`test_explicit_close_on_live_session_succeeds`) that verifies `close_session` on a still-alive worker succeeds without error.
 - Existing tests pass locally (`cargo test`).

 ## Breaking Changes

 None. `WorkerQuitReason` is `#[non_exhaustive]`, so the new `IdleTimeout` variant is additive. The removed `LocalSessionWorkerError::KeepAliveTimeout` variant was not part of the public API.

 ## Types of changes

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Documentation update

 ## Checklist

 - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
 - [x] My code follows the repository's style guidelines
 - [x] New and existing tests pass locally
 - [x] I have added appropriate error handling
 - [x] I have added or updated documentation as needed

 ## Additional context

 This implements Option A from #817: a dedicated `WorkerQuitReason::IdleTimeout(Duration)` variant that is logged at `debug` level alongside the other expected-exit arms (`Cancelled`, `TransportClosed`, `HandlerTerminated`). True
  transport failures continue to flow through `Fatal` and keep their ERROR severity.

 Changes across two commits:
 1. **`d41d3c8`** — Add `WorkerQuitReason::IdleTimeout`, return it from the keep-alive arm, log at debug. Remove unused `KeepAliveTimeout` error variant.
 2. **`2463369`** — Swallow `SessionServiceTerminated` in `close_session` when the worker has already exited, preventing a spurious error during post-exit cleanup.