### PR TITLE
fix: preserve transient OAuth discovery HTTP errors

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2635,10 +2635,14 @@ impl AuthorizationManager {
         request: OAuthHttpRequest,
     ) -> Result<HttpResponse, OAuthHttpClientError> {
         let response = self.http_client.execute(request).await?;
-        if response.status().is_server_error() {
-            return Err(Box::new(OAuthHttpError::UnexpectedStatus(
-                response.status(),
-            )));
+        let status = response.status();
+        if status.is_server_error()
+            || matches!(
+                status,
+                StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+            )
+        {
+            return Err(Box::new(OAuthHttpError::UnexpectedStatus(status)));
         }
         Ok(response)
     }
@@ -3820,6 +3824,7 @@ mod tests {
     };
 
     use oauth2::{AuthType, CsrfToken, HttpResponse, PkceCodeVerifier};
+    use reqwest::StatusCode;
     use rstest::rstest;
     use url::Url;
 
@@ -3985,6 +3990,63 @@ mod tests {
             ),
             "unexpected discovery error: {error}"
         );
+    }
+
+    #[rstest]
+    #[case::resource_request_timeout(StatusCode::REQUEST_TIMEOUT, 0, "https://mcp.example.com/mcp")]
+    #[case::resource_too_many_requests(
+        StatusCode::TOO_MANY_REQUESTS,
+        0,
+        "https://mcp.example.com/mcp"
+    )]
+    #[case::protected_metadata_request_timeout(
+        StatusCode::REQUEST_TIMEOUT,
+        1,
+        "https://mcp.example.com/.well-known/oauth-protected-resource"
+    )]
+    #[case::protected_metadata_too_many_requests(
+        StatusCode::TOO_MANY_REQUESTS,
+        1,
+        "https://mcp.example.com/.well-known/oauth-protected-resource"
+    )]
+    #[case::authorization_request_timeout(
+        StatusCode::REQUEST_TIMEOUT,
+        2,
+        "https://auth.example.com/.well-known/oauth-authorization-server"
+    )]
+    #[case::authorization_too_many_requests(
+        StatusCode::TOO_MANY_REQUESTS,
+        2,
+        "https://auth.example.com/.well-known/oauth-authorization-server"
+    )]
+    #[tokio::test]
+    async fn discovery_propagates_transient_client_errors(
+        #[case] status: StatusCode,
+        #[case] successful_response_count: usize,
+        #[case] expected_url: &str,
+    ) {
+        let mut responses = preregistered_discovery_responses();
+        responses.insert(successful_response_count, empty_response(status.as_u16()));
+
+        let client = RecordingOAuthHttpClient::with_responses(responses);
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/mcp",
+            Arc::new(client.clone()),
+        )
+        .await
+        .unwrap();
+
+        let error = manager.resolve_metadata().await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AuthError::MetadataError(ref reason)
+                    if reason.contains(expected_url) && reason.contains(status.as_str())
+            ),
+            "unexpected discovery error for {status}: {error}"
+        );
+        assert_eq!(client.requests().len(), successful_response_count + 1);
     }
 
     #[tokio::test]
@@ -4330,13 +4392,18 @@ mod tests {
         );
     }
 
+    #[rstest]
+    #[case::not_found(StatusCode::NOT_FOUND)]
+    #[case::method_not_allowed(StatusCode::METHOD_NOT_ALLOWED)]
     #[tokio::test]
-    async fn resolve_metadata_reports_legacy_fallback_when_nothing_is_discovered() {
+    async fn resolve_metadata_reports_legacy_fallback_when_nothing_is_discovered(
+        #[case] status: StatusCode,
+    ) {
         let client = RecordingOAuthHttpClient::with_responses(vec![
-            empty_response(404),
-            empty_response(404),
-            empty_response(404),
-            empty_response(404),
+            empty_response(status.as_u16()),
+            empty_response(status.as_u16()),
+            empty_response(status.as_u16()),
+            empty_response(status.as_u16()),
         ]);
         let manager = AuthorizationManager::new_with_oauth_http_client(
             "https://legacy.example.com/",

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2639,7 +2639,7 @@ impl AuthorizationManager {
         if status.is_server_error()
             || matches!(
                 status,
-                StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+                StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_EARLY | StatusCode::TOO_MANY_REQUESTS
             )
         {
             return Err(Box::new(OAuthHttpError::UnexpectedStatus(status)));
@@ -3994,6 +3994,7 @@ mod tests {
 
     #[rstest]
     #[case::resource_request_timeout(StatusCode::REQUEST_TIMEOUT, 0, "https://mcp.example.com/mcp")]
+    #[case::resource_too_early(StatusCode::TOO_EARLY, 0, "https://mcp.example.com/mcp")]
     #[case::resource_too_many_requests(
         StatusCode::TOO_MANY_REQUESTS,
         0,
@@ -4004,6 +4005,11 @@ mod tests {
         1,
         "https://mcp.example.com/.well-known/oauth-protected-resource"
     )]
+    #[case::protected_metadata_too_early(
+        StatusCode::TOO_EARLY,
+        1,
+        "https://mcp.example.com/.well-known/oauth-protected-resource"
+    )]
     #[case::protected_metadata_too_many_requests(
         StatusCode::TOO_MANY_REQUESTS,
         1,
@@ -4011,6 +4017,11 @@ mod tests {
     )]
     #[case::authorization_request_timeout(
         StatusCode::REQUEST_TIMEOUT,
+        2,
+        "https://auth.example.com/.well-known/oauth-authorization-server"
+    )]
+    #[case::authorization_too_early(
+        StatusCode::TOO_EARLY,
         2,
         "https://auth.example.com/.well-known/oauth-authorization-server"
     )]


### PR DESCRIPTION
## Summary

Follow-up to #1069.

OAuth metadata discovery now preserves transport failures and HTTP 5xx responses, but HTTP `408 Request Timeout`, `425 Too Early`, and `429 Too Many Requests` still fall through as though a metadata endpoint were absent. As a result, a temporary timeout, early-data rejection, or rate limit can cause discovery to continue to another endpoint or report a legacy fallback instead of surfacing the operational failure.

This change classifies HTTP 408, 425, and 429 alongside 5xx in the existing `discovery_request` helper. The resulting metadata error preserves both the actual response status and the failing discovery URL.

## Compatibility

- Preserve HTTP 401 challenge handling.
- Preserve HTTP 404 and 405 discovery fallback, with separate regression cases for both.
- Preserve the existing HTTP 5xx behavior.
- Do not introduce automatic retries, new dependencies, or public API changes.

## Regression coverage

Add nine parameterized cases covering HTTP 408, 425, and 429 at each of:

1. The protected resource endpoint.
2. The protected resource metadata endpoint.
3. The authorization server metadata endpoint.

Each case verifies that discovery reports the correct failing URL and status and does not issue additional discovery requests. The regression was first reproduced against upstream `main` before applying the production fix.

## Validation

- `cargo +1.96 test -p rmcp --lib --all-features` (482 tests passing).
- `cargo +1.96 clippy --all-targets --all-features -- -D warnings`.
- `cargo +nightly-2025-09-18 fmt --all -- --check`.
