### PR TITLE
chore: consolidate repeated rmcp tests

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -200,6 +200,7 @@ tracing-subscriber = { version = "0.3", features = [
   "fmt",
 ] }
 async-trait = "0.1"
+rstest = "0.26.1"
 [[test]]
 name = "test_tool_macros"
 required-features = ["server", "client"]

--- a/crates/rmcp/src/handler/server/common.rs
+++ b/crates/rmcp/src/handler/server/common.rs
@@ -233,6 +233,8 @@ pub trait AsRequestContext {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
@@ -245,46 +247,44 @@ mod tests {
         value: i32,
     }
 
-    #[test]
-    fn test_schema_for_type_handles_primitive() {
-        let schema = schema_for_type::<i32>();
+    #[rstest]
+    #[case::primitive(schema_for_type::<i32>, "integer")]
+    #[case::array(schema_for_type::<Vec<i32>>, "array")]
+    #[case::struct_object(schema_for_type::<TestObject>, "object")]
+    fn schema_for_type_sets_expected_root_type(
+        #[case] schema_fn: fn() -> Arc<JsonObject>,
+        #[case] expected_type: &str,
+    ) {
+        let schema = schema_fn();
 
-        assert_eq!(schema.get("type"), Some(&serde_json::json!("integer")));
+        assert_eq!(schema.get("type"), Some(&serde_json::json!(expected_type)));
     }
 
     #[test]
-    fn test_schema_for_type_handles_array() {
+    fn schema_for_type_sets_array_item_type() {
         let schema = schema_for_type::<Vec<i32>>();
+        let items = schema.get("items").and_then(|v| v.as_object()).unwrap();
 
-        assert_eq!(schema.get("type"), Some(&serde_json::json!("array")));
-        let items = schema.get("items").and_then(|v| v.as_object());
-        assert_eq!(
-            items.unwrap().get("type"),
-            Some(&serde_json::json!("integer"))
-        );
+        assert_eq!(items.get("type"), Some(&serde_json::json!("integer")));
     }
 
     #[test]
-    fn test_schema_for_type_handles_struct() {
+    fn schema_for_type_sets_struct_properties() {
         let schema = schema_for_type::<TestObject>();
+        let properties = schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .unwrap();
 
-        assert_eq!(schema.get("type"), Some(&serde_json::json!("object")));
-        let properties = schema.get("properties").and_then(|v| v.as_object());
-        assert!(properties.unwrap().contains_key("value"));
+        assert!(properties.contains_key("value"));
     }
 
-    #[test]
-    fn test_schema_for_type_caches_primitive_types() {
-        let schema1 = schema_for_type::<i32>();
-        let schema2 = schema_for_type::<i32>();
-
-        assert!(Arc::ptr_eq(&schema1, &schema2));
-    }
-
-    #[test]
-    fn test_schema_for_type_caches_struct_types() {
-        let schema1 = schema_for_type::<TestObject>();
-        let schema2 = schema_for_type::<TestObject>();
+    #[rstest]
+    #[case::primitive(schema_for_type::<i32>)]
+    #[case::struct_object(schema_for_type::<TestObject>)]
+    fn test_schema_for_type_caches_schemas(#[case] schema_fn: fn() -> Arc<JsonObject>) {
+        let schema1 = schema_fn();
+        let schema2 = schema_fn();
 
         assert!(Arc::ptr_eq(&schema1, &schema2));
     }
@@ -305,51 +305,36 @@ mod tests {
         assert!(Arc::ptr_eq(&schema, &cloned));
     }
 
-    #[test]
-    fn test_schema_for_output_rejects_primitive() {
-        let result = schema_for_output::<i32>();
-        assert!(result.is_err(),);
-    }
-
-    #[test]
-    fn test_schema_for_output_accepts_object() {
-        let result = schema_for_output::<TestObject>();
-        assert!(result.is_ok(),);
-    }
-
-    #[test]
-    fn test_schema_for_output_strips_top_level_title() {
-        let schema = schema_for_output::<TestObject>().unwrap();
-        assert!(!schema.contains_key("title"));
-    }
-
-    #[test]
-    fn test_schema_for_output_strips_top_level_description() {
-        let schema = schema_for_output::<TestObject>().unwrap();
-        assert!(!schema.contains_key("description"));
-    }
-
-    #[test]
-    fn test_schema_for_input_rejects_primitive() {
-        let result = schema_for_input::<i32>();
+    #[rstest]
+    #[case::output(schema_for_output::<i32>)]
+    #[case::input(schema_for_input::<i32>)]
+    fn test_schema_for_object_wrappers_reject_primitives(
+        #[case] schema_fn: fn() -> Result<Arc<JsonObject>, String>,
+    ) {
+        let result = schema_fn();
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_schema_for_input_accepts_object() {
-        let result = schema_for_input::<TestObject>();
+    #[rstest]
+    #[case::output(schema_for_output::<TestObject>)]
+    #[case::input(schema_for_input::<TestObject>)]
+    fn test_schema_for_object_wrappers_accept_objects(
+        #[case] schema_fn: fn() -> Result<Arc<JsonObject>, String>,
+    ) {
+        let result = schema_fn();
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_schema_for_input_strips_top_level_title() {
-        let schema = schema_for_input::<TestObject>().unwrap();
-        assert!(!schema.contains_key("title"));
-    }
-
-    #[test]
-    fn test_schema_for_input_strips_top_level_description() {
-        let schema = schema_for_input::<TestObject>().unwrap();
-        assert!(!schema.contains_key("description"));
+    #[rstest]
+    #[case::output_title(schema_for_output::<TestObject>, "title")]
+    #[case::output_description(schema_for_output::<TestObject>, "description")]
+    #[case::input_title(schema_for_input::<TestObject>, "title")]
+    #[case::input_description(schema_for_input::<TestObject>, "description")]
+    fn test_schema_for_object_wrappers_strip_top_level_metadata(
+        #[case] schema_fn: fn() -> Result<Arc<JsonObject>, String>,
+        #[case] field: &str,
+    ) {
+        let schema = schema_fn().unwrap();
+        assert!(!schema.contains_key(field));
     }
 }

--- a/crates/rmcp/src/model/elicitation_schema.rs
+++ b/crates/rmcp/src/model/elicitation_schema.rs
@@ -1701,49 +1701,70 @@ impl ElicitationSchemaBuilder {
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;
+    use rstest::rstest;
     use serde_json::json;
 
     use super::*;
 
-    #[test]
-    fn test_string_schema_serialization() {
-        let schema = StringSchema::email().description("Email address");
-        let json = serde_json::to_value(&schema).unwrap();
-
-        assert_eq!(json["type"], "string");
-        assert_eq!(json["format"], "email");
-        assert_eq!(json["description"], "Email address");
+    fn string_schema_json() -> serde_json::Value {
+        serde_json::to_value(StringSchema::email().description("Email address")).unwrap()
     }
 
-    #[test]
-    fn test_number_schema_serialization() {
-        let schema = NumberSchema::new()
-            .range(0.0, 100.0)
-            .description("Percentage");
-        let json = serde_json::to_value(&schema).unwrap();
-
-        assert_eq!(json["type"], "number");
-        assert_eq!(json["minimum"], 0.0);
-        assert_eq!(json["maximum"], 100.0);
+    fn number_schema_json() -> serde_json::Value {
+        serde_json::to_value(
+            NumberSchema::new()
+                .range(0.0, 100.0)
+                .description("Percentage"),
+        )
+        .unwrap()
     }
 
-    #[test]
-    fn test_integer_schema_serialization() {
-        let schema = IntegerSchema::new().range(0, 150);
-        let json = serde_json::to_value(&schema).unwrap();
-
-        assert_eq!(json["type"], "integer");
-        assert_eq!(json["minimum"], 0);
-        assert_eq!(json["maximum"], 150);
+    fn integer_schema_json() -> serde_json::Value {
+        serde_json::to_value(IntegerSchema::new().range(0, 150)).unwrap()
     }
 
-    #[test]
-    fn test_boolean_schema_serialization() {
-        let schema = BooleanSchema::new().with_default(true);
-        let json = serde_json::to_value(&schema).unwrap();
+    fn boolean_schema_json() -> serde_json::Value {
+        serde_json::to_value(BooleanSchema::new().with_default(true)).unwrap()
+    }
 
-        assert_eq!(json["type"], "boolean");
-        assert_eq!(json["default"], true);
+    #[rstest]
+    #[case::string_schema(
+        string_schema_json,
+        json!({
+            "type": "string",
+            "format": "email",
+            "description": "Email address",
+        })
+    )]
+    #[case::number_schema(
+        number_schema_json,
+        json!({
+            "type": "number",
+            "description": "Percentage",
+            "minimum": 0.0,
+            "maximum": 100.0,
+        })
+    )]
+    #[case::integer_schema(
+        integer_schema_json,
+        json!({
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 150,
+        })
+    )]
+    #[case::boolean_schema(
+        boolean_schema_json,
+        json!({
+            "type": "boolean",
+            "default": true,
+        })
+    )]
+    fn primitive_schema_serializes_to_expected_json(
+        #[case] schema_json: fn() -> serde_json::Value,
+        #[case] expected: serde_json::Value,
+    ) {
+        assert_eq!(schema_json(), expected);
     }
 
     #[test]

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2975,6 +2975,7 @@ mod tests {
     };
 
     use oauth2::{AuthType, CsrfToken, HttpResponse, PkceCodeVerifier};
+    use rstest::rstest;
     use url::Url;
 
     use super::{
@@ -3348,44 +3349,35 @@ mod tests {
 
     // -- header value parsing --
 
-    #[test]
-    fn parse_auth_param_value_handles_quoted_string() {
-        let fragment = r#""example", realm="foo""#;
-        let parsed = AuthorizationManager::parse_next_header_value(fragment).unwrap();
-        assert_eq!(parsed.0, "example");
-        assert_eq!(parsed.1, 9);
-    }
+    #[rstest]
+    #[case::quoted_string(r#""example", realm="foo""#, "example", r#""example""#)]
+    #[case::escaped_quotes_and_whitespace(
+        r#"   "a\"b\\c" ,next=value"#,
+        r#"a"b\c"#,
+        r#"   "a\"b\\c""#
+    )]
+    #[case::token_values("  token,next", "token", "  token")]
+    #[case::semicolon_separated_tokens(
+        r#"  https://example.com/meta; error="invalid_token""#,
+        "https://example.com/meta",
+        "  https://example.com/meta"
+    )]
+    #[case::semicolon_after_quoted_value(
+        r#"  "https://example.com/meta"; error="invalid_token""#,
+        "https://example.com/meta",
+        r#"  "https://example.com/meta""#
+    )]
+    fn parse_auth_param_value_handles_supported_values(
+        #[case] fragment: &str,
+        #[case] expected_value: &str,
+        #[case] expected_consumed_prefix: &str,
+    ) {
+        let (value, consumed) = AuthorizationManager::parse_next_header_value(fragment).unwrap();
 
-    #[test]
-    fn parse_auth_param_value_handles_escaped_quotes_and_whitespace() {
-        let fragment = r#"   "a\"b\\c" ,next=value"#;
-        let parsed = AuthorizationManager::parse_next_header_value(fragment).unwrap();
-        assert_eq!(parsed.0, r#"a"b\c"#);
-        assert_eq!(parsed.1, 12);
-    }
-
-    #[test]
-    fn parse_auth_param_value_handles_token_values() {
-        let fragment = "  token,next";
-        let parsed = AuthorizationManager::parse_next_header_value(fragment).unwrap();
-        assert_eq!(parsed.0, "token");
-        assert_eq!(parsed.1, 7);
-    }
-
-    #[test]
-    fn parse_auth_param_value_handles_semicolon_separated_tokens() {
-        let fragment = r#"  https://example.com/meta; error="invalid_token""#;
-        let parsed = AuthorizationManager::parse_next_header_value(fragment).unwrap();
-        assert_eq!(parsed.0, "https://example.com/meta");
-        assert_eq!(&fragment[..parsed.1], "  https://example.com/meta");
-    }
-
-    #[test]
-    fn parse_auth_param_value_handles_semicolon_after_quoted_value() {
-        let fragment = r#"  "https://example.com/meta"; error="invalid_token""#;
-        let parsed = AuthorizationManager::parse_next_header_value(fragment).unwrap();
-        assert_eq!(parsed.0, "https://example.com/meta");
-        assert_eq!(&fragment[..parsed.1], r#"  "https://example.com/meta""#);
+        assert_eq!(
+            (value.as_str(), &fragment[..consumed]),
+            (expected_value, expected_consumed_prefix)
+        );
     }
 
     #[test]
@@ -4010,104 +4002,113 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn validate_authorization_response_issuer_accepts_match_and_missing_issuer() {
+    #[rstest]
+    #[case::matching_issuer(
+        Some("https://auth.example.com"),
+        false,
+        Some("https://auth.example.com")
+    )]
+    #[case::missing_issuer_when_not_required(Some("https://auth.example.com"), false, None)]
+    fn validate_authorization_response_issuer_accepts_valid_cases(
+        #[case] expected_issuer: Option<&str>,
+        #[case] require_issuer: bool,
+        #[case] received_issuer: Option<&str>,
+    ) {
         let pkce = PkceCodeVerifier::new("verifier".to_string());
         let csrf = CsrfToken::new("csrf".to_string());
         let state = StoredAuthorizationState::new_with_expected_issuer(
             &pkce,
             &csrf,
-            Some("https://auth.example.com".to_string()),
-            false,
+            expected_issuer.map(str::to_owned),
+            require_issuer,
         );
 
         assert!(
-            AuthorizationManager::validate_authorization_response_issuer(
-                &state,
-                Some("https://auth.example.com")
-            )
-            .is_ok()
-        );
-        assert!(AuthorizationManager::validate_authorization_response_issuer(&state, None).is_ok());
-    }
-
-    #[test]
-    fn validate_authorization_response_issuer_requires_issuer_when_advertised() {
-        let pkce = PkceCodeVerifier::new("verifier".to_string());
-        let csrf = CsrfToken::new("csrf".to_string());
-        let state = StoredAuthorizationState::new_with_expected_issuer(
-            &pkce,
-            &csrf,
-            Some("https://auth.example.com".to_string()),
-            true,
-        );
-
-        let error =
-            AuthorizationManager::validate_authorization_response_issuer(&state, None).unwrap_err();
-
-        assert!(matches!(
-            error,
-            AuthError::AuthorizationServerMissingIssuer { expected_issuer }
-                if expected_issuer == "https://auth.example.com"
-        ));
-    }
-
-    #[test]
-    fn validate_authorization_response_issuer_rejects_present_issuer_without_expected_issuer() {
-        let pkce = PkceCodeVerifier::new("verifier".to_string());
-        let csrf = CsrfToken::new("csrf".to_string());
-        let state = StoredAuthorizationState::new_with_expected_issuer(&pkce, &csrf, None, false);
-
-        let error = AuthorizationManager::validate_authorization_response_issuer(
-            &state,
-            Some("https://auth.example.com"),
-        )
-        .unwrap_err();
-
-        assert!(
-            matches!(error, AuthError::AuthorizationFailed(message) if message.contains("expected issuer was not recorded"))
+            AuthorizationManager::validate_authorization_response_issuer(&state, received_issuer)
+                .is_ok()
         );
     }
 
-    #[test]
-    fn validate_authorization_response_issuer_rejects_required_issuer_without_expected_issuer() {
-        let pkce = PkceCodeVerifier::new("verifier".to_string());
-        let csrf = CsrfToken::new("csrf".to_string());
-        let state = StoredAuthorizationState::new_with_expected_issuer(&pkce, &csrf, None, true);
-
-        let error =
-            AuthorizationManager::validate_authorization_response_issuer(&state, None).unwrap_err();
-
-        assert!(
-            matches!(error, AuthError::AuthorizationFailed(message) if message.contains("expected issuer was not recorded"))
-        );
+    #[derive(Clone, Copy, Debug)]
+    enum ExpectedIssuerError {
+        Missing {
+            expected_issuer: &'static str,
+        },
+        NotRecorded,
+        Mismatch {
+            expected_issuer: &'static str,
+            received_issuer: &'static str,
+        },
     }
 
-    #[test]
-    fn validate_authorization_response_issuer_rejects_mismatch() {
-        let pkce = PkceCodeVerifier::new("verifier".to_string());
-        let csrf = CsrfToken::new("csrf".to_string());
-        let state = StoredAuthorizationState::new_with_expected_issuer(
-            &pkce,
-            &csrf,
-            Some("https://auth.example.com".to_string()),
-            false,
-        );
-
-        let error = AuthorizationManager::validate_authorization_response_issuer(
-            &state,
-            Some("https://evil.example.com"),
-        )
-        .unwrap_err();
-
-        assert!(matches!(
-            error,
-            AuthError::AuthorizationServerMismatch {
+    fn assert_expected_issuer_error(error: AuthError, expected: ExpectedIssuerError) {
+        match expected {
+            ExpectedIssuerError::Missing { expected_issuer } => assert!(matches!(
+                error,
+                AuthError::AuthorizationServerMissingIssuer { expected_issuer: actual }
+                    if actual == expected_issuer
+            )),
+            ExpectedIssuerError::NotRecorded => assert!(
+                matches!(error, AuthError::AuthorizationFailed(message) if message.contains("expected issuer was not recorded"))
+            ),
+            ExpectedIssuerError::Mismatch {
                 expected_issuer,
-                received_issuer
-            } if expected_issuer == "https://auth.example.com"
-                && received_issuer == "https://evil.example.com"
-        ));
+                received_issuer,
+            } => assert!(matches!(
+                error,
+                AuthError::AuthorizationServerMismatch {
+                    expected_issuer: actual_expected,
+                    received_issuer: actual_received
+                } if actual_expected == expected_issuer && actual_received == received_issuer
+            )),
+        }
+    }
+
+    #[rstest]
+    #[case::requires_advertised_issuer(
+        Some("https://auth.example.com"),
+        true,
+        None,
+        ExpectedIssuerError::Missing {
+            expected_issuer: "https://auth.example.com",
+        }
+    )]
+    #[case::present_issuer_without_expected(
+        None,
+        false,
+        Some("https://auth.example.com"),
+        ExpectedIssuerError::NotRecorded
+    )]
+    #[case::required_issuer_without_expected(None, true, None, ExpectedIssuerError::NotRecorded)]
+    #[case::mismatched_issuer(
+        Some("https://auth.example.com"),
+        false,
+        Some("https://evil.example.com"),
+        ExpectedIssuerError::Mismatch {
+            expected_issuer: "https://auth.example.com",
+            received_issuer: "https://evil.example.com",
+        }
+    )]
+    fn validate_authorization_response_issuer_rejects_invalid_cases(
+        #[case] expected_issuer: Option<&str>,
+        #[case] require_issuer: bool,
+        #[case] received_issuer: Option<&str>,
+        #[case] expected_error: ExpectedIssuerError,
+    ) {
+        let pkce = PkceCodeVerifier::new("verifier".to_string());
+        let csrf = CsrfToken::new("csrf".to_string());
+        let state = StoredAuthorizationState::new_with_expected_issuer(
+            &pkce,
+            &csrf,
+            expected_issuer.map(str::to_owned),
+            require_issuer,
+        );
+
+        let error =
+            AuthorizationManager::validate_authorization_response_issuer(&state, received_issuer)
+                .unwrap_err();
+
+        assert_expected_issuer_error(error, expected_error);
     }
 
     #[tokio::test]
