### PR TITLE
fix!: preserve OAuth discovery transport errors

### DIFF
--- a/crates/rmcp/src/error.rs
+++ b/crates/rmcp/src/error.rs
@@ -17,6 +17,20 @@ impl Display for ErrorData {
 
 impl std::error::Error for ErrorData {}
 
+#[cfg(all(feature = "auth", any(feature = "client", feature = "server")))]
+pub(crate) struct ErrorChain<'a>(pub(crate) &'a (dyn std::error::Error + 'static));
+
+#[cfg(all(feature = "auth", any(feature = "client", feature = "server")))]
+impl Display for ErrorChain<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)?;
+        for source in std::iter::successors(self.0.source(), |source| source.source()) {
+            write!(f, "\n  Caused by: {source}")?;
+        }
+        Ok(())
+    }
+}
+
 /// This is an unified error type for the errors could be returned by the service.
 #[derive(Debug, thiserror::Error)]
 #[allow(clippy::large_enum_variant)]

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -70,36 +70,19 @@ impl OAuthHttpRequest {
     }
 }
 
-/// Error returned by a custom OAuth HTTP client.
-#[derive(Debug, Error)]
-#[error(transparent)]
-pub struct OAuthHttpClientError {
-    inner: OAuthHttpClientErrorKind,
-}
+/// Type-erased error returned by an [`OAuthHttpClient`].
+pub type OAuthHttpClientError = Box<dyn std::error::Error + Send + Sync>;
 
 #[derive(Debug, Error)]
-enum OAuthHttpClientErrorKind {
-    #[error("{0}")]
-    Message(String),
-
-    #[error("{0}")]
-    Source(#[source] Box<dyn std::error::Error + Send + Sync>),
-}
-
-impl OAuthHttpClientError {
-    /// Create an error from a message.
-    pub fn new(message: impl Into<String>) -> Self {
-        Self {
-            inner: OAuthHttpClientErrorKind::Message(message.into()),
-        }
-    }
-
-    /// Create an error from its underlying cause.
-    pub fn from_error(source: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
-        Self {
-            inner: OAuthHttpClientErrorKind::Source(source.into()),
-        }
-    }
+enum OAuthHttpError {
+    #[error("OAuth HTTP response body exceeds {0} bytes")]
+    ResponseBodyTooLarge(usize),
+    #[error("unexpected HTTP status {0}")]
+    UnexpectedStatus(StatusCode),
+    #[error("OAuth discovery redirect to non-same-origin URL rejected: {0}")]
+    CrossOriginRedirect(Url),
+    #[error("OAuth discovery exceeded {0} redirects")]
+    TooManyRedirects(usize),
 }
 
 /// Future returned by [`OAuthHttpClient::execute`].
@@ -147,12 +130,12 @@ impl OAuthHttpClient for ReqwestOAuthHttpClient {
                 OAuthHttpRedirectPolicy::Follow => &self.follow_redirects,
                 OAuthHttpRedirectPolicy::Stop => &self.stop_redirects,
             };
-            let request =
-                reqwest::Request::try_from(request).map_err(OAuthHttpClientError::from_error)?;
+            let request = reqwest::Request::try_from(request)
+                .map_err(|error| Box::new(error) as OAuthHttpClientError)?;
             let response = client
                 .execute(request)
                 .await
-                .map_err(OAuthHttpClientError::from_error)?;
+                .map_err(|error| Box::new(error) as OAuthHttpClientError)?;
 
             let mut builder = oauth2::http::Response::builder()
                 .status(response.status())
@@ -163,17 +146,17 @@ impl OAuthHttpClient for ReqwestOAuthHttpClient {
             let mut body = Vec::new();
             let mut body_stream = response.bytes_stream();
             while let Some(chunk) = body_stream.next().await {
-                let chunk = chunk.map_err(OAuthHttpClientError::from_error)?;
+                let chunk = chunk.map_err(|error| Box::new(error) as OAuthHttpClientError)?;
                 if chunk.len() > MAX_OAUTH_HTTP_RESPONSE_BODY_BYTES - body.len() {
-                    return Err(OAuthHttpClientError::new(format!(
-                        "OAuth HTTP response body exceeds {MAX_OAUTH_HTTP_RESPONSE_BODY_BYTES} bytes"
-                    )));
+                    return Err(Box::new(OAuthHttpError::ResponseBodyTooLarge(
+                        MAX_OAUTH_HTTP_RESPONSE_BODY_BYTES,
+                    )) as OAuthHttpClientError);
                 }
                 body.extend_from_slice(&chunk);
             }
             builder
                 .body(body)
-                .map_err(|error| OAuthHttpClientError::new(error.to_string()))
+                .map_err(|error| Box::new(error) as OAuthHttpClientError)
         })
     }
 }
@@ -183,16 +166,35 @@ struct OAuth2HttpClient<'a> {
     redirect_policy: OAuthHttpRedirectPolicy,
 }
 
+#[derive(Debug)]
+struct OAuth2HttpClientError(OAuthHttpClientError);
+
+impl std::fmt::Display for OAuth2HttpClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("OAuth HTTP request failed")
+    }
+}
+
+impl std::error::Error for OAuth2HttpClientError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.0.as_ref())
+    }
+}
+
 impl<'c> AsyncHttpClient<'c> for OAuth2HttpClient<'_> {
-    type Error = OAuthHttpClientError;
+    type Error = OAuth2HttpClientError;
 
     type Future = std::pin::Pin<
         Box<dyn std::future::Future<Output = Result<HttpResponse, Self::Error>> + Send + 'c>,
     >;
 
     fn call(&'c self, request: HttpRequest) -> Self::Future {
-        self.client
-            .execute(OAuthHttpRequest::new(request, self.redirect_policy))
+        Box::pin(async move {
+            self.client
+                .execute(OAuthHttpRequest::new(request, self.redirect_policy))
+                .await
+                .map_err(OAuth2HttpClientError)
+        })
     }
 }
 
@@ -2622,10 +2624,9 @@ impl AuthorizationManager {
     }
 
     fn discovery_failed(url: &Url, error: OAuthHttpClientError) -> AuthError {
-        let source = std::error::Error::source(&error).unwrap_or(&error);
         AuthError::MetadataError(format!(
             "OAuth metadata discovery failed for {url}\n  Caused by: {}",
-            crate::error::ErrorChain(source)
+            crate::error::ErrorChain(error.as_ref())
         ))
     }
 
