### PR TITLE
feat(http): log Host/Origin rejections

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -330,13 +330,23 @@ fn bad_request_response(message: &str) -> BoxResponse {
 
 fn parse_host_header(headers: &HeaderMap) -> Result<NormalizedAuthority, BoxResponse> {
     let Some(host) = headers.get(http::header::HOST) else {
+        tracing::warn!("rejected request with missing Host header");
         return Err(bad_request_response("Bad Request: missing Host header"));
     };
 
-    let host = host
+    let host_str = host
         .to_str()
+        .inspect_err(|_| {
+            tracing::warn!(host = ?host, "rejected request with non-UTF-8 Host header");
+        })
         .map_err(|_| bad_request_response("Bad Request: Invalid Host header encoding"))?;
-    let authority = http::uri::Authority::try_from(host)
+    let authority = http::uri::Authority::try_from(host_str)
+        .inspect_err(|_| {
+            tracing::warn!(
+                host = host_str,
+                "rejected request with malformed Host header"
+            );
+        })
         .map_err(|_| bad_request_response("Bad Request: Invalid Host header"))?;
     Ok(normalize_authority(authority.host(), authority.port_u16()))
 }
@@ -347,6 +357,10 @@ fn validate_dns_rebinding_headers(
 ) -> Result<(), BoxResponse> {
     let host = parse_host_header(headers)?;
     if !host_is_allowed(&host, &config.allowed_hosts) {
+        tracing::warn!(
+            host = ?host,
+            "rejected request with disallowed Host header (possible DNS rebinding attempt)",
+        );
         return Err(forbidden_response("Forbidden: Host header is not allowed"));
     }
     validate_origin_header(headers, &config.allowed_origins)?;
@@ -365,10 +379,22 @@ fn validate_origin_header(
     };
     let origin_str = origin_header
         .to_str()
+        .inspect_err(|_| {
+            tracing::warn!(origin = ?origin_header, "rejected request with non-UTF-8 Origin header");
+        })
         .map_err(|_| bad_request_response("Bad Request: Invalid Origin header encoding"))?;
-    let origin = parse_origin_value(origin_str)
-        .ok_or_else(|| bad_request_response("Bad Request: Invalid Origin header"))?;
+    let origin = parse_origin_value(origin_str).ok_or_else(|| {
+        tracing::warn!(
+            origin = origin_str,
+            "rejected request with malformed Origin header",
+        );
+        bad_request_response("Bad Request: Invalid Origin header")
+    })?;
     if !origin_is_allowed(&origin, allowed_origins) {
+        tracing::warn!(
+            origin = ?origin,
+            "rejected request with disallowed Origin header (possible cross-origin attack)",
+        );
         return Err(forbidden_response(
             "Forbidden: Origin header is not allowed",
         ));


### PR DESCRIPTION
## Motivation and Context

The `StreamableHttpService` rejects requests due to Host or Origin validation failures, returning HTTP 400 or 403 responses. However, it doesn't emit a `tracing` event, which makes log-based alerting for DNS-rebinding attempts impossible. The only signal at the application layer is the HTTP status, but it doesn't include the rejected `Host` value. 
This PR adds a `tracing::warn!` at each rejection point in `parse_host_header`, `validate_dns_rebinding_headers`, and `validate_origin_header`. This way, operators can detect and investigate potential DNS-rebinding or cross-origin attempts. The change is purely additive, meaning it doesn't alter any behavior, status codes, or response bodies.

## How Has This Been Tested?

The existing integration tests continue to pass.

## Breaking Changes

None. Logging-only addition

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
