### PR TITLE
feat!: type Annotations.lastModified as a string

### DIFF
--- a/crates/rmcp/src/model/annotated.rs
+++ b/crates/rmcp/src/model/annotated.rs
@@ -20,20 +20,23 @@ pub struct Annotations {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "lastModified")]
-    pub last_modified: Option<DateTime<Utc>>,
+    pub last_modified: Option<String>,
 }
 
 impl Annotations {
-    /// Creates a new Annotations instance specifically for resources
-    /// optional priority, and a timestamp (defaults to now if None)
+    /// Creates annotations for a resource with priority and an RFC 3339 timestamp.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `priority` is not in the inclusive range `0.0..=1.0`.
     pub fn for_resource(priority: f32, timestamp: DateTime<Utc>) -> Self {
         assert!(
             (0.0..=1.0).contains(&priority),
             "Priority {priority} must be between 0.0 and 1.0"
         );
-        Annotations {
+        Self {
             priority: Some(priority),
-            last_modified: Some(timestamp),
+            last_modified: Some(timestamp.to_rfc3339()),
             audience: None,
         }
     }
@@ -48,12 +51,69 @@ impl Annotations {
         self
     }
 
+    /// Sets `lastModified` from a typed timestamp, serialized as RFC 3339.
     pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
-        self.last_modified = Some(timestamp);
+        self.last_modified = Some(timestamp.to_rfc3339());
         self
     }
 
+    /// Sets `lastModified` to the current time, serialized as RFC 3339.
     pub fn with_timestamp_now(self) -> Self {
         self.with_timestamp(Utc::now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use serde_json::json;
+
+    use super::*;
+
+    fn annotations_of(value: serde_json::Value) -> Annotations {
+        serde_json::from_value::<Annotations>(value).unwrap()
+    }
+
+    #[test]
+    fn preserves_date_only_last_modified_verbatim() {
+        let annotations = annotations_of(json!({ "lastModified": "2025-01-12" }));
+        assert_eq!(annotations.last_modified.as_deref(), Some("2025-01-12"));
+    }
+
+    #[test]
+    fn preserves_rfc3339_last_modified_verbatim() {
+        let value = "2025-01-12T15:00:58Z";
+        let annotations = annotations_of(json!({ "lastModified": value }));
+        assert_eq!(annotations.last_modified.as_deref(), Some(value));
+    }
+
+    #[test]
+    fn missing_last_modified_is_none() {
+        let annotations = annotations_of(json!({}));
+        assert_eq!(annotations.last_modified, None);
+    }
+
+    #[test]
+    fn null_last_modified_is_none() {
+        let annotations = annotations_of(json!({ "lastModified": null }));
+        assert_eq!(annotations.last_modified, None);
+    }
+
+    #[test]
+    fn invalid_last_modified_string_is_preserved() {
+        let annotations = annotations_of(json!({ "lastModified": "not-a-date" }));
+        assert_eq!(annotations.last_modified.as_deref(), Some("not-a-date"));
+    }
+
+    #[test]
+    fn timestamp_round_trips_as_rfc3339_string() {
+        let timestamp = Utc.with_ymd_and_hms(2025, 1, 12, 15, 0, 58).unwrap();
+        let annotations = Annotations::default().with_timestamp(timestamp);
+
+        let value = serde_json::to_value(&annotations).unwrap();
+        assert_eq!(value["lastModified"], json!(timestamp.to_rfc3339()));
+
+        let round_tripped: Annotations = serde_json::from_value(value).unwrap();
+        assert_eq!(round_tripped, annotations);
     }
 }

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema.json
@@ -54,8 +54,7 @@
           "type": [
             "string",
             "null"
-          ],
-          "format": "date-time"
+          ]
         },
         "priority": {
           "type": [

--- a/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/client_json_rpc_message_schema_current.json
@@ -54,8 +54,7 @@
           "type": [
             "string",
             "null"
-          ],
-          "format": "date-time"
+          ]
         },
         "priority": {
           "type": [

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -54,8 +54,7 @@
           "type": [
             "string",
             "null"
-          ],
-          "format": "date-time"
+          ]
         },
         "priority": {
           "type": [

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -54,8 +54,7 @@
           "type": [
             "string",
             "null"
-          ],
-          "format": "date-time"
+          ]
         },
         "priority": {
           "type": [


### PR DESCRIPTION
## Motivation and Context

[The MCP 2025-11-25 schema](https://modelcontextprotocol.io/specification/2025-11-25/schema#annotations) types `Annotations.lastModified` as a plain string. Some schema-valid values, such as date-only strings or offset-less date-times, are not strict RFC 3339 and could previously cause a whole message to fail deserialization when nested in content or resource annotations.

This PR changes `Annotations.last_modified` to preserve `lastModified` as the schema-defined string instead of eagerly parsing it as `DateTime<Utc>`. The DateTime-based writer helpers still accept `DateTime<Utc>` and serialize RFC 3339 strings, while callers that need a typed read can use `last_modified_datetime()`.

This is also consistent with `Task.createdAt` and `Task.lastUpdatedAt`, which are already represented as strings in rmcp. Keeping the raw string is lossless for proxying and forwarding, while the new accessor keeps DateTime ergonomics for callers that want best-effort typed parsing.

## How Has This Been Tested?

Added tests

## Breaking Changes

Yes. The public field `Annotations.last_modified` changes type from `Option<DateTime<Utc>>` to `Option<String>`.

The public API / SemVer check is expected to flag this field-type change. That is intentional for the v3 release.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