@@ -4642,62 +4643,40 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn validate_client_credentials_metadata_accepts_supported_method() {
+    fn client_secret_credentials_config() -> super::ClientCredentialsConfig {
+        super::ClientCredentialsConfig::ClientSecret {
+            client_id: "id".to_string(),
+            client_secret: "secret".to_string(),
+            scopes: vec![],
+            resource: None,
+        }
+    }
+
+    fn metadata_with_auth_methods(methods: serde_json::Value) -> AuthorizationMetadata {
         let mut additional_fields = HashMap::new();
-        additional_fields.insert(
-            "token_endpoint_auth_methods_supported".to_string(),
-            serde_json::json!(["client_secret_post", "client_secret_basic"]),
-        );
-        let meta = AuthorizationMetadata {
+        additional_fields.insert("token_endpoint_auth_methods_supported".to_string(), methods);
+        AuthorizationMetadata {
             authorization_endpoint: "http://localhost/authorize".to_string(),
             token_endpoint: "http://localhost/token".to_string(),
             additional_fields,
             ..Default::default()
-        };
-        let mgr = manager_with_metadata(Some(meta)).await;
-        let config = super::ClientCredentialsConfig::ClientSecret {
-            client_id: "id".to_string(),
-            client_secret: "secret".to_string(),
-            scopes: vec![],
-            resource: None,
-        };
-        mgr.validate_client_credentials_metadata(&config).unwrap();
+        }
     }
 
+    #[rstest]
+    #[case::supported_methods(Some(serde_json::json!([
+        "client_secret_post",
+        "client_secret_basic"
+    ])))]
+    #[case::field_absent(None)]
+    #[case::client_secret_basic_only(Some(serde_json::json!(["client_secret_basic"])))]
     #[tokio::test]
