### PR TITLE
feat(auth): bind DCR client credentials to issuing authorization server (SEP-2352)

### DIFF
--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -4,7 +4,7 @@ use rmcp::{
     service::RequestContext,
     transport::{
         AuthClient, AuthorizationManager, StreamableHttpClientTransport,
-        auth::{AuthorizationCallback, OAuthState},
+        auth::{AuthorizationCallback, InMemoryCredentialStore, OAuthState},
         streamable_http_client::StreamableHttpClientTransportConfig,
     },
 };
@@ -495,6 +495,66 @@ async fn run_auth_scope_retry_limit_client(
     Ok(())
 }
 
+async fn migration_token(
+    server_url: &str,
+    store: &InMemoryCredentialStore,
+) -> anyhow::Result<String> {
+    let mut manager = AuthorizationManager::new(server_url).await?;
+    manager.set_credential_store(store.clone());
+
+    if manager.initialize_from_store().await? {
+        return Ok(manager.get_access_token().await?);
+    }
+
+    let metadata = manager.discover_metadata().await?;
+    manager.set_metadata(metadata);
+    manager
+        .register_client("conformance-client", REDIRECT_URI, &[])
+        .await?;
+
+    let scopes = manager.select_scopes(None, &[]);
+    let scope_refs: Vec<&str> = scopes.iter().map(|s| s.as_str()).collect();
+    let auth_url = manager.get_authorization_url(&scope_refs).await?;
+    let callback = headless_authorize(&auth_url).await?;
+    manager
+        .exchange_code_for_token_with_issuer(
+            &callback.code,
+            &callback.csrf_token,
+            callback.issuer.as_deref(),
+        )
+        .await?;
+
+    Ok(manager.get_access_token().await?)
+}
+
+async fn run_auth_server_migration_client(
+    server_url: &str,
+    _ctx: &ConformanceContext,
+) -> anyhow::Result<()> {
+    let store = InMemoryCredentialStore::new();
+    let http = reqwest::Client::new();
+    let body = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}});
+
+    let mut token = migration_token(server_url, &store).await?;
+    for _ in 0..3 {
+        let resp = http
+            .post(server_url)
+            .header(
+                "MCP-Protocol-Version",
+                conformance_protocol_version().as_str(),
+            )
+            .bearer_auth(&token)
+            .json(&body)
+            .send()
+            .await?;
+        if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+            token = migration_token(server_url, &store).await?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Auth flow with pre-registered credentials (from context).
 async fn run_auth_preregistered_client(
     server_url: &str,
@@ -955,6 +1015,11 @@ async fn main() -> anyhow::Result<()> {
 
         // Auth - scope retry limit
         "auth/scope-retry-limit" => run_auth_scope_retry_limit_client(&server_url, &ctx).await?,
+
+        // Auth - authorization server migration (SEP-2352)
+        "auth/authorization-server-migration" => {
+            run_auth_server_migration_client(&server_url, &ctx).await?
+        }
 
         // Auth - pre-registration
         "auth/pre-registration" => run_auth_preregistered_client(&server_url, &ctx).await?,

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -201,6 +201,8 @@ pub struct StoredCredentials {
     pub granted_scopes: Vec<String>,
     #[serde(default)]
     pub token_received_at: Option<u64>,
+    #[serde(default)]
+    pub issuer: Option<String>,
 }
 
 impl std::fmt::Debug for StoredCredentials {
@@ -213,6 +215,7 @@ impl std::fmt::Debug for StoredCredentials {
             )
             .field("granted_scopes", &self.granted_scopes)
             .field("token_received_at", &self.token_received_at)
+            .field("issuer", &self.issuer)
             .finish()
     }
 }
@@ -230,6 +233,7 @@ impl StoredCredentials {
             token_response,
             granted_scopes,
             token_received_at,
+            issuer: None,
         }
     }
 }
@@ -1088,6 +1092,15 @@ impl AuthorizationManager {
                     self.metadata = Some(metadata);
                 }
 
+                if let (Some(stored_issuer), Some(current_issuer)) =
+                    (stored.issuer.as_deref(), self.metadata_issuer().as_deref())
+                {
+                    if stored_issuer != current_issuer {
+                        self.credential_store.clear().await?;
+                        return Ok(false);
+                    }
+                }
+
                 self.configure_client_id(&stored.client_id)?;
                 return Ok(true);
             }
@@ -1703,6 +1716,7 @@ impl AuthorizationManager {
             token_response: Some(token_result.clone()),
             granted_scopes,
             token_received_at: Some(Self::now_epoch_secs()),
+            issuer: self.metadata_issuer(),
         };
         self.credential_store.save(stored).await?;
 
@@ -1714,6 +1728,10 @@ impl AuthorizationManager {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs()
+    }
+
+    fn metadata_issuer(&self) -> Option<String> {
+        self.metadata.as_ref().and_then(|m| m.issuer.clone())
     }
 
     /// Proactive refresh buffer: refresh tokens this many seconds before they expire
@@ -1838,6 +1856,7 @@ impl AuthorizationManager {
             token_response: Some(token_result.clone()),
             granted_scopes,
             token_received_at: Some(Self::now_epoch_secs()),
+            issuer: self.metadata_issuer(),
         };
         self.credential_store.save(stored).await?;
 
@@ -2658,6 +2677,7 @@ impl AuthorizationManager {
             token_response: Some(token_result.clone()),
             granted_scopes,
             token_received_at: Some(Self::now_epoch_secs()),
+            issuer: self.metadata_issuer(),
         };
         self.credential_store.save(stored).await?;
 
@@ -2780,6 +2800,7 @@ impl AuthorizationManager {
             token_response: Some(token_result.clone()),
             granted_scopes,
             token_received_at: Some(Self::now_epoch_secs()),
+            issuer: self.metadata_issuer(),
         };
         self.credential_store.save(stored).await?;
 
@@ -3147,6 +3168,7 @@ impl OAuthState {
                 token_response: Some(credentials),
                 granted_scopes,
                 token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+                issuer: None,
             };
             manager.credential_store.save(stored).await?;
 
@@ -4617,6 +4639,7 @@ mod tests {
             token_response: Some(token_response),
             granted_scopes: vec![],
             token_received_at: None,
+            issuer: None,
         };
         let debug_output = format!("{:?}", creds);
 
@@ -5594,6 +5617,7 @@ mod tests {
             token_response: Some(make_token_response("my-access-token", Some(3600))),
             granted_scopes: vec![],
             token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -5611,6 +5635,7 @@ mod tests {
             token_response: Some(make_token_response("stale-token", Some(3600))),
             granted_scopes: vec![],
             token_received_at: Some(AuthorizationManager::now_epoch_secs() - 7200),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -5629,6 +5654,7 @@ mod tests {
             token_response: Some(make_token_response("no-expiry-token", None)),
             granted_scopes: vec![],
             token_received_at: None,
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -5646,6 +5672,7 @@ mod tests {
             token_response: Some(make_token_response("almost-expired", Some(3600))),
             granted_scopes: vec![],
             token_received_at: Some(AuthorizationManager::now_epoch_secs() - 3590),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -5664,6 +5691,7 @@ mod tests {
             token_response: Some(make_token_response("stale-token", Some(3600))),
             granted_scopes: vec![],
             token_received_at: Some(AuthorizationManager::now_epoch_secs() - 7200),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -5993,6 +6021,7 @@ mod tests {
             token_response: None,
             granted_scopes: vec![],
             token_received_at: None,
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -6013,6 +6042,7 @@ mod tests {
             token_response: Some(make_token_response("old-token", Some(3600))),
             granted_scopes: vec![],
             token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -6103,6 +6133,7 @@ mod tests {
                 )),
                 granted_scopes: vec![],
                 token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+                issuer: None,
             })
             .await
             .unwrap();
@@ -6308,6 +6339,7 @@ mod tests {
             )),
             granted_scopes: vec!["read".to_string(), "write".to_string()],
             token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -6345,6 +6377,7 @@ mod tests {
             )),
             granted_scopes: vec![],
             token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -6382,6 +6415,7 @@ mod tests {
             )),
             granted_scopes: vec!["read".to_string()],
             token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -6419,6 +6453,7 @@ mod tests {
             )),
             granted_scopes: vec![],
             token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -6457,6 +6492,7 @@ mod tests {
             )),
             granted_scopes: vec![],
             token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 
