### PR TITLE
fix(rmcp): flatten Resource variant of PromptMessageContent

### DIFF
--- a/crates/rmcp/src/model/prompt.rs
+++ b/crates/rmcp/src/model/prompt.rs
@@ -158,7 +158,10 @@ pub enum PromptMessageContent {
         image: ImageContent,
     },
     /// Embedded server-side resource
-    Resource { resource: EmbeddedResource },
+    Resource {
+        #[serde(flatten)]
+        resource: EmbeddedResource,
+    },
     /// A link to a resource that can be fetched separately
     ResourceLink {
         #[serde(flatten)]
@@ -319,6 +322,57 @@ mod tests {
         assert!(json.contains("\"type\":\"resource_link\""));
         assert!(json.contains("\"uri\":\"file:///test.txt\""));
         assert!(json.contains("\"name\":\"test.txt\""));
+    }
+
+    #[test]
+    fn test_prompt_message_resource_serialization_is_flat() {
+        // Regression test: PromptMessageContent::Resource must serialize to
+        // the spec-compliant flat shape `{ "type": "resource", "resource": { "uri", "mimeType", "text" } }`
+        // and NOT the double-nested shape `{ "type": "resource", "resource": { "resource": {...} } }`.
+        // See: https://modelcontextprotocol.io/specification/2025-06-18/server/prompts
+        let message = PromptMessage::new_resource(
+            PromptMessageRole::User,
+            "alc://packages/sc/narrative".to_string(),
+            Some("text/markdown".to_string()),
+            Some("# Hello".to_string()),
+            None,
+            None,
+            None,
+        );
+
+        let value: serde_json::Value = serde_json::to_value(&message).unwrap();
+
+        // Drill into content
+        let content = value.get("content").expect("content present");
+        assert_eq!(
+            content.get("type").and_then(|v| v.as_str()),
+            Some("resource")
+        );
+
+        let resource = content
+            .get("resource")
+            .expect("resource field present at content level");
+
+        // Spec-compliant: resource.uri / resource.mimeType / resource.text MUST be flat
+        assert_eq!(
+            resource.get("uri").and_then(|v| v.as_str()),
+            Some("alc://packages/sc/narrative"),
+            "expected flat resource.uri, got: {resource:#?}"
+        );
+        assert_eq!(
+            resource.get("mimeType").and_then(|v| v.as_str()),
+            Some("text/markdown")
+        );
+        assert_eq!(
+            resource.get("text").and_then(|v| v.as_str()),
+            Some("# Hello")
+        );
+
+        // Regression guard: content.resource MUST NOT contain a nested `resource` key.
+        assert!(
+            resource.get("resource").is_none(),
+            "double-nested resource detected (regression): {resource:#?}"
+        );
     }
 
     #[test]

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -140,35 +140,6 @@
       ]
     },
     "Annotated2": {
-      "type": "object",
-      "properties": {
-        "_meta": {
-          "description": "Optional protocol-level metadata for this content block",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
-        },
-        "annotations": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Annotations"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "resource": {
-          "$ref": "#/definitions/ResourceContents"
-        }
-      },
-      "required": [
-        "resource"
-      ]
-    },
-    "Annotated3": {
       "description": "Represents a resource in the extension with metadata",
       "type": "object",
       "properties": {
@@ -244,7 +215,7 @@
         "name"
       ]
     },
-    "Annotated4": {
+    "Annotated3": {
       "type": "object",
       "properties": {
         "annotations": {
@@ -1475,7 +1446,7 @@
         "resourceTemplates": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Annotated4"
+            "$ref": "#/definitions/Annotated3"
           }
         }
       },
@@ -1502,7 +1473,7 @@
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Annotated3"
+            "$ref": "#/definitions/Annotated2"
           }
         }
       },