-    async fn validate_client_credentials_metadata_permits_when_field_absent() {
-        let mgr = manager_with_metadata(None).await;
-        let config = super::ClientCredentialsConfig::ClientSecret {
-            client_id: "id".to_string(),
-            client_secret: "secret".to_string(),
-            scopes: vec![],
-            resource: None,
-        };
-        mgr.validate_client_credentials_metadata(&config).unwrap();
-    }
+    async fn validate_client_credentials_metadata_accepts_supported_configurations(
+        #[case] auth_methods: Option<serde_json::Value>,
+    ) {
+        let mgr = manager_with_metadata(auth_methods.map(metadata_with_auth_methods)).await;
+        let config = client_secret_credentials_config();
 
-    #[tokio::test]
-    async fn validate_client_credentials_metadata_accepts_client_secret_basic_only() {
-        let mut additional_fields = HashMap::new();
-        additional_fields.insert(
-            "token_endpoint_auth_methods_supported".to_string(),
-            serde_json::json!(["client_secret_basic"]),
-        );
-        let meta = AuthorizationMetadata {
-            authorization_endpoint: "http://localhost/authorize".to_string(),
-            token_endpoint: "http://localhost/token".to_string(),
-            additional_fields,
-            ..Default::default()
-        };
-        let mgr = manager_with_metadata(Some(meta)).await;
-        let config = super::ClientCredentialsConfig::ClientSecret {
-            client_id: "id".to_string(),
-            client_secret: "secret".to_string(),
-            scopes: vec![],
-            resource: None,
-        };
-        // A server advertising only client_secret_basic must be accepted.
         mgr.validate_client_credentials_metadata(&config).unwrap();
     }
 

--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -309,6 +309,8 @@ impl StreamableHttpClientTransport<reqwest::Client> {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::parse_json_rpc_error;
     use crate::{
         model::JsonRpcMessage,
@@ -346,25 +348,15 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn parse_json_rpc_error_rejects_non_error_request() {
-        // A valid JSON-RPC request (method + id) must not be accepted as an error.
-        let body = r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+    #[rstest]
+    #[case::non_error_request(r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#)]
+    #[case::notification(
+        r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}}"#
+    )]
+    #[case::plain_text("not json at all")]
+    #[case::empty("")]
+    #[case::truncated_json(r#"{"broken":"#)]
+    fn parse_json_rpc_error_rejects_non_error_bodies(#[case] body: &str) {
         assert!(parse_json_rpc_error(body).is_none());
-    }
-
-    #[test]
-    fn parse_json_rpc_error_rejects_notification() {
-        // A notification (method, no id) must not be accepted as an error.
-        let body =
-            r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}}"#;
-        assert!(parse_json_rpc_error(body).is_none());
-    }
-
-    #[test]
-    fn parse_json_rpc_error_rejects_malformed_json() {
-        assert!(parse_json_rpc_error("not json at all").is_none());
-        assert!(parse_json_rpc_error("").is_none());
-        assert!(parse_json_rpc_error(r#"{"broken":"#).is_none());
     }
 }

--- a/crates/rmcp/tests/test_inflight_response_drain.rs
+++ b/crates/rmcp/tests/test_inflight_response_drain.rs
@@ -23,6 +23,7 @@ use tokio::io::{AsyncRead, ReadBuf};
 // A slow tool server that sleeps before returning a response.
 #[derive(Debug, Clone)]
 struct SlowToolServer {
+    #[expect(dead_code, reason = "tool_handler macro accesses this router field")]
     tool_router: ToolRouter<Self>,
 }
 

--- a/crates/rmcp/tests/test_notification.rs
+++ b/crates/rmcp/tests/test_notification.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 use tokio::sync::{Mutex, Notify};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-pub struct Server {}
+struct Server {}
 
 impl ServerHandler for Server {
     fn get_info(&self) -> ServerInfo {

--- a/crates/rmcp/tests/test_progress_subscriber.rs
+++ b/crates/rmcp/tests/test_progress_subscriber.rs
@@ -39,6 +39,7 @@ impl ClientHandler for MyClient {
 }
 
 pub struct MyServer {
+    #[expect(dead_code, reason = "tool_handler macro accesses this router field")]
     tool_router: ToolRouter<Self>,
 }
 

--- a/crates/rmcp/tests/test_prompt_macros.rs
+++ b/crates/rmcp/tests/test_prompt_macros.rs
@@ -17,9 +17,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, JsonSchema)]
-pub struct CodeReviewRequest {
-    pub file_path: String,
-    pub language: String,
+struct CodeReviewRequest {
+    file_path: String,
+    language: String,
 }
 
 #[prompt_handler(router = self.prompt_router)]
@@ -194,17 +194,17 @@ impl CodeReviewRequest {}
 
 // Struct defined for testing optional field schema generation
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct OptionalFieldTestSchema {
+struct OptionalFieldTestSchema {
     #[schemars(description = "An optional description field")]
-    pub description: Option<String>,
+    description: Option<String>,
 }
 
 // Struct defined for testing optional i64 field schema generation and null handling
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct OptionalI64TestSchema {
+struct OptionalI64TestSchema {
     #[schemars(description = "An optional i64 field")]
-    pub count: Option<i64>,
-    pub mandatory_field: String, // Added to ensure non-empty object schema
+    count: Option<i64>,
+    mandatory_field: String, // Added to ensure non-empty object schema
 }
 
 // Dummy struct to host the test prompt method

--- a/crates/rmcp/tests/test_prompt_routers.rs
+++ b/crates/rmcp/tests/test_prompt_routers.rs
@@ -9,21 +9,21 @@ use rmcp::{
 };
 
 #[derive(Debug, Default)]
-pub struct TestHandler<T: 'static = ()> {
-    pub _marker: std::marker::PhantomData<fn(*const T)>,
+struct TestHandler<T: 'static = ()> {
+    _marker: std::marker::PhantomData<fn(*const T)>,
 }
 
 impl<T: 'static> ServerHandler for TestHandler<T> {}
 
 #[derive(Debug, schemars::JsonSchema, serde::Deserialize, serde::Serialize)]
-pub struct Request {
-    pub fields: HashMap<String, String>,
+struct Request {
+    fields: HashMap<String, String>,
 }
 
 #[derive(Debug, schemars::JsonSchema, serde::Deserialize, serde::Serialize)]
-pub struct Sum {
-    pub a: i32,
-    pub b: i32,
+struct Sum {
+    a: i32,
+    b: i32,
 }
 
 #[rmcp::prompt_router(router = "test_router")]

--- a/crates/rmcp/tests/test_task_support_validation.rs
+++ b/crates/rmcp/tests/test_task_support_validation.rs
@@ -18,6 +18,7 @@ use rmcp::{
 /// Server with tools having different task support modes.
 #[derive(Debug, Clone)]
 pub struct TaskSupportTestServer {
+    #[expect(dead_code, reason = "tool_handler macro accesses this router field")]
     tool_router: ToolRouter<Self>,
 }
 

--- a/crates/rmcp/tests/test_tool_disable_notification.rs
+++ b/crates/rmcp/tests/test_tool_disable_notification.rs
@@ -45,33 +45,26 @@ impl ServerHandler for TestToolServer {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
     }
 
-    fn call_tool(
+    async fn call_tool(
         &self,
         request: rmcp::model::CallToolRequestParams,
         context: rmcp::service::RequestContext<RoleServer>,
-    ) -> impl std::future::Future<Output = Result<CallToolResult, rmcp::ErrorData>> + MaybeSendFuture + '_
-    {
-        async move {
-            let router = self.router.read().await;
-            let tcc = ToolCallContext::new(self, request, context);
-            router.call(tcc).await
-        }
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let router = self.router.read().await;
+        let tcc = ToolCallContext::new(self, request, context);
+        router.call(tcc).await
     }
 
-    fn list_tools(
+    async fn list_tools(
         &self,
         _request: Option<rmcp::model::PaginatedRequestParams>,
         _context: rmcp::service::RequestContext<RoleServer>,
-    ) -> impl std::future::Future<Output = Result<rmcp::model::ListToolsResult, rmcp::ErrorData>>
-    + MaybeSendFuture
-    + '_ {
-        async move {
-            let router = self.router.read().await;
-            Ok(rmcp::model::ListToolsResult {
-                tools: router.list_all(),
-                ..Default::default()
-            })
-        }
+    ) -> Result<rmcp::model::ListToolsResult, rmcp::ErrorData> {
+        let router = self.router.read().await;
+        Ok(rmcp::model::ListToolsResult {
+            tools: router.list_all(),
+            ..Default::default()
+        })
     }
 
     fn on_initialized(

--- a/crates/rmcp/tests/test_tool_macros.rs
+++ b/crates/rmcp/tests/test_tool_macros.rs
@@ -18,11 +18,11 @@ use serde::{Deserialize, Serialize};
 
 /// Parameters for weather tool.
 #[derive(Serialize, Deserialize, JsonSchema)]
-pub struct GetWeatherRequest {
+struct GetWeatherRequest {
     /// City of interest.
-    pub city: String,
+    city: String,
     /// Date of interest.
-    pub date: String,
+    date: String,
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -162,21 +162,21 @@ impl GetWeatherRequest {}
 
 /// Struct defined for testing optional field schema generation.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct OptionalFieldTestSchema {
+struct OptionalFieldTestSchema {
     /// Field description.
     #[schemars(description = "An optional description field")]
-    pub description: Option<String>,
+    description: Option<String>,
 }
 
 /// Struct defined for testing optional i64 field schema generation and null handling.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-pub struct OptionalI64TestSchema {
+struct OptionalI64TestSchema {
     /// Optional count field.
     #[schemars(description = "An optional i64 field")]
-    pub count: Option<i64>,
+    count: Option<i64>,
 
     /// Added to ensure non-empty object schema.
-    pub mandatory_field: String,
+    mandatory_field: String,
 }
 
 /// Dummy struct to host the test tool method.
@@ -370,7 +370,7 @@ async fn test_optional_i64_field_with_null_input() -> anyhow::Result<()> {
 
 /// Minimal server: no tool_router field, no new(), no get_info().
 #[derive(Debug, Clone)]
-pub struct MinimalServer;
+struct MinimalServer;
 
 #[tool_router]
 impl MinimalServer {
@@ -452,7 +452,7 @@ async fn test_minimal_server_tool_call() -> anyhow::Result<()> {
 /// Same minimal pattern as [`MinimalServer`], but `#[tool_handler]` is omitted using
 /// `#[tool_router(server_handler)]` (emits `#[tool_handler]` for a second macro pass).
 #[derive(Debug, Clone)]
-pub struct ElidedToolHandlerServer;
+struct ElidedToolHandlerServer;
 
 #[tool_router(server_handler)]
 impl ElidedToolHandlerServer {
@@ -509,7 +509,7 @@ async fn test_tool_router_server_handler_flag_end_to_end_tool_call() -> anyhow::
 
 /// Server with custom name/version/instructions via tool_handler attributes.
 #[derive(Debug, Clone)]
-pub struct CustomInfoServer;
+struct CustomInfoServer;
 
 #[tool_router]
 impl CustomInfoServer {
@@ -539,7 +539,7 @@ fn test_custom_info_server() {
 
 /// Server that provides its own get_info() — macro should not override it.
 #[derive(Debug, Clone)]
-pub struct ManualInfoServer;
+struct ManualInfoServer;
 
 #[tool_router]
 impl ManualInfoServer {

--- a/crates/rmcp/tests/test_tool_routers.rs
+++ b/crates/rmcp/tests/test_tool_routers.rs
@@ -11,20 +11,20 @@ use rmcp::{
 };
 
 #[derive(Debug, Default)]
-pub struct TestHandler<T: 'static = ()> {
-    pub _marker: std::marker::PhantomData<fn(*const T)>,
+struct TestHandler<T: 'static = ()> {
+    _marker: std::marker::PhantomData<fn(*const T)>,
 }
 
 impl<T: 'static> ServerHandler for TestHandler<T> {}
 #[derive(Debug, schemars::JsonSchema, serde::Deserialize, serde::Serialize)]
-pub struct Request {
-    pub fields: HashMap<String, String>,
+struct Request {
+    fields: HashMap<String, String>,
 }
 
 #[derive(Debug, schemars::JsonSchema, serde::Deserialize, serde::Serialize)]
-pub struct Sum {
-    pub a: i32,
-    pub b: i32,
+struct Sum {
+    a: i32,
+    b: i32,
 }
 
 #[rmcp::tool_router(router = test_router_1)]


### PR DESCRIPTION
## Motivation and Context

This introduces `rstest` for repeated rmcp unit-test cases so near-duplicate test clusters can stay individually reported without hand-written loops. It also cleans up existing test-target lint failures by making private test fixtures private, simplifying manual future-returning test handlers to async fns, and keeping macro-only router fields explicitly expected. Before this change, strict clippy on the rmcp test targets failed on `clippy::exhaustive_structs`, `clippy::manual_async_fn`, and `dead_code`; after the cleanup, `cargo clippy -p rmcp --all-targets --all-features --locked -- -D warnings` passes.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Before:

```text
❯ cargo clippy -p rmcp --features "client auth elicitation transport-streamable-http-client-reqwest" --lib --tests -- -D warnings
    Checking rmcp v1.8.0 (/Users/dale.seo/dale/rust-sdk/crates/rmcp)
error: unused imports: `ListPromptsResult`, `PaginatedRequestParams`, `RoleServer`, and `service::RequestContext`
  --> crates/rmcp/tests/test_prompt_macros.rs:7:20
   |
 7 |     ClientHandler, RoleServer, ServerHandler, ServiceExt,
   |                    ^^^^^^^^^^
...
10 |         ClientInfo, ContentBlock, GetPromptRequestParams, GetPromptResult, ListPromptsResult,
   |                                                                            ^^^^^^^^^^^^^^^^^
11 |         PaginatedRequestParams, PromptMessage, Role,
   |         ^^^^^^^^^^^^^^^^^^^^^^
...
14 |     service::RequestContext,
   |     ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D unused-imports` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_imports)]`

error: this function can be simplified using the `async fn` syntax
  --> crates/rmcp/tests/test_tool_disable_notification.rs:48:5
   |
48 | /     fn call_tool(
49 | |         &self,
50 | |         request: rmcp::model::CallToolRequestParams,
51 | |         context: rmcp::service::RequestContext<RoleServer>,
52 | |     ) -> impl std::future::Future<Output = Result<CallToolResult, rmcp::ErrorData>> + MaybeSendFuture + '_
   | |__________________________________________________________________________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#manual_async_fn
   = note: `-D clippy::manual-async-fn` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::manual_async_fn)]`

error: this function can be simplified using the `async fn` syntax
  --> crates/rmcp/tests/test_tool_disable_notification.rs:61:5
   |
61 | /     fn list_tools(
62 | |         &self,
63 | |         _request: Option<rmcp::model::PaginatedRequestParams>,
64 | |         _context: rmcp::service::RequestContext<RoleServer>,
65 | |     ) -> impl std::future::Future<Output = Result<rmcp::model::ListToolsResult, rmcp::ErrorData>>
66 | |     + MaybeSendFuture
67 | |     + '_ {
   | |________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#manual_async_fn

error: exported structs should not be exhaustive
  --> crates/rmcp/tests/test_notification.rs:15:1
   |
15 | pub struct Server {}
   | ^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
   = note: `-D clippy::exhaustive-structs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::exhaustive_structs)]`
help: try adding #[non_exhaustive]
   |
15 + #[non_exhaustive]
16 | pub struct Server {}
   |

error: could not compile `rmcp` (test "test_tool_disable_notification") due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `rmcp` (test "test_notification") due to 1 previous error
error: field `tool_router` is never read
  --> crates/rmcp/tests/test_task_support_validation.rs:21:5
   |
20 | pub struct TaskSupportTestServer {
   |            --------------------- field in this struct
21 |     tool_router: ToolRouter<Self>,
   |     ^^^^^^^^^^^
   |
   = note: `TaskSupportTestServer` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[expect(dead_code)]` or `#[allow(dead_code)]`

error: could not compile `rmcp` (test "test_task_support_validation") due to 1 previous error
error: exported structs should not be exhaustive
  --> crates/rmcp/tests/test_prompt_macros.rs:20:1
   |
20 | / pub struct CodeReviewRequest {
21 | |     pub file_path: String,
22 | |     pub language: String,
23 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
   = note: `-D clippy::exhaustive-structs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::exhaustive_structs)]`
help: try adding #[non_exhaustive]
   |
20 + #[non_exhaustive]
21 | pub struct CodeReviewRequest {
   |

error: exported structs should not be exhaustive
   --> crates/rmcp/tests/test_prompt_macros.rs:197:1
    |
197 | / pub struct OptionalFieldTestSchema {
198 | |     #[schemars(description = "An optional description field")]
199 | |     pub description: Option<String>,
200 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
help: try adding #[non_exhaustive]
    |
197 + #[non_exhaustive]
198 | pub struct OptionalFieldTestSchema {
    |

error: exported structs should not be exhaustive
   --> crates/rmcp/tests/test_prompt_macros.rs:204:1
    |
204 | / pub struct OptionalI64TestSchema {
205 | |     #[schemars(description = "An optional i64 field")]
206 | |     pub count: Option<i64>,
207 | |     pub mandatory_field: String, // Added to ensure non-empty object schema
208 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
help: try adding #[non_exhaustive]
    |
204 + #[non_exhaustive]
205 | pub struct OptionalI64TestSchema {
    |

error: could not compile `rmcp` (test "test_prompt_macros") due to 4 previous errors
error: exported structs should not be exhaustive
  --> crates/rmcp/tests/test_prompt_routers.rs:12:1
   |
12 | / pub struct TestHandler<T: 'static = ()> {
13 | |     pub _marker: std::marker::PhantomData<fn(*const T)>,
14 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
   = note: `-D clippy::exhaustive-structs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::exhaustive_structs)]`
help: try adding #[non_exhaustive]
   |
12 + #[non_exhaustive]
13 | pub struct TestHandler<T: 'static = ()> {
   |

error: exported structs should not be exhaustive
  --> crates/rmcp/tests/test_prompt_routers.rs:19:1
   |
19 | / pub struct Request {
20 | |     pub fields: HashMap<String, String>,
21 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
help: try adding #[non_exhaustive]
   |
19 + #[non_exhaustive]
20 | pub struct Request {
   |

error: exported structs should not be exhaustive
  --> crates/rmcp/tests/test_prompt_routers.rs:24:1
   |
24 | / pub struct Sum {
25 | |     pub a: i32,
26 | |     pub b: i32,
27 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
help: try adding #[non_exhaustive]
   |
24 + #[non_exhaustive]
25 | pub struct Sum {
   |

error: could not compile `rmcp` (test "test_prompt_routers") due to 3 previous errors
error: exported structs should not be exhaustive
  --> crates/rmcp/tests/test_tool_macros.rs:21:1
   |
21 | / pub struct GetWeatherRequest {
22 | |     /// City of interest.
23 | |     pub city: String,
24 | |     /// Date of interest.
25 | |     pub date: String,
26 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
   = note: `-D clippy::exhaustive-structs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::exhaustive_structs)]`
help: try adding #[non_exhaustive]
   |
21 + #[non_exhaustive]
22 | pub struct GetWeatherRequest {
   |

error: exported structs should not be exhaustive
   --> crates/rmcp/tests/test_tool_macros.rs:165:1
    |
165 | / pub struct OptionalFieldTestSchema {
166 | |     /// Field description.
167 | |     #[schemars(description = "An optional description field")]
168 | |     pub description: Option<String>,
169 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
help: try adding #[non_exhaustive]
    |
165 + #[non_exhaustive]
166 | pub struct OptionalFieldTestSchema {
    |

error: exported structs should not be exhaustive
   --> crates/rmcp/tests/test_tool_macros.rs:173:1
    |
173 | / pub struct OptionalI64TestSchema {
174 | |     /// Optional count field.
175 | |     #[schemars(description = "An optional i64 field")]
176 | |     pub count: Option<i64>,
...   |
179 | |     pub mandatory_field: String,
180 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
help: try adding #[non_exhaustive]
    |
173 + #[non_exhaustive]
174 | pub struct OptionalI64TestSchema {
    |

error: exported structs should not be exhaustive
   --> crates/rmcp/tests/test_tool_macros.rs:373:1
    |
373 | pub struct MinimalServer;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
help: try adding #[non_exhaustive]
    |
373 + #[non_exhaustive]
374 | pub struct MinimalServer;
    |

error: exported structs should not be exhaustive
   --> crates/rmcp/tests/test_tool_macros.rs:455:1
    |
455 | pub struct ElidedToolHandlerServer;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
help: try adding #[non_exhaustive]
    |
455 + #[non_exhaustive]
456 | pub struct ElidedToolHandlerServer;
    |

error: exported structs should not be exhaustive
   --> crates/rmcp/tests/test_tool_macros.rs:512:1
    |
512 | pub struct CustomInfoServer;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
help: try adding #[non_exhaustive]
    |
512 + #[non_exhaustive]
513 | pub struct CustomInfoServer;
    |

error: exported structs should not be exhaustive
   --> crates/rmcp/tests/test_tool_macros.rs:542:1
    |
542 | pub struct ManualInfoServer;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#exhaustive_structs
help: try adding #[non_exhaustive]
    |
542 + #[non_exhaustive]
543 | pub struct ManualInfoServer;
    |

error: could not compile `rmcp` (test "test_tool_macros") due to 7 previous errors
```

After:

```text
❯ cargo clippy -p rmcp --features "client auth elicitation transport-streamable-http-client-reqwest" --lib --tests -- -D warnings
    Checking rmcp v1.8.0 (/Users/dale.seo/dale/rust-sdk/crates/rmcp)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.18s
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