@@ -6520,6 +6556,7 @@ mod tests {
             )),
             granted_scopes: vec![],
             token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+            issuer: None,
         };
         manager.credential_store.save(stored).await.unwrap();
 

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -236,6 +236,11 @@ impl StoredCredentials {
             issuer: None,
         }
     }
+
+    pub fn with_issuer(mut self, issuer: Option<String>) -> Self {
+        self.issuer = issuer;
+        self
+    }
 }
 
 /// Trait for storing and retrieving OAuth2 credentials
@@ -1095,9 +1100,43 @@ impl AuthorizationManager {
                 if let (Some(stored_issuer), Some(current_issuer)) =
                     (stored.issuer.as_deref(), self.metadata_issuer().as_deref())
                 {
+                    // A CIMD client ID is the client's metadata URL, so it is
+                    // portable across authorization servers and exempt here.
                     if stored_issuer != current_issuer {
+                        if is_https_url(&stored.client_id) {
+                            // A CIMD client ID is the client's metadata URL, so it is
+                            // portable across authorization servers — but the tokens
+                            // were minted by the previous AS and must not be reused.
+                            tracing::warn!(
+                                stored_issuer,
+                                current_issuer,
+                                "authorization server issuer changed; discarding tokens but keeping portable CIMD client ID"
+                            );
+                            self.credential_store
+                                .save(
+                                    StoredCredentials::new(
+                                        stored.client_id.clone(),
+                                        None,
+                                        vec![],
+                                        None,
+                                    )
+                                    .with_issuer(self.metadata_issuer()),
+                                )
+                                .await?;
+                            self.configure_client_id(&stored.client_id)?;
+                            return Ok(false);
+                        }
+
+                        tracing::warn!(
+                            stored_issuer,
+                            current_issuer,
+                            "authorization server issuer changed; clearing stored credentials bound to the previous issuer"
+                        );
                         self.credential_store.clear().await?;
-                        return Ok(false);
+                        return Err(AuthError::AuthorizationServerMismatch {
+                            expected_issuer: stored_issuer.to_string(),
+                            received_issuer: current_issuer.to_string(),
+                        });
                     }
                 }
 
@@ -3163,17 +3202,17 @@ impl OAuthState {
 
             *manager.current_scopes.write().await = granted_scopes.clone();
 
+            let metadata = manager.discover_metadata().await?;
+            manager.metadata = Some(metadata);
+
             let stored = StoredCredentials {
                 client_id: client_id.to_string(),
                 token_response: Some(credentials),
                 granted_scopes,
                 token_received_at: Some(AuthorizationManager::now_epoch_secs()),
-                issuer: None,
+                issuer: manager.metadata_issuer(),
             };
             manager.credential_store.save(stored).await?;
-
-            let metadata = manager.discover_metadata().await?;
-            manager.metadata = Some(metadata);
 
             manager.configure_client_id(client_id)?;
 
@@ -5993,6 +6032,7 @@ mod tests {
                 )),
                 granted_scopes: vec![],
                 token_received_at: Some(AuthorizationManager::now_epoch_secs()),
+                issuer: None,
             })
             .await
             .unwrap();


### PR DESCRIPTION
## Motivation and Context

Per https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2352 clients SHOULD maintain separate registration state per auth server and MUST NOT assume cross-AS credential validity

## How Has This Been Tested?
Conformance tests
```
cargo build -p mcp-conformance
npx -y @modelcontextprotocol/conformance@0.2.0-alpha.9 client --command ./target/debug/conformance-client --scenario auth/authorization-server-migration -o results
```

## Breaking Changes
None. `StoredCredentials` is #[non_exhaustive] and has a `new` constructor

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
Closes https://github.com/modelcontextprotocol/rust-sdk/issues/879