### PR TITLE
feat: deprecate roots/sampling/logging types (SEP-2577)

### DIFF
--- a/crates/rmcp/src/handler/client.rs
+++ b/crates/rmcp/src/handler/client.rs
@@ -1,3 +1,5 @@
+// Sampling/Roots/Logging are SEP-2577-deprecated; internal references are expected.
+#![expect(deprecated)]
 pub mod progress;
 use std::sync::Arc;
 

--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -1,3 +1,5 @@
+// Sampling/Roots/Logging are SEP-2577-deprecated; internal references are expected.
+#![expect(deprecated)]
 use std::sync::Arc;
 
 use crate::{

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1,3 +1,6 @@
+// Internal references to the SEP-2577-deprecated Roots/Sampling/Logging types
+// defined in this module are expected; the deprecation is advisory for downstream users.
+#![expect(deprecated)]
 use std::{
     borrow::Cow,
     ops::{Deref, DerefMut},
@@ -1488,6 +1491,10 @@ pub type ToolListChangedNotification = NotificationNoParam<ToolListChangedNotifi
 #[serde(rename_all = "lowercase")] //match spec
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[expect(clippy::exhaustive_enums, reason = "intentionally exhaustive")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Logging is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub enum LoggingLevel {
     Debug,
     Info,
@@ -1505,6 +1512,10 @@ const_string!(SetLevelRequestMethod = "logging/setLevel");
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Logging is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct SetLevelRequestParams {
     /// Protocol-level metadata for this request (SEP-1319)
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -1534,6 +1545,10 @@ impl RequestParamsMeta for SetLevelRequestParams {
 pub type SetLevelRequestParam = SetLevelRequestParams;
 
 /// Request to set the logging level
+#[deprecated(
+    since = "2.0.0",
+    note = "Logging is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub type SetLevelRequest = Request<SetLevelRequestMethod, SetLevelRequestParams>;
 
 const_string!(LoggingMessageNotificationMethod = "notifications/message");
@@ -1542,6 +1557,10 @@ const_string!(LoggingMessageNotificationMethod = "notifications/message");
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Logging is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct LoggingMessageNotificationParam {
     /// The severity level of this log message
     pub level: LoggingLevel,
@@ -1573,6 +1592,10 @@ impl LoggingMessageNotificationParam {
 }
 
 /// Notification containing a log message
+#[deprecated(
+    since = "2.0.0",
+    note = "Logging is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub type LoggingMessageNotification =
     Notification<LoggingMessageNotificationMethod, LoggingMessageNotificationParam>;
 
@@ -1581,6 +1604,10 @@ pub type LoggingMessageNotification =
 // =============================================================================
 
 const_string!(CreateMessageRequestMethod = "sampling/createMessage");
+#[deprecated(
+    since = "2.0.0",
+    note = "Sampling is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub type CreateMessageRequest = Request<CreateMessageRequestMethod, CreateMessageRequestParams>;
 
 /// Represents the role of a participant in a conversation or message exchange.
@@ -1618,6 +1645,10 @@ pub enum ToolChoiceMode {
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Sampling is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct ToolChoice {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<ToolChoiceMode>,
@@ -1750,6 +1781,10 @@ impl<T> From<Vec<T>> for SamplingContent<T> {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Sampling is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct SamplingMessage {
     /// The role of the message sender (User or Assistant)
     pub role: Role,
@@ -1764,6 +1799,10 @@ pub struct SamplingMessage {
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Sampling is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub enum SamplingMessageContentBlock {
     Text(TextContent),
     Image(ImageContent),
@@ -1912,6 +1951,10 @@ pub enum ContextInclusion {
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Sampling is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct CreateMessageRequestParams {
     /// Protocol-level metadata for this request (SEP-1319)
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
@@ -2125,6 +2168,10 @@ pub type CreateMessageRequestParam = CreateMessageRequestParams;
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Sampling is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct ModelPreferences {
     /// Specific model names or families to prefer (e.g., "claude", "gpt")
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2189,6 +2236,10 @@ impl Default for ModelPreferences {
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Sampling is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct ModelHint {
     /// The suggested model name or family identifier
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2522,6 +2573,10 @@ impl ArgumentInfo {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Roots is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct Root {
     pub uri: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2554,12 +2609,20 @@ impl Root {
 }
 
 const_string!(ListRootsRequestMethod = "roots/list");
+#[deprecated(
+    since = "2.0.0",
+    note = "Roots is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub type ListRootsRequest = RequestNoParam<ListRootsRequestMethod>;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Roots is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct ListRootsResult {
     pub roots: Vec<Root>,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
@@ -3167,6 +3230,10 @@ pub type CallToolRequest = Request<CallToolRequestMethod, CallToolRequestParams>
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Sampling is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct CreateMessageResult {
     /// The identifier of the model that generated the response
     pub model: String,

--- a/crates/rmcp/src/model/content.rs
+++ b/crates/rmcp/src/model/content.rs
@@ -7,6 +7,8 @@
 //! [`SamplingMessageContentBlock`] extends the union with `tool_use` and `tool_result`
 //! variants for sampling messages (SEP-1577).
 
+// ToolUseContent/ToolResultContent are SEP-2577-deprecated; internal references are expected.
+#![expect(deprecated)]
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -178,6 +180,10 @@ impl EmbeddedResource {
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Sampling is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct ToolUseContent {
     pub id: String,
     pub name: String,
@@ -191,6 +197,10 @@ pub struct ToolUseContent {
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
+#[deprecated(
+    since = "2.0.0",
+    note = "Sampling is deprecated by SEP-2577 and will be removed in a future release. See https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577"
+)]
 pub struct ToolResultContent {
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,

--- a/crates/rmcp/src/service/client.rs
+++ b/crates/rmcp/src/service/client.rs
@@ -1,3 +1,5 @@
+// Sampling/Roots/Logging are SEP-2577-deprecated; internal references are expected.
+#![expect(deprecated)]
 use std::borrow::Cow;
 
 use thiserror::Error;

--- a/crates/rmcp/src/service/server.rs
+++ b/crates/rmcp/src/service/server.rs
@@ -1,3 +1,5 @@
+// Sampling/Roots/Logging are SEP-2577-deprecated; internal references are expected.
+#![expect(deprecated)]
 use std::borrow::Cow;
 #[cfg(feature = "elicitation")]
 use std::collections::HashSet;

--- a/crates/rmcp/tests/common/handlers.rs
+++ b/crates/rmcp/tests/common/handlers.rs
@@ -1,3 +1,5 @@
+// Sampling/Roots/Logging are SEP-2577-deprecated; this test handler exercises them.
+#![expect(deprecated)]
 use std::{
     future::Future,
     sync::{Arc, Mutex},

--- a/crates/rmcp/tests/test_message_protocol.rs
+++ b/crates/rmcp/tests/test_message_protocol.rs
@@ -1,5 +1,6 @@
 //cargo test --test test_message_protocol --features "client server"
 #![cfg(not(feature = "local"))]
+#![expect(deprecated)] // exercises SEP-2577-deprecated Sampling/Roots/Logging types
 
 mod common;
 use common::handlers::{TestClientHandler, TestServer};

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
@@ -494,6 +494,7 @@
           ]
         }
       },
+      "deprecated": true,
       "required": [
         "model",
         "role",
@@ -1152,6 +1153,7 @@
           }
         }
       },
+      "deprecated": true,
       "required": [
         "roots"
       ]
@@ -1169,6 +1171,7 @@
     "LoggingLevel": {
       "description": "Logging levels supported by the MCP protocol",
       "type": "string",
+      "deprecated": true,
       "enum": [
         "debug",
         "info",
@@ -1894,6 +1897,7 @@
           "type": "string"
         }
       },
+      "deprecated": true,
       "required": [
         "uri"
       ]
@@ -1953,6 +1957,7 @@
     },
     "SamplingMessageContentBlock": {
       "description": "Content types for sampling messages (SEP-1577).",
+      "deprecated": true,
       "oneOf": [
         {
           "type": "object",
@@ -2082,6 +2087,7 @@
           ]
         }
       },
+      "deprecated": true,
       "required": [
         "level"
       ]
@@ -2357,6 +2363,7 @@
           "type": "string"
         }
       },
+      "deprecated": true,
       "required": [
         "toolUseId",
         "content"
@@ -2384,6 +2391,7 @@
           "type": "string"
         }
       },
+      "deprecated": true,
       "required": [
         "id",
         "name",

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
@@ -494,6 +494,7 @@
           ]
         }
       },
+      "deprecated": true,
       "required": [
         "model",
         "role",
@@ -1152,6 +1153,7 @@
           }
         }
       },
+      "deprecated": true,
       "required": [
         "roots"
       ]
@@ -1169,6 +1171,7 @@
     "LoggingLevel": {
       "description": "Logging levels supported by the MCP protocol",
       "type": "string",
+      "deprecated": true,
       "enum": [
         "debug",
         "info",
@@ -1894,6 +1897,7 @@
           "type": "string"
         }
       },
+      "deprecated": true,
       "required": [
         "uri"
       ]
@@ -1953,6 +1957,7 @@
     },
     "SamplingMessageContentBlock": {
       "description": "Content types for sampling messages (SEP-1577).",
+      "deprecated": true,
       "oneOf": [
         {
           "type": "object",
@@ -2082,6 +2087,7 @@
           ]
         }
       },
+      "deprecated": true,
       "required": [
         "level"
       ]
@@ -2357,6 +2363,7 @@
           "type": "string"
         }
       },
+      "deprecated": true,
       "required": [
         "toolUseId",
         "content"
@@ -2384,6 +2391,7 @@
           "type": "string"
         }
       },
+      "deprecated": true,
       "required": [
         "id",
         "name",

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -565,6 +565,7 @@
           }
         }
       },
+      "deprecated": true,
       "required": [
         "messages",
         "maxTokens"
@@ -1577,6 +1578,7 @@
     "LoggingLevel": {
       "description": "Logging levels supported by the MCP protocol",
       "type": "string",
+      "deprecated": true,
       "enum": [
         "debug",
         "info",
@@ -1623,6 +1625,7 @@
           ]
         }
       },
+      "deprecated": true,
       "required": [
         "level",
         "data"
@@ -1639,7 +1642,8 @@
             "null"
           ]
         }
-      }
+      },
+      "deprecated": true
     },
     "ModelPreferences": {
       "description": "Preferences for model selection and behavior in sampling requests.\n\nThis allows servers to express their preferences for which model to use\nand how to balance different priorities when the client has multiple\nmodel options available.",
@@ -1679,7 +1683,8 @@
           ],
           "format": "float"
         }
-      }
+      },
+      "deprecated": true
     },
     "MultiSelectEnumSchema": {
       "description": "Multi-select enum options",
@@ -2494,6 +2499,7 @@
           ]
         }
       },
+      "deprecated": true,
       "required": [
         "role",
         "content"
@@ -2501,6 +2507,7 @@
     },
     "SamplingMessageContentBlock": {
       "description": "Content types for sampling messages (SEP-1577).",
+      "deprecated": true,
       "oneOf": [
         {
           "type": "object",
@@ -3379,7 +3386,8 @@
             }
           ]
         }
-      }
+      },
+      "deprecated": true
     },
     "ToolChoiceMode": {
       "description": "Tool selection mode (SEP-1577).",
@@ -3457,6 +3465,7 @@
           "type": "string"
         }
       },
+      "deprecated": true,
       "required": [
         "toolUseId",
         "content"
@@ -3484,6 +3493,7 @@
           "type": "string"
         }
       },
+      "deprecated": true,
       "required": [
         "id",
         "name",

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -565,6 +565,7 @@
           }
         }
       },
+      "deprecated": true,
       "required": [
         "messages",
         "maxTokens"
@@ -1577,6 +1578,7 @@
     "LoggingLevel": {
       "description": "Logging levels supported by the MCP protocol",
       "type": "string",
+      "deprecated": true,
       "enum": [
         "debug",
         "info",
@@ -1623,6 +1625,7 @@
           ]
         }
       },
+      "deprecated": true,
       "required": [
         "level",
         "data"
@@ -1639,7 +1642,8 @@
             "null"
           ]
         }
-      }
+      },
+      "deprecated": true
     },
     "ModelPreferences": {
       "description": "Preferences for model selection and behavior in sampling requests.\n\nThis allows servers to express their preferences for which model to use\nand how to balance different priorities when the client has multiple\nmodel options available.",
@@ -1679,7 +1683,8 @@
           ],
           "format": "float"
         }
-      }
+      },
+      "deprecated": true
     },
     "MultiSelectEnumSchema": {
       "description": "Multi-select enum options",
@@ -2494,6 +2499,7 @@
           ]
         }
       },
+      "deprecated": true,
       "required": [
         "role",
         "content"
@@ -2501,6 +2507,7 @@
     },
     "SamplingMessageContentBlock": {
       "description": "Content types for sampling messages (SEP-1577).",
+      "deprecated": true,
       "oneOf": [
         {
           "type": "object",
@@ -3379,7 +3386,8 @@
             }
           ]
         }
-      }
+      },
+      "deprecated": true
     },
     "ToolChoiceMode": {
       "description": "Tool selection mode (SEP-1577).",
@@ -3457,6 +3465,7 @@
           "type": "string"
         }
       },
+      "deprecated": true,
       "required": [
         "toolUseId",
         "content"
@@ -3484,6 +3493,7 @@
           "type": "string"
         }
       },
+      "deprecated": true,
       "required": [
         "id",
         "name",


### PR DESCRIPTION
Closes #881

## Motivation and Context

[SEP-2577](https://modelcontextprotocol.io/seps/2577-deprecate-roots-sampling-and-logging) deprecates the Roots, Sampling, and Logging features as of the 2026-07-28 spec. PR #881 already landed the SDK side of this for the service methods and the capability structs/builders, but it did not annotate the corresponding model types, even though the spec's schema reference marks all of them `@deprecated`. 

This PR closes that gap so downstream users get consistent deprecation warnings for the whole surface for the following types:

-  Sampling: `CreateMessageRequest`, `CreateMessageRequestParams`, `CreateMessageResult`, `SamplingMessage`, `SamplingMessageContentBlock`, `ToolUseContent`, `ToolResultContent`, `ModelPreferences`, `ModelHint`, `ToolChoice`
-  Roots: `ListRootsRequest`, `ListRootsResult`, `Root`
-  Logging: `LoggingMessageNotification`, `LoggingMessageNotificationParam`, `LoggingLevel`, `SetLevelRequest`, `SetLevelRequestParams`

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
The message-schema snapshots were regenerated.

## Breaking Changes

No. `#[deprecated]` is advisory only

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) <!-- deprecation annotations: a non-breaking public-API change -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