@@ -2142,8 +2113,26 @@
           "description": "Embedded server-side resource",
           "type": "object",
           "properties": {
+            "_meta": {
+              "description": "Optional protocol-level metadata for this content block",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            },
+            "annotations": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Annotations"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "resource": {
-              "$ref": "#/definitions/Annotated2"
+              "$ref": "#/definitions/ResourceContents"
             },
             "type": {
               "type": "string",

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -140,35 +140,6 @@
       ]
     },
     "Annotated2": {
-      "type": "object",
-      "properties": {
-        "_meta": {
-          "description": "Optional protocol-level metadata for this content block",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
-        },
-        "annotations": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Annotations"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "resource": {
-          "$ref": "#/definitions/ResourceContents"
-        }
-      },
-      "required": [
-        "resource"
-      ]
-    },
-    "Annotated3": {
       "description": "Represents a resource in the extension with metadata",
       "type": "object",
       "properties": {
@@ -244,7 +215,7 @@
         "name"
       ]
     },
-    "Annotated4": {
+    "Annotated3": {
       "type": "object",
       "properties": {
         "annotations": {
@@ -1475,7 +1446,7 @@
         "resourceTemplates": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Annotated4"
+            "$ref": "#/definitions/Annotated3"
           }
         }
       },
@@ -1502,7 +1473,7 @@
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Annotated3"
+            "$ref": "#/definitions/Annotated2"
           }
         }
       },
@@ -2142,8 +2113,26 @@
           "description": "Embedded server-side resource",
           "type": "object",
           "properties": {
+            "_meta": {
+              "description": "Optional protocol-level metadata for this content block",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            },
+            "annotations": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Annotations"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "resource": {
-              "$ref": "#/definitions/Annotated2"
+              "$ref": "#/definitions/ResourceContents"
             },
             "type": {
               "type": "string",


### PR DESCRIPTION
Fixes #842

## Motivation and Context

`PromptMessageContent::Resource` currently serializes with a doubly-nested
`resource` object, producing:

```json
{
  "type": "resource",
  "resource": {
    "resource": { "uri": "file:///example.md", "text": "...", "mimeType": "text/markdown" }
  }
}
```

The MCP specification (Prompts — Embedded Resources) defines the wire shape
as a single, flat `resource` field:

```json
{
  "type": "resource",
  "resource": { "uri": "file:///example.md", "text": "...", "mimeType": "text/markdown" }
}
```

The other variants of `PromptMessageContent` (`Text`, `Image`, `ResourceLink`)
already use `#[serde(flatten)]` and serialize flat. `Resource` is the only
outlier: the `resource: EmbeddedResource` field was missing `#[serde(flatten)]`,
so the outer enum tag wrapper plus the inner struct's own `resource` field both
serialize, yielding the double nesting.

This breaks interop with any MCP client that follows the spec literally — the
inner `{uri, text, mimeType}` is unreachable without descending two levels.

## How Has This Been Tested?

- Added a regression test (`test_prompt_message_resource_serialization_is_flat`)
  that constructs a `PromptMessage::new_resource(...)`, serializes it, and
  asserts:
  - `content.type == "resource"`
  - `content.resource.uri`, `content.resource.mimeType`, `content.resource.text`
    are reachable directly (flat shape).
  - `content.resource.resource` is **absent** (regression guard against the
    doubly-nested shape).
- Regenerated the affected schema snapshot via `UPDATE_SCHEMA=1`.
- `cargo test --all-features` passes locally for the `rmcp` crate (lib + all
  integration tests).
- `cargo +nightly fmt --all -- --check` and
  `cargo clippy --all-targets --all-features -- -D warnings` pass.

## Breaking Changes

**Wire format**: yes, but in the spec-compliance direction. Any client that
relied on the previous (non-spec) doubly-nested shape would break, but such
clients are already non-conformant against the MCP spec and against the other
content variants in this same enum.

**Rust API**: none. The variant's field name (`resource`) and type
(`EmbeddedResource`) are unchanged; only the serde representation is corrected.
`cargo semver-checks` should be unaffected.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Additional Context

Single-line behavioral fix in `crates/rmcp/src/model/prompt.rs`: add
`#[serde(flatten)]` to the `Resource` variant's inner field, matching the
pattern used by `Image` and `ResourceLink` in the same enum.