### PR TITLE
Fix/issue 817 idle timeout log level

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/session/local.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/local.rs
@@ -928,8 +928,6 @@ pub enum LocalSessionWorkerError {
     FailToSendInitializeRequest(SessionError),
     #[error("fail to handle message: {0}")]
     FailToHandleMessage(SessionError),
-    #[error("keep alive timeout after {}ms", _0.as_millis())]
-    KeepAliveTimeout(Duration),
     #[error("Transport closed")]
     TransportClosed,
     #[error("Tokio join error {0}")]
@@ -1008,7 +1006,7 @@ impl Worker for LocalSessionWorker {
                     return Err(WorkerQuitReason::Cancelled)
                 }
                 _ = keep_alive_timeout => {
-                    return Err(WorkerQuitReason::fatal(LocalSessionWorkerError::KeepAliveTimeout(keep_alive), "poll next session event"))
+                    return Err(WorkerQuitReason::IdleTimeout(keep_alive))
                 }
             };
             match event {

--- a/crates/rmcp/src/transport/streamable_http_server/session/local.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/local.rs
@@ -66,9 +66,16 @@ impl SessionManager for LocalSessionManager {
         Ok(response)
     }
     async fn close_session(&self, id: &SessionId) -> Result<(), Self::Error> {
-        let mut sessions = self.sessions.write().await;
-        if let Some(handle) = sessions.remove(id) {
-            handle.close().await?;
+        let handle = {
+            let mut sessions = self.sessions.write().await;
+            sessions.remove(id)
+        };
+        if let Some(handle) = handle {
+            match handle.close().await {
+                // Worker already exited — nothing left to clean up.
+                Ok(()) | Err(SessionError::SessionServiceTerminated) => {}
+                Err(e) => return Err(e.into()),
+            }
         }
         Ok(())
     }

--- a/crates/rmcp/src/transport/streamable_http_server/session/local.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session/local.rs
@@ -935,6 +935,9 @@ pub enum LocalSessionWorkerError {
     FailToSendInitializeRequest(SessionError),
     #[error("fail to handle message: {0}")]
     FailToHandleMessage(SessionError),
+    #[deprecated(note = "idle timeout now surfaces as WorkerQuitReason::IdleTimeout")]
+    #[error("keep alive timeout after {}ms", _0.as_millis())]
+    KeepAliveTimeout(Duration),
     #[error("Transport closed")]
     TransportClosed,
     #[error("Tokio join error {0}")]

--- a/crates/rmcp/src/transport/worker.rs
+++ b/crates/rmcp/src/transport/worker.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, time::Duration};
 
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Level};
@@ -22,6 +22,8 @@ pub enum WorkerQuitReason<E> {
     TransportClosed,
     #[error("Handler terminated")]
     HandlerTerminated,
+    #[error("Worker idle timeout ({}ms)", _0.as_millis())]
+    IdleTimeout(Duration),
 }
 
 impl<E: std::error::Error + Send + 'static> WorkerQuitReason<E> {
@@ -122,7 +124,8 @@ impl<W: Worker> WorkerTransport<W> {
                 .inspect_err(|e| match e {
                     WorkerQuitReason::Cancelled
                     | WorkerQuitReason::TransportClosed
-                    | WorkerQuitReason::HandlerTerminated => {
+                    | WorkerQuitReason::HandlerTerminated
+                    | WorkerQuitReason::IdleTimeout(_) => {
                         tracing::debug!("worker quit with reason: {:?}", e);
                     }
                     WorkerQuitReason::Join(e) => {

--- a/crates/rmcp/src/transport/worker.rs
+++ b/crates/rmcp/src/transport/worker.rs
@@ -22,7 +22,7 @@ pub enum WorkerQuitReason<E> {
     TransportClosed,
     #[error("Handler terminated")]
     HandlerTerminated,
-    #[error("Worker idle timeout ({}ms)", _0.as_millis())]
+    #[error("Worker idle timeout after {}ms", _0.as_millis())]
     IdleTimeout(Duration),
 }
 

--- a/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
+++ b/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
@@ -10,15 +10,14 @@ use std::{
 };
 
 use rmcp::transport::streamable_http_server::{
-    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    StreamableHttpServerConfig, StreamableHttpService,
+    session::{SessionManager, local::LocalSessionManager},
 };
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::layer::SubscriberExt;
 
 mod common;
 use common::calculator::Calculator;
-
-// Issue #817: keep-alive timeout emits tracing::error! for normal idle reaping.
 
 struct CapturedEvent {
     level: tracing::Level,
@@ -92,7 +91,6 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
 
     let client = reqwest::Client::new();
 
-    // Initialize session
     let response = client
         .post(format!("http://{addr}/mcp"))
         .header("Content-Type", "application/json")
@@ -107,7 +105,6 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
         .unwrap()
         .to_string();
 
-    // Complete handshake
     client
         .post(format!("http://{addr}/mcp"))
         .header("Content-Type", "application/json")
@@ -119,19 +116,37 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
         .await
         .unwrap();
 
-    // Wait for keep_alive timeout (200ms) plus margin
     tokio::time::sleep(Duration::from_millis(400)).await;
+
+    // Wait until close_session() has completed so all logs are captured.
+    let session_id_parsed: Arc<str> = Arc::from(session_id.as_str());
+    for _ in 0..20 {
+        if !session_manager
+            .has_session(&session_id_parsed)
+            .await
+            .unwrap()
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        !session_manager
+            .has_session(&session_id_parsed)
+            .await
+            .unwrap(),
+        "session should have been removed after idle reap"
+    );
 
     let captured = events.lock().unwrap();
 
     let error_events: Vec<_> = captured
         .iter()
         .filter(|e| e.level == tracing::Level::ERROR)
-        .filter(|e| e.message.contains("keep alive timeout") || e.message.contains("IdleTimeout"))
         .collect();
     assert!(
         error_events.is_empty(),
-        "keep-alive timeout should not produce ERROR logs, found {}: {:?}",
+        "idle reap should not produce any ERROR logs, found {}: {:?}",
         error_events.len(),
         error_events.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
@@ -143,6 +158,88 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
     assert!(
         !debug_events.is_empty(),
         "expected a DEBUG log with IdleTimeout, but found none"
+    );
+
+    ct.cancel();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_explicit_close_on_live_session_succeeds() {
+    let ct = CancellationToken::new();
+    let mut session_manager = LocalSessionManager::default();
+    session_manager.session_config.keep_alive = Some(Duration::from_secs(60));
+    let session_manager = Arc::new(session_manager);
+
+    let service = StreamableHttpService::new(
+        || Ok(Calculator::new()),
+        session_manager.clone(),
+        StreamableHttpServerConfig::default()
+            .with_sse_keep_alive(None)
+            .with_cancellation_token(ct.child_token()),
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = tcp_listener.local_addr().unwrap();
+
+    tokio::spawn({
+        let ct = ct.clone();
+        async move {
+            let _ = axum::serve(tcp_listener, router)
+                .with_graceful_shutdown(async move { ct.cancelled_owned().await })
+                .await;
+        }
+    });
+
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("http://{addr}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let session_id = response.headers()["mcp-session-id"]
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    client
+        .post(format!("http://{addr}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .header("Mcp-Protocol-Version", "2025-06-18")
+        .body(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let session_id_parsed: Arc<str> = Arc::from(session_id.as_str());
+
+    assert!(
+        session_manager
+            .has_session(&session_id_parsed)
+            .await
+            .unwrap(),
+        "session should exist before explicit close"
+    );
+
+    let result = session_manager.close_session(&session_id_parsed).await;
+    assert!(
+        result.is_ok(),
+        "close_session on a live worker should succeed: {result:?}"
+    );
+
+    assert!(
+        !session_manager
+            .has_session(&session_id_parsed)
+            .await
+            .unwrap(),
+        "session should not exist after explicit close"
     );
 
     ct.cancel();

--- a/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
+++ b/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
@@ -1,0 +1,149 @@
+#![cfg(all(
+    feature = "transport-streamable-http-server",
+    feature = "transport-streamable-http-client-reqwest",
+    not(feature = "local")
+))]
+
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
+use tokio_util::sync::CancellationToken;
+use tracing_subscriber::layer::SubscriberExt;
+
+mod common;
+use common::calculator::Calculator;
+
+// Issue #817: keep-alive timeout emits tracing::error! for normal idle reaping.
+
+struct CapturedEvent {
+    level: tracing::Level,
+    message: String,
+}
+
+struct CapturingLayer {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturingLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut visitor = MessageVisitor(String::new());
+        event.record(&mut visitor);
+        self.events.lock().unwrap().push(CapturedEvent {
+            level: *event.metadata().level(),
+            message: visitor.0,
+        });
+    }
+}
+
+struct MessageVisitor(String);
+
+impl tracing::field::Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.0 = format!("{:?}", value);
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_keep_alive_timeout_does_not_emit_error_log() {
+    let events = Arc::new(Mutex::new(Vec::<CapturedEvent>::new()));
+
+    let subscriber = tracing_subscriber::registry().with(CapturingLayer {
+        events: events.clone(),
+    });
+
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let ct = CancellationToken::new();
+    let mut session_manager = LocalSessionManager::default();
+    session_manager.session_config.keep_alive = Some(Duration::from_millis(200));
+    let session_manager = Arc::new(session_manager);
+
+    let service = StreamableHttpService::new(
+        || Ok(Calculator::new()),
+        session_manager.clone(),
+        StreamableHttpServerConfig::default()
+            .with_sse_keep_alive(None)
+            .with_cancellation_token(ct.child_token()),
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = tcp_listener.local_addr().unwrap();
+
+    tokio::spawn({
+        let ct = ct.clone();
+        async move {
+            let _ = axum::serve(tcp_listener, router)
+                .with_graceful_shutdown(async move { ct.cancelled_owned().await })
+                .await;
+        }
+    });
+
+    let client = reqwest::Client::new();
+
+    // Initialize session
+    let response = client
+        .post(format!("http://{addr}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let session_id = response.headers()["mcp-session-id"]
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // Complete handshake
+    client
+        .post(format!("http://{addr}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .header("Mcp-Protocol-Version", "2025-06-18")
+        .body(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    // Wait for keep_alive timeout (200ms) plus margin
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let captured = events.lock().unwrap();
+
+    let error_events: Vec<_> = captured
+        .iter()
+        .filter(|e| e.level == tracing::Level::ERROR)
+        .filter(|e| e.message.contains("keep alive timeout") || e.message.contains("IdleTimeout"))
+        .collect();
+    assert!(
+        error_events.is_empty(),
+        "keep-alive timeout should not produce ERROR logs, found {}: {:?}",
+        error_events.len(),
+        error_events.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+
+    let debug_events: Vec<_> = captured
+        .iter()
+        .filter(|e| e.level == tracing::Level::DEBUG && e.message.contains("IdleTimeout"))
+        .collect();
+    assert!(
+        !debug_events.is_empty(),
+        "expected a DEBUG log with IdleTimeout, but found none"
+    );
+
+    ct.cancel();
+}

--- a/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
+++ b/crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs
@@ -21,6 +21,7 @@ use common::calculator::Calculator;
 
 struct CapturedEvent {
     level: tracing::Level,
+    target: String,
     message: String,
 }
 
@@ -38,6 +39,7 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturingLayer {
         event.record(&mut visitor);
         self.events.lock().unwrap().push(CapturedEvent {
             level: *event.metadata().level(),
+            target: event.metadata().target().to_string(),
             message: visitor.0,
         });
     }
@@ -142,7 +144,7 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
 
     let error_events: Vec<_> = captured
         .iter()
-        .filter(|e| e.level == tracing::Level::ERROR)
+        .filter(|e| e.level == tracing::Level::ERROR && e.target.starts_with("rmcp"))
         .collect();
     assert!(
         error_events.is_empty(),
@@ -153,7 +155,11 @@ async fn test_keep_alive_timeout_does_not_emit_error_log() {
 
     let debug_events: Vec<_> = captured
         .iter()
-        .filter(|e| e.level == tracing::Level::DEBUG && e.message.contains("IdleTimeout"))
+        .filter(|e| {
+            e.level == tracing::Level::DEBUG
+                && e.target.starts_with("rmcp")
+                && e.message.contains("IdleTimeout")
+        })
         .collect();
     assert!(
         !debug_events.is_empty(),


### PR DESCRIPTION
Fix issue #817 — route the streamable-http idle keep-alive reap through a dedicated `WorkerQuitReason::IdleTimeout` variant and log it at `debug` instead of `error`. Also stop emitting an `ERROR` log from                            
`LocalSessionManager::close_session` when the worker has already exited on its own.                                                                                                                                                   
                                                                                                                                                                                                                                        
## Motivation and Context                                                                                                                                                                                                               
`LocalSessionWorker`'s keep-alive timeout is documented as a safety net for zombie-session cleanup (silently-dropped HTTP/2 connections, `RST_STREAM`, etc.) — it is normal lifecycle, not a transport failure. Today it is returned as 
`WorkerQuitReason::Fatal { KeepAliveTimeout, .. }`, which `WorkerTransport` logs at `tracing::error!`. The result is a red log line on every idle reap (every ~5 min by default), indistinguishable from a real fatal like a peer reset.
                                                                                                                                                                                                                                        
Operators who alert on `ERROR` get paged on something that is normal by design, and silencing it via target filters (`rmcp::transport::worker=warn`) also silences real fatals. No downstream filter preserves the original signal.     
                                                                                                                                                                                                                                      
There's a related issue in the cleanup path: when the worker exits on its own (e.g. via the idle reap), `spawn_session_worker` calls `close_session` to remove the entry from the map. That call hits `handle.close().await`, which     
returns `SessionError::SessionServiceTerminated` because the worker is already gone — surfacing as another `ERROR` log for what is again a no-op.                                                                                     
                                                                                                                                                                                                                                        
This PR implements Option A from the issue (the preferred direction).                                                                                                                                                                   
 
## How Has This Been Tested?                                                                                                                                                                                                            
- New integration test `crates/rmcp/tests/test_streamable_http_idle_timeout_log.rs`:                                                                                                                                                  
  - `test_keep_alive_timeout_does_not_emit_error_log` — spins up a real `StreamableHttpService` with a 200 ms `keep_alive`, drives a full `initialize` + `notifications/initialized` handshake, waits for the idle reap, and asserts via
 a `tracing_subscriber::Layer` collector that **zero** `ERROR` records are emitted and at least one `DEBUG` record mentions `IdleTimeout`.                                                                                              
  - `test_explicit_close_on_live_session_succeeds` — regression guard that `close_session` on a still-live worker continues to succeed and remove the session.                                                                          
- `cargo test -p rmcp --features "server,transport-streamable-http-server,transport-streamable-http-client-reqwest" --test test_streamable_http_idle_timeout_log` passes locally.                                                       
- Full `cargo test -p rmcp` continues to pass.                                                                                                                                                                                          
                                                                                                                                                                                                                                        
## Breaking Changes                                                                                                                                                                                                                     
None for typical users.                                                                                                                                                                                                               
                                                                                                                                                                                                                                        
- `WorkerQuitReason` is `#[non_exhaustive]`, so adding the `IdleTimeout(Duration)` variant is additive.                                                                                                                                 
- `LocalSessionWorkerError::KeepAliveTimeout` is removed. Any downstream code that pattern-matched on this specific variant would need to update — but the idle-timeout signal now flows through `WorkerQuitReason::IdleTimeout` at the 
transport layer, which is the layer that actually observes it.                                                                                                                                                                          
                                                                                                                                                                                                                                      
## Types of changes                                                                                                                                                                                                                     
- [x] Bug fix (non-breaking change which fixes an issue)                                                                                                                                                                              
- [ ] New feature (non-breaking change which adds functionality)                                                                                                                                                                        
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update                                                                                                                                                                                                              
                                                                                                                                                                                                                                      
## Checklist                                                                                                                                                                                                                            
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)                                                                                                                                                            
- [x] My code follows the repository's style guidelines                                                                                                                                                                                 
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling                                                                                                                                                                                           
- [ ] I have added or updated documentation as needed                                                                                                                                                                                   
 
## Additional context                                                                                                                                                                                                                   
Implementation notes:                                                                                                                                                                                                                 
- `LocalSessionWorker::run` now returns `WorkerQuitReason::IdleTimeout(keep_alive)` from the `keep_alive_timeout` arm instead of constructing a `Fatal { KeepAliveTimeout, .. }`.                                                       
- `WorkerTransport::spawn_with_ct`'s `inspect_err` arm groups `IdleTimeout(_)` with the other expected-exit reasons (`Cancelled`, `TransportClosed`, `HandlerTerminated`) and logs at `debug!`. Real fatals continue to log at `error!`.
- `LocalSessionManager::close_session` swallows `SessionError::SessionServiceTerminated` from `handle.close()` — the worker has already exited and there's nothing left to clean up. Any other error still propagates. The session map  
lock is also dropped before awaiting `handle.close()` to avoid holding the write lock across an `await`.                                                                                                                                
                                                                                                                                                                                                                                        
Closes #817. 