### PR TITLE
fix(examples): accept stringified prompt argument values

### DIFF
--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -44,9 +44,29 @@ pub struct ExamplePromptArgs {
     pub message: String,
 }
 
+/// MCP spec types prompt arguments as `Record<string, string>`, so
+/// spec-compliant clients stringify all values. Accept both wire forms.
+fn deserialize_i32_from_string_or_int<'de, D>(deserializer: D) -> Result<i32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrInt {
+        Int(i32),
+        Str(String),
+    }
+    match StringOrInt::deserialize(deserializer)? {
+        StringOrInt::Int(n) => Ok(n),
+        StringOrInt::Str(s) => s.parse::<i32>().map_err(serde::de::Error::custom),
+    }
+}
+
 #[derive(Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct CounterAnalysisArgs {
     /// The target value you're trying to reach
+    #[serde(deserialize_with = "deserialize_i32_from_string_or_int")]
     pub goal: i32,
     /// Preferred strategy: 'fast' or 'careful'
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -332,6 +352,34 @@ mod tests {
         assert_eq!(args[0].required, Some(true));
         assert_eq!(args[1].name, "strategy");
         assert_eq!(args[1].required, Some(false));
+    }
+
+    #[test]
+    fn test_counter_analysis_args_accepts_integer_goal() {
+        let json = serde_json::json!({ "goal": 20 });
+        let args: CounterAnalysisArgs = serde_json::from_value(json).unwrap();
+        assert_eq!(args.goal, 20);
+    }
+
+    #[test]
+    fn test_counter_analysis_args_accepts_string_goal() {
+        let json = serde_json::json!({ "goal": "20" });
+        let args: CounterAnalysisArgs = serde_json::from_value(json).unwrap();
+        assert_eq!(args.goal, 20);
+    }
+
+    #[test]
+    fn test_counter_analysis_args_accepts_negative_string_goal() {
+        let json = serde_json::json!({ "goal": "-7" });
+        let args: CounterAnalysisArgs = serde_json::from_value(json).unwrap();
+        assert_eq!(args.goal, -7);
+    }
+
+    #[test]
+    fn test_counter_analysis_args_rejects_non_numeric_string_goal() {
+        let json = serde_json::json!({ "goal": "not a number" });
+        let result: Result<CounterAnalysisArgs, _> = serde_json::from_value(json);
+        assert!(result.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation and Context

The MCP spec defines prompt arguments as `arguments: { [key: string]: string }` ([MCP 2025-11-25 — Server: Prompts](https://modelcontextprotocol.io/specification/2025-11-25/server/prompts)) — every value crosses the wire as a JSON string. `CounterAnalysisArgs.goal` in the counter example is typed as `i32`, which rejects that representation.

For example, entering `20` for `goal` in **MCP Inspector** sends the argument as the JSON string `"20"`, and the example fails with:

```
MCP error -32602: Failed to parse parameters: invalid type: string "20", expected i32
```

The example now accepts both the JSON number form (`20`) and the JSON string form (`"20"`) for `goal` via a small `deserialize_with` helper. No framework changes.

**Reproduction over the wire**

```jsonc
// prompts/get
{
  "method": "prompts/get",
  "params": {
    "name": "counter_analysis",
    "arguments": { "goal": "20", "strategy": "fast" }
  }
}
```
Expected: prompt returns. Actual on `main`: `-32602 invalid type: string "20", expected i32`.

## How Has This Been Tested?

Four unit tests added in the same file:
- `test_counter_analysis_args_accepts_integer_goal` — `{"goal": 20}` → `20`
- `test_counter_analysis_args_accepts_string_goal` — `{"goal": "20"}` → `20`
- `test_counter_analysis_args_accepts_negative_string_goal` — `{"goal": "-7"}` → `-7`
- `test_counter_analysis_args_rejects_non_numeric_string_goal` — `{"goal": "not a number"}` errors out

Local CI parity:
- `cargo +nightly fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test --manifest-path examples/servers/Cargo.toml --all-features --all-targets` ✓ (7/7)
- `cargo +nightly doc --no-deps -p rmcp -p rmcp-macros --all-features` with `-Dwarnings` ✓

End-to-end re-verified in MCP Inspector against the patched `servers_counter_stdio` release binary.

## Breaking Changes

None. The struct still accepts JSON numbers as before; it additionally accepts JSON strings.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

**Why fix the example rather than the framework.** rmcp already accepts arbitrary JSON for prompt arguments at the wire level (`GetPromptRequestParams.arguments: Option<JsonObject>`) and correctly forwards whatever the spec produces. The example happened to declare a strict `i32` field for a value the spec defines as a string — the mismatch lives in the example.

**Why an inline helper rather than `serde_with`.** There are no existing `deserialize_with` helpers in the SDK today (verified via `grep -r 'deserialize_with' crates/rmcp/src examples`), and the crate doesn't currently depend on `serde_with`. Pulling in a proc-macro dependency for one example field felt heavier than the situation needs; the inline helper is 13 lines and only requires `serde` knowledge to read. If the same coercion shows up in more places later, `serde_with::PickFirst<(_, DisplayFromStr)>` would be the cleaner swap.