@@ -2635,9 +2636,8 @@ impl AuthorizationManager {
     ) -> Result<HttpResponse, OAuthHttpClientError> {
         let response = self.http_client.execute(request).await?;
         if response.status().is_server_error() {
-            return Err(OAuthHttpClientError::new(format!(
-                "HTTP {}",
-                response.status()
+            return Err(Box::new(OAuthHttpError::UnexpectedStatus(
+                response.status(),
             )));
         }
         Ok(response)
@@ -2651,7 +2651,7 @@ impl AuthorizationManager {
                 .uri(current_url.as_str())
                 .header(HEADER_MCP_PROTOCOL_VERSION, "2024-11-05")
                 .body(Vec::new())
-                .map_err(|error| OAuthHttpClientError::new(error.to_string()))?;
+                .map_err(|error| Box::new(error) as OAuthHttpClientError)?;
             let response = self
                 .discovery_request(OAuthHttpRequest::new(
                     request,
@@ -2668,23 +2668,21 @@ impl AuthorizationManager {
             };
             let location = location
                 .to_str()
-                .map_err(|error| OAuthHttpClientError::new(error.to_string()))?;
+                .map_err(|error| Box::new(error) as OAuthHttpClientError)?;
             let next_url = current_url
                 .join(location)
-                .map_err(|error| OAuthHttpClientError::new(error.to_string()))?;
+                .map_err(|error| Box::new(error) as OAuthHttpClientError)?;
 
             if Self::is_http_url(&next_url) && Self::is_same_origin(&current_url, &next_url) {
                 current_url = next_url;
                 continue;
             }
 
-            return Err(OAuthHttpClientError::new(format!(
-                "OAuth discovery redirect to non-same-origin URL rejected: {next_url}"
-            )));
+            return Err(Box::new(OAuthHttpError::CrossOriginRedirect(next_url)));
         }
 
-        Err(OAuthHttpClientError::new(format!(
-            "OAuth discovery exceeded {MAX_OAUTH_DISCOVERY_REDIRECTS} redirects"
+        Err(Box::new(OAuthHttpError::TooManyRedirects(
+            MAX_OAUTH_DISCOVERY_REDIRECTS,
         )))
     }
 
@@ -3870,9 +3868,7 @@ mod tests {
                 body: request.request.body().clone(),
             });
             let response = self.responses.lock().unwrap().pop_front();
-            Box::pin(async move {
-                response.ok_or_else(|| OAuthHttpClientError::new("missing fake response"))
-            })
+            Box::pin(async move { response.ok_or_else(|| "missing fake response".into()) })
         }
     }
 
@@ -3904,11 +3900,11 @@ mod tests {
         #[error("request failed")]
         struct RequestError(#[source] std::io::Error);
 
-        let error = OAuthHttpClientError::from_error(RequestError(std::io::Error::other(
+        let error: OAuthHttpClientError = RequestError(std::io::Error::other(
             "certificate signed by unknown authority",
-        )));
-        let source = std::error::Error::source(&error).unwrap();
-        assert!(source.downcast_ref::<RequestError>().is_some());
+        ))
+        .into();
+        assert!(error.downcast_ref::<RequestError>().is_some());
 
         let url = Url::parse("https://mcp.example.com/mcp").unwrap();
         let error = AuthorizationManager::discovery_failed(&url, error);
@@ -3925,7 +3921,7 @@ mod tests {
         drop(listener);
 
         let manager = AuthorizationManager::new(&url).await.unwrap();
-        let error = manager.discover_metadata().await.unwrap_err();
+        let error = manager.resolve_metadata().await.unwrap_err();
 
         assert!(
             matches!(
@@ -3954,7 +3950,7 @@ mod tests {
         .await
         .unwrap();
 
-        let error = manager.discover_metadata().await.unwrap_err();
+        let error = manager.resolve_metadata().await.unwrap_err();
 
         assert!(
             matches!(
@@ -3979,7 +3975,7 @@ mod tests {
         .await
         .unwrap();
 
-        let error = manager.discover_metadata().await.unwrap_err();
+        let error = manager.resolve_metadata().await.unwrap_err();
 
         assert!(
             matches!(

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -72,16 +72,32 @@ impl OAuthHttpRequest {
 
 /// Error returned by a custom OAuth HTTP client.
 #[derive(Debug, Error)]
-#[error("{message}")]
+#[error(transparent)]
 pub struct OAuthHttpClientError {
-    message: String,
+    inner: OAuthHttpClientErrorKind,
+}
+
+#[derive(Debug, Error)]
+enum OAuthHttpClientErrorKind {
+    #[error("{0}")]
+    Message(String),
+
+    #[error("{0}")]
+    Source(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl OAuthHttpClientError {
-    /// Create an error from a transport-provided message.
+    /// Create an error from a message.
     pub fn new(message: impl Into<String>) -> Self {
         Self {
-            message: message.into(),
+            inner: OAuthHttpClientErrorKind::Message(message.into()),
+        }
+    }
+
+    /// Create an error from its underlying cause.
+    pub fn from_error(source: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+        Self {
+            inner: OAuthHttpClientErrorKind::Source(source.into()),
         }
     }
 }
@@ -131,12 +147,12 @@ impl OAuthHttpClient for ReqwestOAuthHttpClient {
                 OAuthHttpRedirectPolicy::Follow => &self.follow_redirects,
                 OAuthHttpRedirectPolicy::Stop => &self.stop_redirects,
             };
-            let request = reqwest::Request::try_from(request)
-                .map_err(|error| OAuthHttpClientError::new(error.to_string()))?;
+            let request =
+                reqwest::Request::try_from(request).map_err(OAuthHttpClientError::from_error)?;
             let response = client
                 .execute(request)
                 .await
-                .map_err(|error| OAuthHttpClientError::new(error.to_string()))?;
+                .map_err(OAuthHttpClientError::from_error)?;
 
             let mut builder = oauth2::http::Response::builder()
                 .status(response.status())
@@ -147,7 +163,7 @@ impl OAuthHttpClient for ReqwestOAuthHttpClient {
             let mut body = Vec::new();
             let mut body_stream = response.bytes_stream();
             while let Some(chunk) = body_stream.next().await {
-                let chunk = chunk.map_err(|error| OAuthHttpClientError::new(error.to_string()))?;
+                let chunk = chunk.map_err(OAuthHttpClientError::from_error)?;
                 if chunk.len() > MAX_OAUTH_HTTP_RESPONSE_BODY_BYTES - body.len() {
                     return Err(OAuthHttpClientError::new(format!(
                         "OAuth HTTP response body exceeds {MAX_OAUTH_HTTP_RESPONSE_BODY_BYTES} bytes"
@@ -2283,13 +2299,10 @@ impl AuthorizationManager {
         discovery_url: &Url,
     ) -> Result<Option<AuthorizationMetadata>, AuthError> {
         debug!("discovery url: {:?}", discovery_url);
-        let response = match self.discovery_get(discovery_url).await {
-            Ok(r) => r,
-            Err(e) => {
-                debug!("discovery request failed: {}", e);
-                return Ok(None);
-            }
-        };
+        let response = self
+            .discovery_get(discovery_url)
+            .await
+            .map_err(|error| Self::discovery_failed(discovery_url, error))?;
 
         if response.status() != StatusCode::OK {
             debug!("discovery returned non-200: {}", response.status());
@@ -2387,7 +2400,7 @@ impl AuthorizationManager {
     async fn discover_oauth_server_via_resource_metadata(
         &self,
     ) -> Result<Option<AuthorizationMetadata>, AuthError> {
-        let Some(resource_metadata_url) = self.discover_resource_metadata_url().await else {
+        let Some(resource_metadata_url) = self.discover_resource_metadata_url().await? else {
             return Ok(None);
         };
         self.discover_oauth_server_from_resource_metadata_url(&resource_metadata_url)
@@ -2509,10 +2522,11 @@ impl AuthorizationManager {
             && Self::is_same_origin(&root_resource, &path_resource)
     }
 
-    async fn discover_resource_metadata_url(&self) -> Option<Url> {
-        if let Some(resource_metadata_url) = self.probe_resource_metadata_url(&self.base_url).await
+    async fn discover_resource_metadata_url(&self) -> Result<Option<Url>, AuthError> {
+        if let Some(resource_metadata_url) =
+            self.probe_resource_metadata_url(&self.base_url).await?
         {
-            return Some(resource_metadata_url);
+            return Ok(Some(resource_metadata_url));
         }
 
         // If the primary URL doesn't use WWW-Authenticate, try oauth-protected-resource discovery.
@@ -2525,37 +2539,33 @@ impl AuthorizationManager {
             discovery_url.set_fragment(None);
             discovery_url.set_path(&candidate_path);
             if let Some(resource_metadata_url) =
-                self.probe_resource_metadata_url(&discovery_url).await
+                self.probe_resource_metadata_url(&discovery_url).await?
             {
-                return Some(resource_metadata_url);
+                return Ok(Some(resource_metadata_url));
             }
         }
 
-        None
+        Ok(None)
     }
 
     /// Probe `url` with a GET, extracting the resource metadata url from a
     /// 200 (the url itself is the metadata document) or from a 401's
     /// WWW-Authenticate header value.
     /// https://www.rfc-editor.org/rfc/rfc9728.html#name-use-of-www-authenticate-for
-    async fn probe_resource_metadata_url(&self, url: &Url) -> Option<Url> {
-        let response = match self.discovery_get(url).await {
-            Ok(r) => r,
-            Err(e) => {
-                debug!("resource metadata probe failed: {}", e);
-                return None;
-            }
-        };
+    async fn probe_resource_metadata_url(&self, url: &Url) -> Result<Option<Url>, AuthError> {
+        let response = self
+            .discovery_get(url)
+            .await
+            .map_err(|error| Self::discovery_failed(url, error))?;
 
         match response.status() {
-            StatusCode::OK => Some(url.clone()),
-            StatusCode::UNAUTHORIZED => {
-                self.extract_resource_metadata_url_from_www_authenticate(&response)
-                    .await
-            }
+            StatusCode::OK => Ok(Some(url.clone())),
+            StatusCode::UNAUTHORIZED => Ok(self
+                .extract_resource_metadata_url_from_www_authenticate(&response)
+                .await),
             status => {
                 debug!("resource metadata probe returned unexpected status: {status}");
-                None
+                Ok(None)
             }
         }
     }
@@ -2588,13 +2598,10 @@ impl AuthorizationManager {
             "resource metadata discovery url: {:?}",
             resource_metadata_url
         );
-        let response = match self.discovery_get(resource_metadata_url).await {
-            Ok(r) => r,
-            Err(e) => {
-                debug!("resource metadata request failed: {}", e);
-                return Ok(None);
-            }
-        };
+        let response = self
+            .discovery_get(resource_metadata_url)
+            .await
+            .map_err(|error| Self::discovery_failed(resource_metadata_url, error))?;
 
         if response.status() != StatusCode::OK {
             debug!(
@@ -2614,6 +2621,28 @@ impl AuthorizationManager {
         Ok(Some(metadata))
     }
 
+    fn discovery_failed(url: &Url, error: OAuthHttpClientError) -> AuthError {
+        let source = std::error::Error::source(&error).unwrap_or(&error);
+        AuthError::MetadataError(format!(
+            "OAuth metadata discovery failed for {url}\n  Caused by: {}",
+            crate::error::ErrorChain(source)
+        ))
+    }
+
+    async fn discovery_request(
+        &self,
+        request: OAuthHttpRequest,
+    ) -> Result<HttpResponse, OAuthHttpClientError> {
+        let response = self.http_client.execute(request).await?;
+        if response.status().is_server_error() {
+            return Err(OAuthHttpClientError::new(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+        Ok(response)
+    }
+
     async fn discovery_get(&self, url: &Url) -> Result<HttpResponse, OAuthHttpClientError> {
         let mut current_url = url.clone();
         for _ in 0..MAX_OAUTH_DISCOVERY_REDIRECTS {
@@ -2624,8 +2653,7 @@ impl AuthorizationManager {
                 .body(Vec::new())
                 .map_err(|error| OAuthHttpClientError::new(error.to_string()))?;
             let response = self
-                .http_client
-                .execute(OAuthHttpRequest::new(
+                .discovery_request(OAuthHttpRequest::new(
                     request,
                     OAuthHttpRedirectPolicy::Stop,
                 ))
@@ -3868,6 +3896,99 @@ mod tests {
             .status(status)
             .body(Vec::new())
             .unwrap()
+    }
+
+    #[test]
+    fn oauth_http_client_error_preserves_source_chain() {
+        #[derive(Debug, thiserror::Error)]
+        #[error("request failed")]
+        struct RequestError(#[source] std::io::Error);
+
+        let error = OAuthHttpClientError::from_error(RequestError(std::io::Error::other(
+            "certificate signed by unknown authority",
+        )));
+        let source = std::error::Error::source(&error).unwrap();
+        assert!(source.downcast_ref::<RequestError>().is_some());
+
+        let url = Url::parse("https://mcp.example.com/mcp").unwrap();
+        let error = AuthorizationManager::discovery_failed(&url, error);
+        assert_eq!(
+            error.to_string(),
+            "Metadata error: OAuth metadata discovery failed for https://mcp.example.com/mcp\n  Caused by: request failed\n  Caused by: certificate signed by unknown authority"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_http_client_preserves_connection_failure_cause() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/mcp", listener.local_addr().unwrap());
+        drop(listener);
+
+        let manager = AuthorizationManager::new(&url).await.unwrap();
+        let error = manager.discover_metadata().await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AuthError::MetadataError(ref reason)
+                    if reason.contains(&url)
+                        && reason.contains("\n  Caused by: error sending request for url")
+                        && reason.matches("error sending request for url").count() == 1
+                        && reason.to_ascii_lowercase().contains("connection refused")
+            ),
+            "unexpected discovery error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn authorization_metadata_propagates_transport_failure() {
+        let responses = preregistered_discovery_responses()
+            .into_iter()
+            .take(2)
+            .collect();
+        let client = RecordingOAuthHttpClient::with_responses(responses);
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/mcp",
+            Arc::new(client.clone()),
+        )
+        .await
+        .unwrap();
+
+        let error = manager.discover_metadata().await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AuthError::MetadataError(ref reason)
+                    if reason.contains("https://auth.example.com/.well-known/oauth-authorization-server")
+                        && reason.contains("missing fake response")
+            ),
+            "unexpected discovery error: {error}"
+        );
+        assert_eq!(client.requests().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn discovery_propagates_server_errors() {
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/mcp",
+            Arc::new(RecordingOAuthHttpClient::with_responses(vec![
+                empty_response(503),
+            ])),
+        )
+        .await
+        .unwrap();
+
+        let error = manager.discover_metadata().await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AuthError::MetadataError(ref reason)
+                    if reason.contains("https://mcp.example.com/mcp") && reason.contains("503")
+            ),
+            "unexpected discovery error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/docs/OAUTH_SUPPORT.md
+++ b/docs/OAUTH_SUPPORT.md
@@ -61,7 +61,9 @@ have been obtained.
 If OAuth requests must run outside reqwest, implement `OAuthHttpClient` and use
 `OAuthState::new_with_oauth_http_client`. The SDK passes each OAuth request to
 your implementation with the raw HTTP request, a suggested timeout, and an
-`OAuthHttpRedirectPolicy`.
+`OAuthHttpRedirectPolicy`. `OAuthHttpClientFuture` returns
+`OAuthHttpClientError`, so implementations can propagate their native error
+types with `?` without flattening their source chains into strings.
 
 ```rust ignore
 use std::sync::Arc;


### PR DESCRIPTION
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

OAuth metadata discovery previously converted transport failures into a successful fallback path, hiding actionable causes such as connection and certificate errors. This PR reports those failures with the discovery URL and complete source chain while retaining fallback behavior for valid non-matching discovery responses.

PR #1028 identified this through a concrete failure: using the Linear MCP server from a `node:22-bookworm-slim` container without CA certificates made the server appear not to support OAuth, while the underlying TLS error was discarded. This PR retains the original intended semantics: transport failures and HTTP 5xx responses stop discovery and surface the cause, while recognized non-success responses can still fall through to other discovery candidates.

Because this work already changes error propagation and v3 is approaching, this is the right point to settle the public API before it becomes stable. Rather than expand the public `OAuthHttpClientError` wrapper with separate constructors for messages and source errors, it becomes a domain-specific alias for `Box<dyn Error + Send + Sync>`. This matches existing SDK error aliases, lets custom clients propagate native errors with `?`, and confines the concrete compatibility wrapper required by `oauth2` to the private implementation.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Added coverage

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

`OAuthHttpClientError` changes from a public struct with an `OAuthHttpClientError::new` constructor to `Box<dyn Error + Send + Sync>`. Custom `OAuthHttpClient` implementations should return their native errors with `.into()` or box them directly.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed