### PR TITLE
docs: retarget roadmap to 2026-07-28 spec

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,31 +2,52 @@
 
 This roadmap tracks the path to SEP-1730 Tier 1 for the Rust MCP SDK.
 
-Server conformance: 87.5% (28/32) · Client conformance: 80.0% (16/20)
+Spec 2025-11-25 (suite 0.1.16): Server 100% (30/30) · Client 100% (18/18)
+Spec 2026-07-28 (suite 0.2.0-alpha.9): Server 92.5% (37/40) · Client 75.0% (24/32)
 
 ---
 
-## Tier 2 → Tier 1
+## Target spec: 2026-07-28 (release 2026-07-28)
 
-### Conformance
+All 2026-07-28 work carries the `2026-07-28` label and the
+[`2026-07-28 spec` milestone](https://github.com/modelcontextprotocol/rust-sdk/milestone/3).
+Per-scenario conformance status is tracked in the epic issue:
+[#977 — Tracking: 2026-07-28 spec conformance](https://github.com/modelcontextprotocol/rust-sdk/issues/977).
 
-#### Server (87.5% → 100%)
+### Conformance (baseline 2026-07-13, suite `0.2.0-alpha.9`)
 
-- [ ] Fix `prompts-get-with-args` — prompt argument handling returns incorrect result (arg1/arg2 not substituted)
-- [ ] Fix `prompts-get-embedded-resource` — embedded resource content in prompt responses (invalid content union)
-- [ ] Fix `elicitation-sep1330-enums` — enum inference handling per SEP-1330 (missing enumNames for legacy titled enum)
-- [ ] Fix `dns-rebinding-protection` — validate `Host` / `Origin` headers on Streamable HTTP transport (accepts invalid headers with 200)
+- Server: 3 scenarios (`tools-call-with-progress` stateless behavior, SEP-2243 server-side custom headers, and `server-stateless` — the SEP-2575 discovery/negotiation suite at 2/28 checks)
+- Client: 8 scenarios (SEP-2243 headers ×3, `request-metadata`, and 4 single-check auth failures: SEP-2350 step-up, pre-registration, SEP-2352 AS migration, SEP-2468 issuer validation); fixes for SEP-2350 (#888) and SEP-2352 (#965) are already in review
+- CI: run the full `--spec-version 2026-07-28` suites (stateless server) instead of hand-picked scenario lists; re-baseline on each draft-suite bump
 
-#### Client (80.0% → 100%)
+### Spec features without conformance scenarios
 
-- [ ] Fix `auth/metadata-var3` — AS metadata discovery variant 3 (no authorization support detected)
-- [ ] Fix `auth/scope-from-www-authenticate` — use scope parameter from WWW-Authenticate header on 403 insufficient_scope
-- [ ] Fix `auth/scope-step-up` — handle 403 `insufficient_scope` and re-authorize with upgraded scopes
-- [ ] Fix `auth/2025-03-26-oauth-endpoint-fallback` — legacy OAuth endpoint fallback for pre-2025-06-18 servers (no authorization support detected)
+Conformance alone does not cover the full spec surface. Feature work tracked via the milestone:
+
+- SEP-2567 sessionless MCP via explicit state handles (#870)
+- SEP-2260 server requests must associate with a client request (#873)
+- SEP-2549 follow-up: client-side TTL-honoring cache (#974)
+
+(SEP-2575 discovery & negotiation is covered by the `server-stateless` conformance scenario;
+implementation is in review — #869, PRs #973, #943.)
+
+### Release
+
+The 2026-07-28 implementation ships as **v3.0.0** (release PR #964): MRTR, SEP-2549 cache hints,
+SEP-2243 standard headers, and the SEP-2106 relaxations are merged but unreleased — tiering and
+relegation are evaluated against the latest stable release, so cutting v3.0.0 with the remaining
+conformance fixes is on the critical path. Migration guide (draft, kept current until release):
+[discussion #969](https://github.com/modelcontextprotocol/rust-sdk/discussions/969).
+
+---
+
+## Tier 1 (non-conformance requirements)
 
 ### Governance & Policy
 
 - [ ] Create `VERSIONING.md` — document semver scheme, what constitutes a breaking change, and how breaking changes are communicated
+- [ ] Publish a dependency update policy (Tier 1 requires a published policy)
+- [ ] Cut v3.0.0 (#964) including all conformance fixes (tier relegation is evaluated against the latest stable release)
 
 ### Documentation (26/48 → 48/48 features with prose + examples)
 
@@ -59,13 +80,25 @@ Server conformance: 87.5% (28/32) · Client conformance: 80.0% (16/20)
 
 ---
 
+## Completed
+
+- [x] 2025-11-25 server conformance 100% (30 scenarios + pending `json-schema-2020-12`, `server-sse-polling`)
+- [x] 2025-11-25 client conformance 100% (18 scenarios + legacy `auth/2025-03-26-*`)
+- [x] SEP-2322 MRTR (14 server scenarios + `sep-2322-client-request-state`)
+- [x] SEP-2164 resource not found
+- [x] Cache hints (`caching`)
+- [x] `http-header-validation`
+- [x] Issue triage labels (bug, enhancement, needs confirmation, needs repro, ready for work, P0–P3)
+
+---
+
 ## Informational (not scored for tiering)
 
-These draft/extension scenarios are tracked but do not count toward tier advancement:
+These extension scenarios are tracked but do not count toward tier advancement:
 
 | Scenario | Tag | Status |
 |---|---|---|
-| `auth/resource-mismatch` | draft | ❌ Failed |
 | `auth/client-credentials-jwt` | extension | ❌ Failed — JWT `aud` claim verification error |
 | `auth/client-credentials-basic` | extension | ✅ Passed |
 | `auth/cross-app-access-complete-flow` | extension | ❌ Failed — sends `authorization_code` grant instead of `jwt-bearer` |
+| `tasks-*` | extension | Not yet attempted |


### PR DESCRIPTION
## Motivation and Context

The 2025-11-25 suites now pass 100%. With the SDK targeting the 2026-07-28 spec, the roadmap needed to reflect the actual remaining work.

## How Has This Been Tested?

Documentation-only change

## Breaking Changes

None

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed