### PR TITLE
feat!: relax tool result structuredContent type (SEP-2106)

### DIFF
--- a/crates/rmcp/src/model/content.rs
+++ b/crates/rmcp/src/model/content.rs
@@ -8,7 +8,7 @@
 //! variants for sampling messages (SEP-1577).
 
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{Value, json};
 
 use super::{Annotations, Meta, resource::ResourceContents};
 
@@ -197,7 +197,7 @@ pub struct ToolResultContent {
     pub tool_use_id: String,
     pub content: Vec<ContentBlock>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub structured_content: Option<super::JsonObject>,
+    pub structured_content: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_error: Option<bool>,
 }

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
@@ -2346,13 +2346,7 @@
             "null"
           ]
         },
-        "structuredContent": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
-        },
+        "structuredContent": true,
         "toolUseId": {
           "type": "string"
         }

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
@@ -2346,13 +2346,7 @@
             "null"
           ]
         },
-        "structuredContent": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
-        },
+        "structuredContent": true,
         "toolUseId": {
           "type": "string"
         }

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -3446,13 +3446,7 @@
             "null"
           ]
         },
-        "structuredContent": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
-        },
+        "structuredContent": true,
         "toolUseId": {
           "type": "string"
         }

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -3446,13 +3446,7 @@
             "null"
           ]
         },
-        "structuredContent": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
-        },
+        "structuredContent": true,
         "toolUseId": {
           "type": "string"
         }

--- a/crates/rmcp/tests/test_sampling.rs
+++ b/crates/rmcp/tests/test_sampling.rs
@@ -371,6 +371,38 @@ fn test_tool_result_content_requires_content() {
 }
 
 #[tokio::test]
+async fn test_tool_result_content_with_array_structured_content() -> Result<()> {
+    let structured =
+        serde_json::json!([{ "city": "SF", "temp": 72 }, { "city": "NY", "temp": 65 }]);
+    let mut tool_result = ToolResultContent::new("call_123", vec![ContentBlock::text("forecast")]);
+    tool_result.structured_content = Some(structured);
+
+    let json = serde_json::to_string(&tool_result)?;
+    let deserialized: ToolResultContent = serde_json::from_str(&json)?;
+    assert_eq!(tool_result, deserialized);
+    assert!(deserialized.structured_content.unwrap().is_array());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_tool_result_content_with_primitive_structured_content() -> Result<()> {
+    let structured = serde_json::json!(42);
+    let mut tool_result = ToolResultContent::new("call_123", vec![ContentBlock::text("count")]);
+    tool_result.structured_content = Some(structured);
+
+    let json = serde_json::to_string(&tool_result)?;
+    let deserialized: ToolResultContent = serde_json::from_str(&json)?;
+    assert_eq!(tool_result, deserialized);
+    assert!(matches!(
+        deserialized.structured_content,
+        Some(serde_json::Value::Number(_))
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_sampling_message_with_tool_use() -> Result<()> {
     let message = SamplingMessage::assistant_tool_use(
         "call_123",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

This was discovered while reviewing PR #895. Besides `CallToolResult`, `ToolResultContent` should also be typed with its structured content as `Option<Value>` to accommodate any JSON value.

2025-11-25|2026-07-28
-|-
<img width="932" height="610" alt="2026-06-23 at 15 42 59" src="https://github.com/user-attachments/assets/76d1d543-775a-47f6-8b1f-c8414ca812c9" />|<img width="720" height="590" alt="2026-06-23 at 15 41 47" src="https://github.com/user-attachments/assets/58a580d2-3ab1-4ba2-bea8-fe4377348d2d" />

## How Has This Been Tested?

Added tests

## Breaking Changes

Yes. The public field `ToolResultContent.structured_content` changes type from `Option<JsonObject>` to `Option<Value>`. 

The green SemVer Check is a false negative due to known upstream gap: obi1kenobi/cargo-semver-checks#148

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
