### PR TITLE
fix: preserve JSON Schema 2020-12 keywords

### DIFF
--- a/conformance/expected-failures-2026-07-28.yaml
+++ b/conformance/expected-failures-2026-07-28.yaml
@@ -9,11 +9,7 @@
 # When bumping DRAFT_CONFORMANCE_VERSION, diff
 # `conformance list --spec-version 2026-07-28` and update #977.
 
-server:
-  # SEP-2106: composition/conditional/$anchor keywords are stripped from
-  # published tool input schemas.
-  # tracked in #1003
-  - json-schema-2020-12
+server: []
 
 client:
   # Client does not yet send MCP-Protocol-Version header pre-initialize as

--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -556,6 +556,7 @@ impl ServerHandler for ConformanceServer {
                     "type": "object",
                     "$defs": {
                         "address": {
+                            "$anchor": "address",
                             "type": "object",
                             "properties": {
                                 "street": { "type": "string" },
@@ -567,6 +568,19 @@ impl ServerHandler for ConformanceServer {
                         "name": { "type": "string" },
                         "address": { "$ref": "#/$defs/address" }
                     },
+                    "allOf": [{
+                        "anyOf": [
+                            { "required": ["name"] },
+                            { "required": ["address"] }
+                        ]
+                    }],
+                    "if": { "required": ["address"] },
+                    "then": {
+                        "properties": {
+                            "address": { "required": ["street"] }
+                        }
+                    },
+                    "else": { "required": ["name"] },
                     "additionalProperties": false
                 })),
             ),


### PR DESCRIPTION
Fixes #1003.

## Motivation and Context

The draft conformance server's JSON Schema fixture did not include the SEP-2106 composition, conditional, and anchor keywords, leaving the `json-schema-2020-12` scenario at 4/7. This adds a coherent schema using those keyword families and removes the stale expected-failure entry now that the suite can verify their preservation end to end.

## How Has This Been Tested?


## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io) <!-- TODO: Confirm before submitting. -->
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
