### PR TITLE
fix(deps): disable chrono default features to drop iana-time-zone pull-in

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -102,7 +102,10 @@ hyper-util = { version = "0.1", features = ["tokio"], optional = true }
 # macro
 rmcp-macros = { workspace = true, optional = true }
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.38", default-features = false, features = [
+  "serde",
+  "now",
+] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 chrono = { version = "0.4.38", default-features = false, features = [


### PR DESCRIPTION
## Motivation and Context

`rmcp`'s non-wasm chrono dependency is currently declared without `default-features = false`, so chrono's default `clock` feature is enabled. `clock` brings in `iana-time-zone`, which on Haiku pulls `iana-time-zone-haiku` and links `libbe.so`. `libbe.so` itself depends on system `libzstd.so.1`, which conflicts with the hidden symbols in vendored `zstd-sys` and breaks the final link for downstreams that combine `rmcp` with `zstd` on Haiku (see #828 and gyscos/zstd-rs#363).

rmcp only uses `chrono::DateTime<Utc>`, `chrono::Utc::now()`, `chrono::Duration`, and RFC3339 formatting (no local timezone discovery), so the `clock`/`iana-time-zone` pull-in is unnecessary.

This switches the non-wasm chrono dep to `default-features = false` with `serde` and `now` enabled. `now` provides `Utc::now()` without `iana-time-zone`. The wasm target block already had `default-features = false` and is left unchanged.

Closes #828.

## How Has This Been Tested?

No behavioral changes; chrono usage in rmcp is limited to `Utc::now`, `DateTime<Utc>`, `Duration`, RFC3339 formatting, and serde derives, all retained via the `now` and `serde` features. CI matrix will exercise the full surface.

## Breaking Changes

None. Public API and runtime behavior are unchanged. Default features dropped (`oldtime`, `wasmbind`, `clock`) are not used by rmcp on the non-wasm target.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed