### PR TITLE
fix: enable task support on counter long_task example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
             if [ -f "$dir/Cargo.toml" ]; then
               if [[ "$dir" != *"wasi"* ]]; then
                 echo "Testing $dir"
-                cargo test --manifest-path "$dir/Cargo.toml" --all-features
+                cargo test --manifest-path "$dir/Cargo.toml" --all-features --all-targets
               fi
             fi
           done

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -103,7 +103,10 @@ impl Counter {
         )]))
     }
 
-    #[tool(description = "Long running task example")]
+    #[tool(
+        description = "Long running task example",
+        execution(task_support = "optional")
+    )]
     async fn long_task(&self) -> Result<CallToolResult, McpError> {
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         Ok(CallToolResult::success(vec![Content::text(
@@ -360,7 +363,7 @@ mod tests {
             "source".into(),
             serde_json::Value::String("integration-test".into()),
         );
-        let params = CallToolRequestParams::new("long_task").with_task(Some(task_meta));
+        let params = CallToolRequestParams::new("long_task").with_task(task_meta);
         let response = client_service
             .send_request(ClientRequest::CallToolRequest(Request::new(params.clone())))
             .await?;


### PR DESCRIPTION
Fixes #836

## Motivation and Context

Fixed the `Counter` example's unit test by adding `execution(task_support = "optional")`. Also widened the example test step in CI to `--all-targets` to avoid the same issue.

## How Has This Been Tested?

The tests pass with the fix.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed