### PR TITLE
feat(conformance): add SEP-2243 header validation tool

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build conformance binaries
         run: cargo build -p mcp-conformance
 
+      - name: Test conformance server
+        run: cargo test -p mcp-conformance --bin conformance-server
+
       - name: Start conformance server
         run: |
           PORT=8001 ./target/debug/conformance-server &
@@ -80,7 +83,12 @@ jobs:
 
       - name: Run draft SEP scenarios
         run: |
-          for scenario in sep-2164-resource-not-found caching http-header-validation; do
+          for scenario in \
+            sep-2164-resource-not-found \
+            caching \
+            http-header-validation \
+            http-custom-header-server-validation \
+          ; do
             npx -y "@modelcontextprotocol/conformance@${DRAFT_CONFORMANCE_VERSION}" server \
               --url http://127.0.0.1:8002/mcp \
               --scenario "$scenario" \

--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -28,6 +28,20 @@ fn json_object(v: Value) -> JsonObject {
     }
 }
 
+fn custom_header_tool() -> Tool {
+    Tool::new(
+        "test_custom_header",
+        "Validates SEP-2243 custom parameter headers",
+        json_object(json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": "string", "x-mcp-header": "Value" }
+            },
+            "required": ["value"]
+        })),
+    )
+}
+
 /// Signing key for SEP-2322 `requestState` sealing. A fixed key is fine for a
 /// conformance harness; real servers must load a secret out of clients' reach.
 const REQUEST_STATE_KEY: &[u8] = b"rust-sdk-conformance-request-state-key!!";
@@ -361,6 +375,10 @@ impl ConformanceServer {
 }
 
 impl ServerHandler for ConformanceServer {
+    fn get_tool(&self, name: &str) -> Option<Tool> {
+        (name == "test_custom_header").then(custom_header_tool)
+    }
+
     async fn initialize(
         &self,
         request: InitializeRequestParams,
@@ -521,6 +539,7 @@ impl ServerHandler for ConformanceServer {
                     "properties": {}
                 })),
             ),
+            custom_header_tool(),
         ];
         // SEP-2322 MRTR test tools; all take no arguments.
         let mrtr_tools = [
@@ -666,6 +685,14 @@ impl ServerHandler for ConformanceServer {
                 Ok(CallToolResult::success(vec![ContentBlock::text(
                     "Progress test completed",
                 )]))
+            }
+
+            "test_custom_header" => {
+                let value = args
+                    .get("value")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| ErrorData::invalid_params("value must be a string", None))?;
+                Ok(CallToolResult::success(vec![ContentBlock::text(value)]))
             }
 
             "test_sampling" => {
@@ -1217,4 +1244,27 @@ async fn main() -> anyhow::Result<()> {
     axum::serve(listener, router).await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_exposes_custom_header_tool_for_transport_validation() {
+        let tool = ConformanceServer::new()
+            .get_tool("test_custom_header")
+            .expect("custom-header conformance tool");
+        let value = Value::Object((*tool.input_schema).clone());
+
+        assert_eq!(
+            value.pointer("/properties/value/type"),
+            Some(&json!("string"))
+        );
+        assert_eq!(
+            value.pointer("/properties/value/x-mcp-header"),
+            Some(&json!("Value"))
+        );
+        assert_eq!(value.pointer("/required/0"), Some(&json!("value")));
+    }
 }

--- a/crates/rmcp/tests/test_streamable_http_standard_headers.rs
+++ b/crates/rmcp/tests/test_streamable_http_standard_headers.rs
@@ -268,6 +268,29 @@ async fn rejects_param_mismatch_with_32020() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn rejects_decoded_base64_param_mismatch_with_32020() -> anyhow::Result<()> {
+    let (client, url, ct) = spawn_server().await;
+
+    let response = post_tool_call(
+        &client,
+        &url,
+        SEP_VERSION,
+        "deploy",
+        serde_json::json!({ "region": "us-west1" }),
+        Some("tools/call"),
+        Some("deploy"),
+        Some("=?base64?ZXUtY2VudHJhbDE=?="),
+    )
+    .await;
+    assert_eq!(response.status(), 400);
+    let body: serde_json::Value = response.json().await?;
+    assert_eq!(body["error"]["code"], -32020);
+
+    ct.cancel();
+    Ok(())
+}
+
+#[tokio::test]
 async fn rejects_missing_param_header_with_32020() -> anyhow::Result<()> {
     let (client, url, ct) = spawn_server().await;
 


### PR DESCRIPTION
## Summary

Expose a conformance tool that exercises server-side SEP-2243 custom parameter header validation.

The Streamable HTTP transport already validates `Mcp-Param-*` headers using the called tool's input schema. The conformance server did not advertise any tool with an `x-mcp-header` annotation, so the `http-custom-header-server-validation` scenario could not exercise that implementation.

## Changes

- Add a `test_custom_header` tool with a required string parameter promoted to `Mcp-Param-Value`.
- Return the same tool definition from `get_tool` so the transport can cache its schema before handler dispatch.
- Expose the tool through `tools/list` and echo the validated value from `tools/call`.
- Add a regression test for the transport-facing tool schema.
- Add a transport regression for a valid Base64 header whose decoded value mismatches the body parameter.
- Run the server unit test and the pinned custom-header scenario in the 2026-07-28 conformance workflow.

The patch reuses the existing transport validation and does not add another header parser or Base64 decoder.

## Verification

```bash
cargo test -p mcp-conformance --all-features
cargo test -p rmcp --test test_streamable_http_standard_headers --features server,client,transport-streamable-http-server,reqwest
cargo test --all-features
cargo fmt --all -- --check
```

The pinned `@modelcontextprotocol/conformance@0.2.0-alpha.9` `http-custom-header-server-validation` scenario also passes all 9 emitted checks, including valid and invalid Base64 values, literal prefix/suffix boundaries, missing custom headers, and JSON-RPC error code `-32020`. The repository integration test separately covers a syntactically valid Base64 value that decodes to a different body value.

Closes #979
