### PR TITLE
feat: add server/discover model types

### DIFF
--- a/crates/rmcp/tests/test_deserialization.rs
+++ b/crates/rmcp/tests/test_deserialization.rs
@@ -1,4 +1,53 @@
-use rmcp::model::{JsonRpcResponse, ServerJsonRpcMessage, ServerResult};
+use rmcp::model::{
+    ClientJsonRpcMessage, ClientRequest, JsonRpcResponse, ServerJsonRpcMessage, ServerResult,
+};
+use serde_json::json;
+
+#[test]
+fn test_discover_request() {
+    let message: ClientJsonRpcMessage = serde_json::from_value(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "server/discover",
+        "params": {}
+    }))
+    .unwrap();
+
+    assert!(matches!(
+        message,
+        ClientJsonRpcMessage::Request(r)
+            if matches!(r.request, ClientRequest::DiscoverRequest(_))
+    ));
+}
+
+#[test]
+fn test_discover_result() {
+    let message: ServerJsonRpcMessage = serde_json::from_value(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "resultType": "complete",
+            "supportedVersions": ["2026-07-28", "2025-11-25"],
+            "capabilities": {},
+            "serverInfo": {
+                "name": "test-server",
+                "version": "1.0.0"
+            },
+            "ttlMs": 0,
+            "cacheScope": "private"
+        }
+    }))
+    .unwrap();
+
+    assert!(matches!(
+        message,
+        ServerJsonRpcMessage::Response(JsonRpcResponse {
+            result: ServerResult::DiscoverResult(_),
+            ..
+        })
+    ));
+}
+
 #[test]
 fn test_tool_list_result() {
     let json = std::fs::read("tests/test_deserialization/tool_list_result.json").unwrap();


### PR DESCRIPTION
## Motivation and Context
Add the SEP-2575 server/discover request and result model, wire it into the JSON-RPC request/result unions, and cover basic serde routing.

This only handles the basic model currently and does not wire up the server/client implementations, which will take some broader work around fallback to initialize etc.

For #869

## How Has This Been Tested?
Tested in Agentgateway

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
