### PR TITLE
ci: fix discovery response parsing

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -97,8 +97,6 @@ jobs:
             -H "Mcp-Method: server/discover"
           )
 
-          # The stateless server streams responses as SSE, so unwrap the
-          # `data:` payload before parsing as JSON.
           discover_response="$(
             curl --fail-with-body --silent --show-error \
               "${common_headers[@]}" \
@@ -118,8 +116,7 @@ jobs:
                   }
                 }
               }' \
-              "$endpoint" \
-              | sed -n 's/^data: //p'
+              "$endpoint"
           )"
           jq -e '
             .result.resultType == "complete" and


### PR DESCRIPTION
## Motivation and Context

Fixing the failing conformance workflow in main. The stateless conformance server returns plain JSON, but the workflow filtered the response as SSE and passed an empty value to `jq`. Passing the response through unchanged lets the assertions validate the actual JSON payload and clears the erroneous failure.

## How Has This Been Tested?


## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io) <!-- TODO: Confirm before submitting. -->
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
