### PR TITLE
fix: flag schema derive on schemars feature

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -116,7 +116,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
 default = ["base64", "macros", "server"]
 local = ["rmcp-macros?/local"]
 client = ["dep:tokio-stream"]
-server = ["transport-async-rw", "dep:schemars", "dep:pastey"]
+server = ["transport-async-rw", "schemars", "dep:pastey"]
 macros = ["dep:rmcp-macros", "dep:pastey"]
 elicitation = ["dep:url"]
 

--- a/crates/rmcp/src/lib.rs
+++ b/crates/rmcp/src/lib.rs
@@ -34,7 +34,7 @@ pub mod transport;
 pub use pastey::paste;
 #[cfg(all(feature = "macros", feature = "server"))]
 pub use rmcp_macros::*;
-#[cfg(any(feature = "server", feature = "schemars"))]
+#[cfg(feature = "schemars")]
 pub use schemars;
 #[cfg(feature = "macros")]
 pub use serde;

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -57,7 +57,7 @@ macro_rules! object {
 /// without returning any specific data.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Copy, Eq)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "server", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[expect(clippy::exhaustive_structs, reason = "intentionally exhaustive")]
 pub struct EmptyObject {}
 


### PR DESCRIPTION
Most `derive(schemars::JsonSchema)`s are flagged on the `schemars` feature, except for one instance (EmptyObject) which was flagged on `server`. This seems like a mistake, and means that enabling only `schemars` misses this one type.

Also changes the `server` feature to include the `schemars` feature itself, not just the dep. This does increate the server API, but preserves compatibility and I think aligns with the intention.

## Motivation and Context
Makes rmcp buildable with only the schemars feature

## How Has This Been Tested?
`cargo check -p rmcp --no-default-features --features server`
`cargo check -p rmcp --no-default-features --features schemars`

## Breaking Changes
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
