### PR TITLE
fix: don't respond to unparseable messages

### DIFF
--- a/crates/rmcp/src/transport/async_rw.rs
+++ b/crates/rmcp/src/transport/async_rw.rs
@@ -13,10 +13,7 @@ use tokio_util::{
 };
 
 use super::{IntoTransport, Transport};
-use crate::{
-    model::ErrorData,
-    service::{RxJsonRpcMessage, ServiceRole, TxJsonRpcMessage},
-};
+use crate::service::{RxJsonRpcMessage, ServiceRole, TxJsonRpcMessage};
 
 #[non_exhaustive]
 pub enum TransportAdapterAsyncRW {}
@@ -143,16 +140,12 @@ where
                 Ok(Some(msg)) => return Some(msg),
                 Ok(None) => continue,
                 Err(JsonRpcMessageCodecError::Serde(e)) => {
-                    tracing::debug!("Parse error on incoming message: {e}");
-                    let mut write = self.write.lock().await;
-                    let framed = write.as_mut()?;
-                    let response = TxJsonRpcMessage::<Role>::error(
-                        ErrorData::parse_error("Parse error", None),
-                        None,
-                    );
-                    if framed.send(response).await.is_err() {
-                        return None;
-                    }
+                    // Don't respond to unparseable input. The message id is unknown, so a response
+                    // can't be correlated to a request, and replying to invalid data can trigger an
+                    // error storm if the peer echoes the response back as more invalid data. This
+                    // matches the other official MCP SDKs, which ignore unparseable messages.
+                    // See https://github.com/modelcontextprotocol/rust-sdk/issues/938
+                    tracing::debug!("Ignoring unparseable incoming message: {e}");
                 }
                 Err(e) => {
                     tracing::error!("Error reading from stream: {}", e);
@@ -618,8 +611,8 @@ mod test {
 
     #[cfg(feature = "server")]
     #[tokio::test]
-    async fn receive_recovers_from_parse_error() {
-        use tokio::io::AsyncWriteExt;
+    async fn receive_ignores_parse_error() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
         use crate::{RoleServer, transport::Transport};
 
@@ -638,28 +631,25 @@ mod test {
             .await
             .unwrap();
 
+        // The unparseable line is skipped and the next valid message is still yielded.
         let received = transport
             .receive()
             .await
-            .expect("transport should recover and yield the next valid message");
-
-        // Read one line back from the peer side and parse as JSON.
-        let mut reply_buf = Vec::new();
-        let mut peer = tokio::io::BufReader::new(&mut client_r);
-        peer.read_until(b'\n', &mut reply_buf).await.unwrap();
-        let reply: serde_json::Value = serde_json::from_slice(&reply_buf).unwrap();
-
-        // Per MCP 2025-11-25: id is omitted when the server can't read the request id.
-        assert_eq!(
-            reply,
-            serde_json::json!({
-                "jsonrpc": "2.0",
-                "error": {"code": -32700, "message": "Parse error"},
-            })
-        );
+            .expect("transport should skip the invalid line and yield the next valid message");
         assert_eq!(
             serde_json::to_value(&received).unwrap()["method"],
             "notifications/initialized",
+        );
+
+        // No response is sent back for the unparseable message (issue #938). Dropping the
+        // transport closes its write side, so the peer reads to EOF and should see no bytes.
+        drop(transport);
+        let mut reply_buf = Vec::new();
+        client_r.read_to_end(&mut reply_buf).await.unwrap();
+        assert!(
+            reply_buf.is_empty(),
+            "expected no response to an unparseable message, got: {}",
+            String::from_utf8_lossy(&reply_buf),
         );
     }
 }

--- a/crates/rmcp/src/transport/async_rw.rs
+++ b/crates/rmcp/src/transport/async_rw.rs
@@ -153,14 +153,14 @@ where
                             tracing::debug!("Ignoring unparsable incoming message: {e}");
                         }
                         serde_json::error::Category::Data | serde_json::error::Category::Io => {
-                            // Valid JSON that doesn't match the expected message shape is a real
-                            // protocol error rather than unparsable input, so surface it with a
-                            // response instead of silently dropping it.
+                            // Well-formed JSON that doesn't match the expected message shape is a
+                            // real protocol error rather than unparsable input, so surface it with
+                            // an Invalid Request response instead of silently dropping it.
                             tracing::debug!("Protocol error on incoming message: {e}");
                             let mut write = self.write.lock().await;
                             let framed = write.as_mut()?;
                             let response = TxJsonRpcMessage::<Role>::error(
-                                ErrorData::parse_error("Parse error", None),
+                                ErrorData::invalid_request("Invalid request", None),
                                 None,
                             );
                             if framed.send(response).await.is_err() {
@@ -715,7 +715,7 @@ mod test {
             reply,
             serde_json::json!({
                 "jsonrpc": "2.0",
-                "error": {"code": -32700, "message": "Parse error"},
+                "error": {"code": -32600, "message": "Invalid request"},
             }),
         );
     }

--- a/crates/rmcp/src/transport/async_rw.rs
+++ b/crates/rmcp/src/transport/async_rw.rs
@@ -13,7 +13,10 @@ use tokio_util::{
 };
 
 use super::{IntoTransport, Transport};
-use crate::service::{RxJsonRpcMessage, ServiceRole, TxJsonRpcMessage};
+use crate::{
+    model::ErrorData,
+    service::{RxJsonRpcMessage, ServiceRole, TxJsonRpcMessage},
+};
 
 #[non_exhaustive]
 pub enum TransportAdapterAsyncRW {}
@@ -140,12 +143,31 @@ where
                 Ok(Some(msg)) => return Some(msg),
                 Ok(None) => continue,
                 Err(JsonRpcMessageCodecError::Serde(e)) => {
-                    // Don't respond to unparsable input. The message id is unknown, so a response
-                    // can't be correlated to a request, and replying to invalid data can trigger an
-                    // error storm if the peer echoes the response back as more invalid data. This
-                    // matches the other official MCP SDKs, which ignore unparsable messages.
-                    // See https://github.com/modelcontextprotocol/rust-sdk/issues/938
-                    tracing::debug!("Ignoring unparsable incoming message: {e}");
+                    match e.classify() {
+                        serde_json::error::Category::Syntax | serde_json::error::Category::Eof => {
+                            // The input isn't valid JSON, so there's no message id to correlate a
+                            // response to, and replying to invalid data can trigger an error storm
+                            // if the peer echoes the response back as more invalid data. This
+                            // matches the other official MCP SDKs, which ignore unparsable input.
+                            // See https://github.com/modelcontextprotocol/rust-sdk/issues/938
+                            tracing::debug!("Ignoring unparsable incoming message: {e}");
+                        }
+                        serde_json::error::Category::Data | serde_json::error::Category::Io => {
+                            // Valid JSON that doesn't match the expected message shape is a real
+                            // protocol error rather than unparsable input, so surface it with a
+                            // response instead of silently dropping it.
+                            tracing::debug!("Protocol error on incoming message: {e}");
+                            let mut write = self.write.lock().await;
+                            let framed = write.as_mut()?;
+                            let response = TxJsonRpcMessage::<Role>::error(
+                                ErrorData::parse_error("Parse error", None),
+                                None,
+                            );
+                            if framed.send(response).await.is_err() {
+                                return None;
+                            }
+                        }
+                    }
                 }
                 Err(e) => {
                     tracing::error!("Error reading from stream: {}", e);
@@ -650,6 +672,51 @@ mod test {
             reply_buf.is_empty(),
             "expected no response to an unparsable message, got: {}",
             String::from_utf8_lossy(&reply_buf),
+        );
+    }
+
+    #[cfg(feature = "server")]
+    #[tokio::test]
+    async fn receive_responds_to_protocol_error() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        use crate::{RoleServer, transport::Transport};
+
+        let (server_io, client_io) = tokio::io::duplex(4096);
+        let (server_r, server_w) = tokio::io::split(server_io);
+        let (client_r, mut client_w) = tokio::io::split(client_io);
+
+        let mut transport = AsyncRwTransport::<RoleServer, _, _>::new(server_r, server_w);
+
+        // Well-formed JSON that does not match the JSON-RPC message shape, followed by a
+        // valid notification. Unlike unparsable bytes, this is a protocol error: the
+        // transport should reply to it and still yield the next valid message.
+        client_w
+            .write_all(
+                b"{\"foo\":\"bar\"}\n{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
+            )
+            .await
+            .unwrap();
+
+        let received = transport.receive().await.expect(
+            "transport should reply to the protocol error and yield the next valid message",
+        );
+        assert_eq!(
+            serde_json::to_value(&received).unwrap()["method"],
+            "notifications/initialized",
+        );
+
+        // A protocol error gets an error response back (id omitted since it can't be read).
+        let mut reply_buf = Vec::new();
+        let mut peer = BufReader::new(client_r);
+        peer.read_until(b'\n', &mut reply_buf).await.unwrap();
+        let reply: serde_json::Value = serde_json::from_slice(&reply_buf).unwrap();
+        assert_eq!(
+            reply,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "error": {"code": -32700, "message": "Parse error"},
+            }),
         );
     }
 }

--- a/crates/rmcp/src/transport/async_rw.rs
+++ b/crates/rmcp/src/transport/async_rw.rs
@@ -140,12 +140,12 @@ where
                 Ok(Some(msg)) => return Some(msg),
                 Ok(None) => continue,
                 Err(JsonRpcMessageCodecError::Serde(e)) => {
-                    // Don't respond to unparseable input. The message id is unknown, so a response
+                    // Don't respond to unparsable input. The message id is unknown, so a response
                     // can't be correlated to a request, and replying to invalid data can trigger an
                     // error storm if the peer echoes the response back as more invalid data. This
-                    // matches the other official MCP SDKs, which ignore unparseable messages.
+                    // matches the other official MCP SDKs, which ignore unparsable messages.
                     // See https://github.com/modelcontextprotocol/rust-sdk/issues/938
-                    tracing::debug!("Ignoring unparseable incoming message: {e}");
+                    tracing::debug!("Ignoring unparsable incoming message: {e}");
                 }
                 Err(e) => {
                     tracing::error!("Error reading from stream: {}", e);
@@ -631,7 +631,7 @@ mod test {
             .await
             .unwrap();
 
-        // The unparseable line is skipped and the next valid message is still yielded.
+        // The unparsable line is skipped and the next valid message is still yielded.
         let received = transport
             .receive()
             .await
@@ -641,14 +641,14 @@ mod test {
             "notifications/initialized",
         );
 
-        // No response is sent back for the unparseable message (issue #938). Dropping the
+        // No response is sent back for the unparsable message (issue #938). Dropping the
         // transport closes its write side, so the peer reads to EOF and should see no bytes.
         drop(transport);
         let mut reply_buf = Vec::new();
         client_r.read_to_end(&mut reply_buf).await.unwrap();
         assert!(
             reply_buf.is_empty(),
-            "expected no response to an unparseable message, got: {}",
+            "expected no response to an unparsable message, got: {}",
             String::from_utf8_lossy(&reply_buf),
         );
     }


### PR DESCRIPTION
Fixes #938.

When rmcp receives invalid JSON on the stdio / async-read-write transport, it replies with `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}`. As reported in the issue, rmcp is the only official MCP SDK that responds to unparseable input, and responding can cause an error storm: if the peer treats the response itself as invalid data and answers with another error, the two sides bounce parse errors back and forth. The reporter hit this against a stdio server that accidentally wrote a log line to stdout.

This makes the transport ignore unparseable messages instead of responding. It still logs at `debug` and continues reading the next message, which matches the behavior of the other official SDKs. The now-unused `ErrorData` import is removed, and the existing test is updated to assert that no response is sent (and that the following valid message is still delivered).

Verified locally:
- `cargo test -p rmcp --features server,transport-async-rw` (the updated `receive_ignores_parse_error` test passes)
- `cargo clippy -p rmcp --all-features --all-targets -- -D warnings`
- `cargo +nightly fmt --check`
