### PR TITLE
ci: extend semver check to all features except local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,18 @@ jobs:
             --only-explicit-features \
             --features default
 
+      - name: Check rmcp (all features except local)
+        run: |
+          FEATURES=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '[.packages[] | select(.name == "rmcp") | .features | keys[]
+                      | select(startswith("__") | not)
+                      | select(. != "local")] | join(",")')
+          cargo semver-checks \
+            --package rmcp \
+            --baseline-rev ${{ github.event.pull_request.base.sha }} \
+            --only-explicit-features \
+            --features "$FEATURES"
+
   spelling:
     name: spell check with typos
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation and Context

CI's SemVer Check job currently only validates the default feature set. This exception exists because the `local` feature intentionally changes the public API, which could lead to false positives if checked. Unfortunately, this means that other non-default features like `transport-streamable-http-server`, `auth`, and `transport-streamable-http-client-reqwest` also go unchecked, even though they are stable public APIs that downstream users rely on. https://github.com/modelcontextprotocol/rust-sdk/pull/824#discussion_r3174065990 highlighted this issue. A breaking change to a transport module wouldn't have been caught by CI.

This PR adds a second `cargo semver-checks` invocation to the existing `semver` job. It enables every published feature except for `local`. The feature list is generated during the job using `cargo metadata` and `jq`, filtering out `local` and any internal `__`-prefixed features. This approach is consistent with the `test-no-local` job already in this workflow, maintaining the same method for handling the `local` exception. The check for default features is kept as a separate step, ensuring that failures from the typical user experience are easy to read in CI logs.

## How Has This Been Tested?

CI passes

## Breaking Changes

CI-only change

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] CI / tooling

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context