### PR TITLE
fix(elicitation): preserve enumNames through ElicitationSchema serde round-trip

### DIFF
--- a/crates/rmcp/src/model/elicitation_schema.rs
+++ b/crates/rmcp/src/model/elicitation_schema.rs
@@ -544,12 +544,13 @@ pub struct LegacyEnumSchema {
     pub description: Option<Cow<'static, str>>,
     #[serde(rename = "enum")]
     pub enum_: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enum_names: Option<Vec<String>>,
 }
 
 /// Untitled single-select
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct UntitledSingleSelectEnumSchema {
@@ -1739,6 +1740,45 @@ mod tests {
         assert_eq!(json["description"], "A legacy enum schema");
         assert_eq!(json["enum"], json!(["A", "B"]));
         assert_eq!(json["enumNames"], json!(["Option A", "Option B"]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_legacy_enum_schema_roundtrip_preserves_enum_names() -> anyhow::Result<()> {
+        // Regression test for: legacy enum payload with `enumNames` was silently
+        // deserialized as `UntitledSingleSelectEnumSchema` (which has no `enumNames`
+        // field), causing the array to be dropped on re-serialization.
+        let input = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "choice": {
+                    "type": "string",
+                    "enum": ["opt1", "opt2", "opt3"],
+                    "enumNames": ["Option One", "Option Two", "Option Three"]
+                }
+            }
+        });
+        let schema: ElicitationSchema = serde_json::from_value(input.clone())?;
+        let output = serde_json::to_value(&schema)?;
+        assert_eq!(
+            output["properties"]["choice"]["enumNames"],
+            serde_json::json!(["Option One", "Option Two", "Option Three"]),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_legacy_enum_schema_no_enum_names_omits_field() -> anyhow::Result<()> {
+        // `LegacyEnumSchema` with `enum_names: None` must not serialize `"enumNames": null`.
+        let schema = EnumSchema::Legacy(LegacyEnumSchema {
+            type_: StringTypeConst,
+            title: None,
+            description: None,
+            enum_: vec!["a".to_string(), "b".to_string()],
+            enum_names: None,
+        });
+        let json = serde_json::to_value(&schema)?;
+        assert!(!json.as_object().unwrap().contains_key("enumNames"));
         Ok(())
     }
 

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -3642,6 +3642,7 @@
           "$ref": "#/definitions/StringTypeConst"
         }
       },
+      "additionalProperties": false,
       "required": [
         "type",
         "enum"

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -3642,6 +3642,7 @@
           "$ref": "#/definitions/StringTypeConst"
         }
       },
+      "additionalProperties": false,
       "required": [
         "type",
         "enum"


### PR DESCRIPTION
Fixes #903.

## Problem

`EnumSchema` is `#[serde(untagged)]` with variants ordered `Single → Multi → Legacy`. `SingleSelectEnumSchema` is itself untagged with `Untitled` before `Titled`. `UntitledSingleSelectEnumSchema` did not have `deny_unknown_fields`, so a legacy payload like:

```json
{"type":"string","enum":["opt1","opt2","opt3"],"enumNames":["Option One","Option Two","Option Three"]}
```

was silently matched by `UntitledSingleSelectEnumSchema` (which has no `enumNames` field). The array was dropped, and `LegacyEnumSchema` was never tried. On re-serialization, `enumNames` was gone.

A secondary issue: `LegacyEnumSchema::enum_names` lacked `skip_serializing_if = "Option::is_none"`, so a `Legacy` with `enum_names: None` would serialize `"enumNames": null`.

## Fix

- Add `deny_unknown_fields` to `UntitledSingleSelectEnumSchema`. When `enumNames` (or any unrecognised field) is present, serde rejects this variant and falls through to `LegacyEnumSchema`.
- Add `skip_serializing_if = "Option::is_none"` to `LegacyEnumSchema::enum_names`.

Two regression tests added:

1. `test_legacy_enum_schema_roundtrip_preserves_enum_names` — mirrors the exact repro from the issue; verifies that a full `ElicitationSchema` round-trip keeps `enumNames` intact.
2. `test_legacy_enum_schema_no_enum_names_omits_field` — verifies `LegacyEnumSchema` with `enum_names: None` does not emit `"enumNames": null`.

All existing elicitation tests continue to pass.