### PR TITLE
fix(auth): align OAuth metadata discovery ordering

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -1409,7 +1409,7 @@ impl AuthorizationManager {
             push_candidate("/.well-known/oauth-authorization-server".to_string());
             push_candidate("/.well-known/openid-configuration".to_string());
         } else {
-            // Path components present: follow spec priority order
+            // Path components present: prefer OAuth discovery before OpenID Connect fallbacks.
             // 1. OAuth 2.0 with path insertion
             push_candidate(format!("/.well-known/oauth-authorization-server/{trimmed}"));
             // 2. OpenID Connect with path insertion

--- a/crates/rmcp/tests/test_client_credentials.rs
+++ b/crates/rmcp/tests/test_client_credentials.rs
@@ -136,6 +136,25 @@ async fn start_mock_server() -> (String, SocketAddr) {
     (base_url, addr)
 }
 
+async fn start_path_insert_metadata_server() -> (String, SocketAddr) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{}", addr);
+
+    let app = Router::new()
+        .route(
+            "/.well-known/oauth-authorization-server/mcp",
+            get(auth_server_metadata_handler),
+        )
+        .route("/token", post(token_handler));
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    (base_url, addr)
+}
+
 #[tokio::test]
 async fn test_client_credentials_flow_client_secret() {
     let (base_url, _addr) = start_mock_server().await;
@@ -147,6 +166,33 @@ async fn test_client_credentials_flow_client_secret() {
         client_secret: "test-m2m-secret".to_string(),
         scopes: vec!["read".to_string(), "write".to_string()],
         resource: Some(base_url.clone()),
+    };
+
+    oauth_state
+        .authenticate_client_credentials(config)
+        .await
+        .unwrap();
+
+    let manager = oauth_state
+        .into_authorization_manager()
+        .expect("Should be in Authorized state");
+
+    let token = manager.get_access_token().await.unwrap();
+    assert_eq!(token, "m2m-access-token-12345");
+}
+
+#[tokio::test]
+async fn test_client_credentials_discovers_path_inserted_oauth_metadata() {
+    let (base_url, _addr) = start_path_insert_metadata_server().await;
+    let resource_url = format!("{base_url}/mcp");
+
+    let mut oauth_state = OAuthState::new(&resource_url, None).await.unwrap();
+
+    let config = ClientCredentialsConfig::ClientSecret {
+        client_id: "test-m2m-client".to_string(),
+        client_secret: "test-m2m-secret".to_string(),
+        scopes: vec!["read".to_string()],
+        resource: Some(resource_url),
     };
 
     oauth_state


### PR DESCRIPTION
Fixes #878.

## Summary

- align path-bearing authorization-server discovery with the MCP authorization spec / RFC 8414 ordering
- keep OAuth authorization-server metadata discovery ahead of OpenID Connect fallback candidates
- add regression coverage for both candidate ordering and a real client credentials discovery flow

## Changes

For a resource URL such as `https://example.com/mcp`, the direct authorization-server discovery list is:

- `https://example.com/.well-known/oauth-authorization-server/mcp`
- `https://example.com/.well-known/openid-configuration/mcp`
- `https://example.com/mcp/.well-known/openid-configuration`
- `https://example.com/.well-known/oauth-authorization-server`

The first three entries match the path-bearing issuer ordering from the MCP authorization spec. The existing canonical OAuth fallback remains last.

The client credentials regression now serves metadata at the RFC 8414 path-inserted OAuth endpoint, so the test exercises the same URL form as the candidate builder.

## Verification

```text
cargo test -p rmcp --features auth generate_discovery_urls
cargo test -p rmcp --features auth --test test_client_credentials test_client_credentials_discovers_path_inserted_oauth_metadata
cargo test -p rmcp --features auth
cargo test --all-features
cargo fmt --all -- --check
cargo clippy -p rmcp --features auth --lib -- -D warnings
cargo clippy -p rmcp --features auth --test test_client_credentials -- -D warnings
```
