### PR TITLE
fix: reap completed response send tasks

### DIFF
--- a/crates/rmcp/src/service.rs
+++ b/crates/rmcp/src/service.rs
@@ -1211,6 +1211,7 @@ where
             PeerMessage(RxJsonRpcMessage<R>),
             ToSink(TxJsonRpcMessage<R>),
             SendTaskResult(SendTaskResult),
+            ResponseSendTaskResult(Result<(), tokio::task::JoinError>),
         }
 
         let quit_reason = loop {
@@ -1256,6 +1257,11 @@ where
                             }
                         }
                     }
+                    result = response_send_tasks.join_next(), if !response_send_tasks.is_empty() => {
+                        Event::ResponseSendTaskResult(
+                            result.expect("non-empty response send task set")
+                        )
+                    }
                     _ = serve_loop_ct.cancelled() => {
                         tracing::info!("task cancelled");
                         break QuitReason::Cancelled
@@ -1292,6 +1298,11 @@ where
                                 }));
                             }
                         }
+                    }
+                }
+                Event::ResponseSendTaskResult(result) => {
+                    if let Err(error) = result {
+                        tracing::error!(%error, "response send task failed");
                     }
                 }
                 // response and error


### PR DESCRIPTION
## Summary

- reap completed response-send tasks during the main service loop
- preserve concurrent response writes and the existing shutdown drain
- log a join failure when a response-send task panics

## Why

`response_send_tasks` currently retains every completed task until transport shutdown. A long-lived stdio server therefore grows resident memory with each request even though the response write has completed.

In a sequential 5,000-call stdio soak, one downstream server grew from 42.9 MiB RSS after warm-up to 60.3 MiB. Direct calls to its handler stayed flat, isolating the growth to the SDK serve loop. With this change, the same stdio workload stayed between 46.1 and 47.3 MiB.

## Verification

- `cargo +1.97.0 fmt --all -- --check`
- `cargo +1.97.0 check -p rmcp --features server,transport-io`
- `cargo +1.97.0 test -p rmcp --features server,transport-io --test test_stdio_response_concurrency`
