### PR TITLE
Revert "feat!: relax tool result structuredContent type (SEP-2106)"

### DIFF
--- a/crates/rmcp/src/model/content.rs
+++ b/crates/rmcp/src/model/content.rs
@@ -10,7 +10,7 @@
 // ToolUseContent/ToolResultContent are SEP-2577-deprecated; internal references are expected.
 #![expect(deprecated)]
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::json;
 
 use super::{Annotations, Meta, resource::ResourceContents};
 
@@ -207,7 +207,7 @@ pub struct ToolResultContent {
     pub tool_use_id: String,
     pub content: Vec<ContentBlock>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub structured_content: Option<Value>,
+    pub structured_content: Option<super::JsonObject>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_error: Option<bool>,
 }

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
@@ -2352,7 +2352,13 @@
             "null"
           ]
         },
-        "structuredContent": true,
+        "structuredContent": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "toolUseId": {
           "type": "string"
         }

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
@@ -2352,7 +2352,13 @@
             "null"
           ]
         },
-        "structuredContent": true,
+        "structuredContent": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "toolUseId": {
           "type": "string"
         }

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -3454,7 +3454,13 @@
             "null"
           ]
         },
-        "structuredContent": true,
+        "structuredContent": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "toolUseId": {
           "type": "string"
         }

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -3454,7 +3454,13 @@
             "null"
           ]
         },
-        "structuredContent": true,
+        "structuredContent": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "toolUseId": {
           "type": "string"
         }

--- a/crates/rmcp/tests/test_sampling.rs
+++ b/crates/rmcp/tests/test_sampling.rs
@@ -371,38 +371,6 @@ fn test_tool_result_content_requires_content() {
 }
 
 #[tokio::test]
-async fn test_tool_result_content_with_array_structured_content() -> Result<()> {
-    let structured =
-        serde_json::json!([{ "city": "SF", "temp": 72 }, { "city": "NY", "temp": 65 }]);
-    let mut tool_result = ToolResultContent::new("call_123", vec![ContentBlock::text("forecast")]);
-    tool_result.structured_content = Some(structured);
-
-    let json = serde_json::to_string(&tool_result)?;
-    let deserialized: ToolResultContent = serde_json::from_str(&json)?;
-    assert_eq!(tool_result, deserialized);
-    assert!(deserialized.structured_content.unwrap().is_array());
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_tool_result_content_with_primitive_structured_content() -> Result<()> {
-    let structured = serde_json::json!(42);
-    let mut tool_result = ToolResultContent::new("call_123", vec![ContentBlock::text("count")]);
-    tool_result.structured_content = Some(structured);
-
-    let json = serde_json::to_string(&tool_result)?;
-    let deserialized: ToolResultContent = serde_json::from_str(&json)?;
-    assert_eq!(tool_result, deserialized);
-    assert!(matches!(
-        deserialized.structured_content,
-        Some(serde_json::Value::Number(_))
-    ));
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn test_sampling_message_with_tool_use() -> Result<()> {
     let message = SamplingMessage::assistant_tool_use(
         "call_123",


### PR DESCRIPTION
Reverts modelcontextprotocol/rust-sdk#919. This is a breaking change for 2026-07-28 so should wait for v2 to come out first.