### PR TITLE
chore(rmcp): remove dependency on chrono default features

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -102,7 +102,7 @@ hyper-util = { version = "0.1", features = ["tokio"], optional = true }
 # macro
 rmcp-macros = { workspace = true, optional = true }
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.38", default-features = false, features = ["serde", "now"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 chrono = { version = "0.4.38", default-features = false, features = [


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Disable `chrono` default features for non-wasm `rmcp` builds and enable only the features `rmcp` actually uses. This avoids pulling unnecessary local-timezone support such as `iana-time-zone` / `iana-time-zone-haiku`, which can introduce avoidable platform library dependencies on Haiku. Fixes #828.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Issue #828 reports that `rmcp`’s native `chrono` dependency leaves default features enabled, which pulls in local-timezone support that `rmcp` does not use. On Haiku, that can bring in `iana-time-zone-haiku` and `libbe.so`, contributing to downstream link failures when combined with vendored `zstd`.

This change narrows the native `chrono` dependency to `default-features = false` with only `["serde", "now"]` enabled. That keeps the functionalities `rmcp` uses while avoiding the extra dependency footprint from `chrono` defaults.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
`cargo test -p rmcp`, `cargo test -p rmcp --all-features`  and `cargo test --workspace --all` under Linux x86_64

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
See #828.