### PR TITLE
ci: declare MSRV and add MSRV check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,32 @@ jobs:
             --only-explicit-features \
             --features "$FEATURES"
 
+  msrv:
+    name: MSRV Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust (MSRV)
+        uses: dtolnay/rust-toolchain@1.88
+
+      - uses: Swatinem/rust-cache@v2
+
+      # `rust-toolchain.toml` pins a newer dev toolchain and would otherwise
+      # override the toolchain installed above for in-repo `cargo` invocations.
+      # Forcing `RUSTUP_TOOLCHAIN` ensures the checks actually run on the MSRV.
+      - name: Check rmcp and rmcp-macros at MSRV
+        env:
+          RUSTUP_TOOLCHAIN: "1.88"
+        run: |
+          rustc --version
+          FEATURES=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '[.packages[] | select(.name == "rmcp") | .features | keys[]
+                      | select(startswith("__") | not)
+                      | select(. != "local")] | join(",")')
+          cargo check -p rmcp --features "$FEATURES"
+          cargo check -p rmcp-macros
+
   spelling:
     name: spell check with typos
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ rmcp-macros = { version = "1.8.0", path = "./crates/rmcp-macros" }
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.88"
 version = "1.8.0"
 authors = ["4t145 <u4t145@163.com>"]
 license = "Apache-2.0"

--- a/crates/rmcp-macros/Cargo.toml
+++ b/crates/rmcp-macros/Cargo.toml
@@ -5,6 +5,7 @@ name = "rmcp-macros"
 license = { workspace = true }
 version = { workspace = true }
 edition = { workspace = true }
+rust-version = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 readme = { workspace = true }

--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -3,6 +3,7 @@ name = "rmcp"
 license = { workspace = true }
 version = { workspace = true }
 edition = { workspace = true }
+rust-version = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 readme = { workspace = true }


### PR DESCRIPTION
## Summary

The project sets `edition = "2024"` (which requires Rust >= 1.85) but never declared a **Minimum Supported Rust Version**, so the MSRV was implicit and untested. Downstream consumers had no machine-readable floor, and nothing prevented a change from silently raising it.

This PR:

- **Declares `rust-version = "1.88"`** on `[workspace.package]` in the root `Cargo.toml`, and inherits it (`rust-version = { workspace = true }`) in the published `rmcp` and `rmcp-macros` crates so the value actually applies to what's published to crates.io.
- **Adds an `MSRV Check` CI job** that enforces the promise on every push/PR.

## Why 1.88?

Edition 2024 sets a hard floor of **1.85**. Compiling upward from there in this lockfile, the floor is raised to **1.88** by current dependencies that declare `rust-version = "1.88.0"` — notably `darling`, `jsonwebtoken`, and `time`. Toolchains 1.85–1.87 fail at the resolver stage; **1.88 is the lowest version where both `rmcp` (all features except `local`) and `rmcp-macros` compile cleanly**, so it is the true MSRV.

## The toolchain-override pitfall (handled)

The repo's `rust-toolchain.toml` pins a newer dev toolchain, and that file **overrides** both `rustup default` and the toolchain installed by `dtolnay/rust-toolchain@<ver>` for in-repo `cargo` invocations. A naive MSRV job would therefore silently test the pinned toolchain instead of the MSRV. To avoid that, the job sets `RUSTUP_TOOLCHAIN: "1.88"` on the run step (which takes precedence over `rust-toolchain.toml`) and prints `rustc --version` so the effective toolchain is visible in logs.

The job stays intentionally minimal (checkout, install toolchain, `Swatinem/rust-cache@v2`, `cargo check`) — `cargo check` for `rmcp`/`rmcp-macros` needs no Node/uv/Python setup.

## Test plan

- [x] `cargo +1.88 check -p rmcp --features <all-except-local>` and `cargo +1.88 check -p rmcp-macros` both compile cleanly.
- [x] Confirmed 1.85/1.86/1.87 fail (dependency `rust-version` requirements force 1.88).
- [x] Verified `cargo metadata` reports `rust_version=1.88` for both `rmcp` and `rmcp-macros` (inheritance works).
- [x] Verified that with `rust-toolchain.toml` present, `RUSTUP_TOOLCHAIN=1.88` makes `rustc` report `1.88.0` (job uses the MSRV, not the pinned toolchain).
- [x] YAML validated with `yaml.safe_load`.