### PR TITLE
fix: .with_stateful_mode -> .with_legacy_session_mode

### DIFF
--- a/crates/rmcp/tests/test_streamable_http_json_response.rs
+++ b/crates/rmcp/tests/test_streamable_http_json_response.rs
@@ -182,7 +182,7 @@ async fn stateless_negotiated_terminal_response_returns_application_json() -> an
     let ct = CancellationToken::new();
     let (client, url, ct) = spawn_progress_server(
         StreamableHttpServerConfig::default()
-            .with_stateful_mode(false)
+            .with_legacy_session_mode(false)
             .with_json_response(true)
             .with_sse_keep_alive(None)
             .with_cancellation_token(ct.child_token()),
@@ -277,7 +277,7 @@ async fn stateless_negotiated_json_response_falls_back_to_sse_for_progress() -> 
     let ct = CancellationToken::new();
     let (client, url, ct) = spawn_progress_server(
         StreamableHttpServerConfig::default()
-            .with_stateful_mode(false)
+            .with_legacy_session_mode(false)
             .with_json_response(true)
             .with_sse_keep_alive(None)
             .with_cancellation_token(ct.child_token()),


### PR DESCRIPTION
#999 and #1005 merged around the same time, and #1005 made use of a fn that was renamed in #999
