### PR TITLE
fix(server): serve draft-version requests statelessly per SEP-2567

### DIFF
--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -1229,7 +1229,7 @@ async fn main() -> anyhow::Result<()> {
     let server = ConformanceServer::new();
     let stateless = std::env::var_os("STATELESS").is_some();
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(!stateless)
+        .with_legacy_session_mode(!stateless)
         .with_json_response(stateless);
     let service = StreamableHttpService::new(
         move || Ok(server.clone()),

--- a/crates/rmcp/CHANGELOG.md
+++ b/crates/rmcp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: rename `StreamableHttpServerConfig::stateful_mode` to `legacy_session_mode` (and the builder `with_stateful_mode` to `with_legacy_session_mode`) to clarify that the option only affects legacy protocol versions (`< 2026-07-28`); per SEP-2567 the `2026-07-28` draft version is always served statelessly ([#999](https://github.com/modelcontextprotocol/rust-sdk/pull/999))
+
 ## [2.2.0](https://github.com/modelcontextprotocol/rust-sdk/compare/rmcp-v2.1.0...rmcp-v2.2.0) - 2026-07-08
 
 ### Added

--- a/crates/rmcp/src/transport/streamable_http_server/session.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/session.rs
@@ -13,7 +13,7 @@
 //!
 //! * [`local::LocalSessionManager`] — in-memory session store (default).
 //! * [`never::NeverSessionManager`] — rejects all session operations, used
-//!   when stateful mode is disabled.
+//!   when legacy session mode is disabled.
 //!
 //! # Custom session managers
 //!

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -59,8 +59,13 @@ pub struct StreamableHttpServerConfig {
     pub sse_retry: Option<Duration>,
     /// If true, the server will create a session for each request and keep it alive.
     /// When enabled, SSE priming events are sent to enable client reconnection.
-    pub stateful_mode: bool,
-    /// When true and `stateful_mode` is false, the server prefers
+    ///
+    /// Only applies to legacy protocol versions (`< 2026-07-28`). Per SEP-2567,
+    /// sessions are removed from the `2026-07-28` draft version, so requests
+    /// negotiating that version are always served statelessly regardless of
+    /// this setting.
+    pub legacy_session_mode: bool,
+    /// When true and `legacy_session_mode` is false, the server prefers
     /// `Content-Type: application/json` for simple request-response tools.
     /// If the handler emits a notification or request before the final response,
     /// the server falls back to `text/event-stream` so no message is lost.
@@ -130,7 +135,7 @@ impl Default for StreamableHttpServerConfig {
         Self {
             sse_keep_alive: Some(Duration::from_secs(15)),
             sse_retry: Some(Duration::from_secs(3)),
-            stateful_mode: true,
+            legacy_session_mode: true,
             json_response: false,
             cancellation_token: CancellationToken::new(),
             allowed_hosts: vec!["localhost".into(), "127.0.0.1".into(), "::1".into()],
@@ -176,8 +181,8 @@ impl StreamableHttpServerConfig {
         self
     }
 
-    pub fn with_stateful_mode(mut self, stateful: bool) -> Self {
-        self.stateful_mode = stateful;
+    pub fn with_legacy_session_mode(mut self, legacy_session_mode: bool) -> Self {
+        self.legacy_session_mode = legacy_session_mode;
         self
     }
 
@@ -690,7 +695,7 @@ fn validate_origin_header(
 ///
 /// ## Session management
 ///
-/// When [`StreamableHttpServerConfig::stateful_mode`] is `true` (the default),
+/// When [`StreamableHttpServerConfig::legacy_session_mode`] is `true` (the default),
 /// the server creates a session for each client that sends an `initialize`
 /// request. The session ID is returned in the `Mcp-Session-Id` response header
 /// and the client must include it on all subsequent requests.
@@ -1186,13 +1191,13 @@ where
             return response;
         }
         let method = request.method().clone();
-        let allowed_methods = match self.config.stateful_mode {
+        let allowed_methods = match self.config.legacy_session_mode {
             true => "GET, POST, DELETE",
             false => "POST",
         };
-        let result = match (method, self.config.stateful_mode) {
+        let result = match (method, self.config.legacy_session_mode) {
             (Method::POST, _) => self.handle_post(request).await,
-            // if we're not in stateful mode, we don't support GET or DELETE because there is no session
+            // if legacy session mode is disabled, we don't support GET or DELETE because there is no session
             (Method::GET, true) => self.handle_get(request).await,
             (Method::DELETE, true) => self.handle_delete(request).await,
             _ => {
@@ -1372,7 +1377,7 @@ where
         };
 
         let use_session =
-            self.config.stateful_mode && is_legacy_request(Some(&message), &part.headers);
+            self.config.legacy_session_mode && is_legacy_request(Some(&message), &part.headers);
 
         if use_session {
             // do we have a session id?

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -1340,7 +1340,31 @@ where
             Err(response) => return Ok(response),
         };
 
-        if self.config.stateful_mode {
+        // SEP-2567: sessions are removed at the protocol level from 2026-07-28.
+        // Serve such requests statelessly even in stateful mode, never assigning
+        // or requiring an Mcp-Session-Id. `initialize` declares the version in its
+        // body params; every other request in the `MCP-Protocol-Version` header
+        // (defaulting to `2025-03-26` when absent).
+        let init_version = match &message {
+            ClientJsonRpcMessage::Request(req) => match &req.request {
+                ClientRequest::InitializeRequest(init) => {
+                    Some(init.params.protocol_version.clone())
+                }
+                _ => None,
+            },
+            _ => None,
+        };
+        let declared_version = init_version.unwrap_or_else(|| {
+            part.headers
+                .get(HEADER_MCP_PROTOCOL_VERSION)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|s| serde_json::from_value(serde_json::Value::String(s.to_owned())).ok())
+                .unwrap_or(ProtocolVersion::V_2025_03_26)
+        });
+        let use_session =
+            self.config.stateful_mode && declared_version < ProtocolVersion::V_2026_07_28;
+
+        if use_session {
             // do we have a session id?
             let session_id = part
                 .headers

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -250,6 +250,34 @@ fn message_has_per_request_protocol_version(message: &ClientJsonRpcMessage) -> b
     }
 }
 
+// SEP-2567: sessions are removed from 2026-07-28; older versions are legacy.
+fn is_legacy_request(message: Option<&ClientJsonRpcMessage>, headers: &HeaderMap) -> bool {
+    let from_body = match message {
+        Some(ClientJsonRpcMessage::Request(req)) => match &req.request {
+            ClientRequest::InitializeRequest(init) => Some(init.params.protocol_version.clone()),
+            _ => req.request.get_meta().protocol_version(),
+        },
+        _ => None,
+    };
+    let version = from_body
+        .or_else(|| {
+            headers
+                .get(HEADER_MCP_PROTOCOL_VERSION)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|s| serde_json::from_value(serde_json::Value::String(s.to_owned())).ok())
+        })
+        .unwrap_or(ProtocolVersion::V_2025_03_26);
+    version < ProtocolVersion::V_2026_07_28
+}
+
+fn method_not_allowed_response() -> BoxResponse {
+    Response::builder()
+        .status(http::StatusCode::METHOD_NOT_ALLOWED)
+        .header(ALLOW, "POST")
+        .body(Full::new(Bytes::from("Method Not Allowed")).boxed())
+        .expect("valid response")
+}
+
 fn invalid_request_jsonrpc_response(
     id: Option<RequestId>,
     message: impl Into<Cow<'static, str>>,
@@ -1204,6 +1232,9 @@ where
                 )
                 .expect("valid response"));
         }
+        if !is_legacy_request(None, request.headers()) {
+            return Ok(method_not_allowed_response());
+        }
         // check session id
         let session_id = request
             .headers()
@@ -1340,29 +1371,8 @@ where
             Err(response) => return Ok(response),
         };
 
-        // SEP-2567: sessions are removed at the protocol level from 2026-07-28.
-        // Serve such requests statelessly even in stateful mode, never assigning
-        // or requiring an Mcp-Session-Id. `initialize` declares the version in its
-        // body params; every other request in the `MCP-Protocol-Version` header
-        // (defaulting to `2025-03-26` when absent).
-        let init_version = match &message {
-            ClientJsonRpcMessage::Request(req) => match &req.request {
-                ClientRequest::InitializeRequest(init) => {
-                    Some(init.params.protocol_version.clone())
-                }
-                _ => None,
-            },
-            _ => None,
-        };
-        let declared_version = init_version.unwrap_or_else(|| {
-            part.headers
-                .get(HEADER_MCP_PROTOCOL_VERSION)
-                .and_then(|value| value.to_str().ok())
-                .and_then(|s| serde_json::from_value(serde_json::Value::String(s.to_owned())).ok())
-                .unwrap_or(ProtocolVersion::V_2025_03_26)
-        });
         let use_session =
-            self.config.stateful_mode && declared_version < ProtocolVersion::V_2026_07_28;
+            self.config.stateful_mode && is_legacy_request(Some(&message), &part.headers);
 
         if use_session {
             // do we have a session id?
@@ -1697,6 +1707,9 @@ where
         B: Body + Send + 'static,
         B::Error: Display,
     {
+        if !is_legacy_request(None, request.headers()) {
+            return Ok(method_not_allowed_response());
+        }
         // check session id
         let session_id = request
             .headers()

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -255,8 +255,31 @@ fn message_has_per_request_protocol_version(message: &ClientJsonRpcMessage) -> b
     }
 }
 
+#[expect(
+    clippy::result_large_err,
+    reason = "BoxResponse is intentionally large; matches other handlers in this file"
+)]
 // SEP-2567: sessions are removed from 2026-07-28; older versions are legacy.
-fn is_legacy_request(message: Option<&ClientJsonRpcMessage>, headers: &HeaderMap) -> bool {
+// Validates protocol-version consistency and returns `Ok(true)` only for a valid legacy request.
+fn is_legacy_request(
+    message: Option<&ClientJsonRpcMessage>,
+    headers: &HeaderMap,
+) -> Result<bool, BoxResponse> {
+    let has_per_request_version = message.is_some_and(message_has_per_request_protocol_version);
+    validate_protocol_version_header(headers, has_per_request_version)?;
+    if let Some(message) = message {
+        if let ClientJsonRpcMessage::Request(req) = message {
+            if let ClientRequest::InitializeRequest(init) = &req.request {
+                validate_header_matches_init_body(
+                    headers,
+                    init.params.protocol_version.as_str(),
+                    Some(req.id.clone()),
+                )?;
+            }
+        }
+        validate_request_protocol_version_meta(headers, message)?;
+    }
+
     let from_body = match message {
         Some(ClientJsonRpcMessage::Request(req)) => match &req.request {
             ClientRequest::InitializeRequest(init) => Some(init.params.protocol_version.clone()),
@@ -272,7 +295,7 @@ fn is_legacy_request(message: Option<&ClientJsonRpcMessage>, headers: &HeaderMap
                 .and_then(|s| serde_json::from_value(serde_json::Value::String(s.to_owned())).ok())
         })
         .unwrap_or(ProtocolVersion::V_2025_03_26);
-    version < ProtocolVersion::V_2026_07_28
+    Ok(version < ProtocolVersion::V_2026_07_28)
 }
 
 fn method_not_allowed_response() -> BoxResponse {
@@ -1220,6 +1243,9 @@ where
         B: Body + Send + 'static,
         B::Error: Display,
     {
+        if !is_legacy_request(None, request.headers())? {
+            return Ok(method_not_allowed_response());
+        }
         // check accept header
         if !request
             .headers()
@@ -1236,9 +1262,6 @@ where
                     .boxed(),
                 )
                 .expect("valid response"));
-        }
-        if !is_legacy_request(None, request.headers()) {
-            return Ok(method_not_allowed_response());
         }
         // check session id
         let session_id = request
@@ -1377,7 +1400,7 @@ where
         };
 
         let use_session =
-            self.config.legacy_session_mode && is_legacy_request(Some(&message), &part.headers);
+            self.config.legacy_session_mode && is_legacy_request(Some(&message), &part.headers)?;
 
         if use_session {
             // do we have a session id?
@@ -1712,7 +1735,7 @@ where
         B: Body + Send + 'static,
         B::Error: Display,
     {
-        if !is_legacy_request(None, request.headers()) {
+        if !is_legacy_request(None, request.headers())? {
             return Ok(method_not_allowed_response());
         }
         // check session id

--- a/crates/rmcp/tests/test_discover_http_client_startup.rs
+++ b/crates/rmcp/tests/test_discover_http_client_startup.rs
@@ -54,7 +54,7 @@ async fn discover_http_client_bootstraps_headers_without_initialize() {
             || Ok(DiscoverHttpServer),
             Default::default(),
             StreamableHttpServerConfig::default()
-                .with_stateful_mode(false)
+                .with_legacy_session_mode(false)
                 .with_json_response(true)
                 .with_cancellation_token(ct.child_token()),
         );

--- a/crates/rmcp/tests/test_server_discover_http.rs
+++ b/crates/rmcp/tests/test_server_discover_http.rs
@@ -32,16 +32,16 @@ impl ServerHandler for DiscoveryServer {
 }
 
 async fn spawn_server(json_response: bool) -> (reqwest::Client, String, CancellationToken) {
-    spawn_server_with_stateful_mode(json_response, false).await
+    spawn_server_with_legacy_session_mode(json_response, false).await
 }
 
-async fn spawn_server_with_stateful_mode(
+async fn spawn_server_with_legacy_session_mode(
     json_response: bool,
-    stateful_mode: bool,
+    legacy_session_mode: bool,
 ) -> (reqwest::Client, String, CancellationToken) {
     let cancellation_token = CancellationToken::new();
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(stateful_mode)
+        .with_legacy_session_mode(legacy_session_mode)
         .with_json_response(json_response)
         .with_sse_keep_alive(None)
         .with_cancellation_token(cancellation_token.clone());
@@ -136,8 +136,8 @@ async fn discover_returns_server_metadata_without_session() {
 }
 
 #[tokio::test]
-async fn discover_does_not_require_initialization_in_stateful_mode() {
-    let (client, url, cancellation_token) = spawn_server_with_stateful_mode(true, true).await;
+async fn discover_does_not_require_initialization_in_legacy_session_mode() {
+    let (client, url, cancellation_token) = spawn_server_with_legacy_session_mode(true, true).await;
 
     let response = post_discover(&client, &url, "2025-11-25", Some("2025-11-25")).await;
 

--- a/crates/rmcp/tests/test_stateless_protocol_version.rs
+++ b/crates/rmcp/tests/test_stateless_protocol_version.rs
@@ -16,7 +16,7 @@ use common::calculator::Calculator;
 
 fn stateless_json_config() -> StreamableHttpServerConfig {
     StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_sse_keep_alive(None)
         .with_cancellation_token(CancellationToken::new())

--- a/crates/rmcp/tests/test_streamable_http_disconnect_cancel.rs
+++ b/crates/rmcp/tests/test_streamable_http_disconnect_cancel.rs
@@ -81,7 +81,7 @@ async fn spawn_stateless_server(json_response: bool) -> anyhow::Result<TestServe
 
     let server_ct = CancellationToken::new();
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(json_response)
         // A short keep-alive lets the SSE server notice a dropped connection
         // quickly (hyper only observes the disconnect on its next write).

--- a/crates/rmcp/tests/test_streamable_http_json_response.rs
+++ b/crates/rmcp/tests/test_streamable_http_json_response.rs
@@ -103,7 +103,7 @@ async fn stateless_json_response_returns_application_json() -> anyhow::Result<()
     let ct = CancellationToken::new();
     let (client, url, ct) = spawn_server(
         StreamableHttpServerConfig::default()
-            .with_stateful_mode(false)
+            .with_legacy_session_mode(false)
             .with_json_response(true)
             .with_sse_keep_alive(None)
             .with_cancellation_token(ct.child_token()),
@@ -145,7 +145,7 @@ async fn stateless_json_response_falls_back_to_sse_for_progress() -> anyhow::Res
     let ct = CancellationToken::new();
     let (client, url, ct) = spawn_progress_server(
         StreamableHttpServerConfig::default()
-            .with_stateful_mode(false)
+            .with_legacy_session_mode(false)
             .with_json_response(true)
             .with_sse_keep_alive(None)
             .with_cancellation_token(ct.child_token()),
@@ -197,7 +197,7 @@ async fn stateless_sse_mode_default_unchanged() -> anyhow::Result<()> {
     let ct = CancellationToken::new();
     let (client, url, ct) = spawn_server(
         StreamableHttpServerConfig::default()
-            .with_stateful_mode(false)
+            .with_legacy_session_mode(false)
             .with_sse_keep_alive(None)
             .with_cancellation_token(ct.child_token()),
     )
@@ -234,9 +234,9 @@ async fn stateless_sse_mode_default_unchanged() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn json_response_ignored_in_stateful_mode() -> anyhow::Result<()> {
+async fn json_response_ignored_in_legacy_session_mode() -> anyhow::Result<()> {
     let ct = CancellationToken::new();
-    // json_response: true has no effect when stateful_mode: true — server still uses SSE
+    // json_response: true has no effect when legacy_session_mode: true — server still uses SSE
     let (client, url, ct) = spawn_server(
         StreamableHttpServerConfig::default()
             .with_json_response(true)

--- a/crates/rmcp/tests/test_streamable_http_priming.rs
+++ b/crates/rmcp/tests/test_streamable_http_priming.rs
@@ -14,7 +14,7 @@ use common::calculator::Calculator;
 async fn test_priming_on_stream_start() -> anyhow::Result<()> {
     let ct = CancellationToken::new();
 
-    // stateful_mode: true automatically enables priming with DEFAULT_RETRY_INTERVAL (3 seconds)
+    // legacy_session_mode: true automatically enables priming with DEFAULT_RETRY_INTERVAL (3 seconds)
     let service: StreamableHttpService<Calculator, LocalSessionManager> =
         StreamableHttpService::new(
             || Ok(Calculator::new()),
@@ -416,7 +416,7 @@ async fn test_priming_on_stream_close() -> anyhow::Result<()> {
     let ct = CancellationToken::new();
     let session_manager = Arc::new(LocalSessionManager::default());
 
-    // stateful_mode: true automatically enables priming with DEFAULT_RETRY_INTERVAL (3 seconds)
+    // legacy_session_mode: true automatically enables priming with DEFAULT_RETRY_INTERVAL (3 seconds)
     let service = StreamableHttpService::new(
         || Ok(Calculator::new()),
         session_manager.clone(),

--- a/crates/rmcp/tests/test_streamable_http_protocol_version.rs
+++ b/crates/rmcp/tests/test_streamable_http_protocol_version.rs
@@ -50,7 +50,7 @@ async fn spawn_server_with_manager(
 
 fn stateless_json_config() -> StreamableHttpServerConfig {
     StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_sse_keep_alive(None)
         .with_cancellation_token(CancellationToken::new())
@@ -58,7 +58,7 @@ fn stateless_json_config() -> StreamableHttpServerConfig {
 
 fn stateful_config() -> StreamableHttpServerConfig {
     StreamableHttpServerConfig::default()
-        .with_stateful_mode(true)
+        .with_legacy_session_mode(true)
         .with_sse_keep_alive(None)
         .with_cancellation_token(CancellationToken::new())
 }

--- a/crates/rmcp/tests/test_streamable_http_session_store.rs
+++ b/crates/rmcp/tests/test_streamable_http_session_store.rs
@@ -73,7 +73,7 @@ fn make_service(
 ) -> StreamableHttpService<Calculator, LocalSessionManager> {
     StreamableHttpService::new(|| Ok(Calculator::new()), Default::default(), {
         let mut cfg = StreamableHttpServerConfig::default();
-        cfg.stateful_mode = true;
+        cfg.legacy_session_mode = true;
         cfg.sse_keep_alive = None;
         cfg.cancellation_token = ct.child_token();
         cfg.session_store = Some(session_store);
@@ -147,7 +147,7 @@ async fn test_session_state_deleted_from_store_on_delete() -> anyhow::Result<()>
 
     let service = StreamableHttpService::new(|| Ok(Calculator::new()), session_manager.clone(), {
         let mut cfg = StreamableHttpServerConfig::default();
-        cfg.stateful_mode = true;
+        cfg.legacy_session_mode = true;
         cfg.sse_keep_alive = None;
         cfg.cancellation_token = ct.child_token();
         cfg.session_store = Some(store.clone());
@@ -219,7 +219,7 @@ fn spawn_server(
 ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
     let svc = StreamableHttpService::new(|| Ok(Calculator::new()), session_manager, {
         let mut cfg = StreamableHttpServerConfig::default();
-        cfg.stateful_mode = true;
+        cfg.legacy_session_mode = true;
         cfg.sse_keep_alive = None;
         cfg.cancellation_token = ct.child_token();
         cfg.session_store = session_store;

--- a/crates/rmcp/tests/test_streamable_http_standard_headers.rs
+++ b/crates/rmcp/tests/test_streamable_http_standard_headers.rs
@@ -37,7 +37,7 @@ impl ServerHandler for HeaderValidationServer {
 
 async fn spawn_server() -> (reqwest::Client, String, CancellationToken) {
     let config = StreamableHttpServerConfig::default()
-        .with_stateful_mode(false)
+        .with_legacy_session_mode(false)
         .with_json_response(true)
         .with_sse_keep_alive(None)
         .with_cancellation_token(CancellationToken::new());


### PR DESCRIPTION
## Motivation and Context

Per https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567 protocol-level sessions (and the `Mcp-Session-Id` header) are removed from the Streamable HTTP transport as of the draft protocol version (`2026-07-28`); servers speaking that version MUST serve requests statelessly.

The rust-sdk server assigned an `Mcp-Session-Id` in its default `stateful_mode` even when the negotiated protocol version was `2026-07-28`. This gates the session code path on the negotiated version: sessions are used only for pre-draft versions (`< 2026-07-28`), and draft-version requests are served statelessly even in `stateful_mode`. Older versions retain full session behavior.

## How Has This Been Tested?

No dedicated SEP-2567 conformance scenario exists (the conformance PR that would add one was closed unmerged); per the maintainer, every existing draft (`2026-07-28`) scenario already sends sessionless requests. Verified against the existing draft server suite:

```
cargo build -p mcp-conformance
STATELESS= ./target/debug/conformance-server &   # default stateful_mode
npx -y @modelcontextprotocol/conformance@0.2.0-alpha.9 server --url http://127.0.0.1:8001/mcp --suite draft -o results
```

The default (stateful) server now produces results byte-for-byte identical to an explicit stateless server (48 passed / 31 failed; the 31 remaining failures are pre-existing SEP-2575 `server/discover` gaps, out of scope). `rmcp` lib unit tests (232) and streamable-HTTP integration tests (session store, stale session, protocol version, JSON response — 19) pass locally.

## Breaking Changes

None. The session code path is unchanged for all pre-`2026-07-28` versions; only the draft version changes behavior, bringing it into spec compliance.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

SEP-2575 (also in progress) removes the `initialize` handshake for the draft version. Once that lands, the version detection here can be simplified to a lifecycle check (an `initialize` request implies the pre-draft/stateful lifecycle; draft requests never carry `initialize`).
