### PR TITLE
fix: recognize 2026-07-28 MCP methods

### DIFF
--- a/crates/rmcp/src/transport/async_rw.rs
+++ b/crates/rmcp/src/transport/async_rw.rs
@@ -249,12 +249,13 @@ const UTF8_BOM: &[u8; 3] = b"\xEF\xBB\xBF";
 /// Check if a method is a standard MCP method (request, response, or notification).
 /// This includes both requests and notifications defined in the MCP specification.
 ///
-/// Based on MCP specification 2025-06-18: https://modelcontextprotocol.io/specification/2025-06-18
+/// Based on MCP specification 2026-07-28: https://modelcontextprotocol.io/specification/2026-07-28
 fn is_standard_method(method: &str) -> bool {
     matches!(
         method,
         "initialize"
             | "ping"
+            | "server/discover"
             | "prompts/get"
             | "prompts/list"
             | "resources/list"
@@ -262,9 +263,11 @@ fn is_standard_method(method: &str) -> bool {
             | "resources/subscribe"
             | "resources/unsubscribe"
             | "resources/templates/list"
+            | "subscriptions/listen"
             | "tools/call"
             | "tools/list"
             | "completion/complete"
+            | "elicitation/create"
             | "logging/setLevel"
             | "roots/list"
             | "sampling/createMessage"
@@ -282,6 +285,7 @@ fn is_standard_notification(method: &str) -> bool {
             | "notifications/resources/list_changed"
             | "notifications/resources/updated"
             | "notifications/roots/list_changed"
+            | "notifications/subscriptions/acknowledged"
             | "notifications/tools/list_changed"
     )
 }
@@ -582,12 +586,48 @@ mod test {
         assert!(is_standard_notification("notifications/tools/list_changed"));
         assert!(is_standard_notification("notifications/message"));
         assert!(is_standard_notification("notifications/roots/list_changed"));
+        assert!(is_standard_notification(
+            "notifications/subscriptions/acknowledged"
+        ));
 
         // Test that non-standard notifications are not recognized
         assert!(!is_standard_notification("notifications/stderr"));
         assert!(!is_standard_notification("notifications/custom"));
         assert!(!is_standard_notification("notifications/debug"));
         assert!(!is_standard_notification("some/other/method"));
+    }
+
+    #[test]
+    fn test_2026_07_28_standard_method_check() {
+        for method in [
+            "elicitation/create",
+            "server/discover",
+            "subscriptions/listen",
+        ] {
+            assert!(is_standard_method(method), "{method} should be standard");
+        }
+    }
+
+    #[test]
+    fn test_current_standard_notification_is_not_ignored() {
+        let method = "notifications/subscriptions/acknowledged";
+        let notification = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+        });
+
+        assert!(!should_ignore_notification(&notification, method));
+    }
+
+    #[test]
+    fn test_unknown_notification_is_ignored() {
+        let method = "notifications/custom";
+        let notification = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+        });
+
+        assert!(should_ignore_notification(&notification, method));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1075.

## Motivation and Context
The compatibility parser ignores unknown notifications after deserialization fails. Because the registry was still based on MCP 2025-06-18, a malformed `notifications/subscriptions/acknowledged` message could be mistaken for an unrelated notification and silently discarded. This change recognizes the current discovery, subscription, and elicitation methods so parse failures surface correctly.

## How Has This Been Tested?

```sh
cargo test -p rmcp --lib transport::async_rw::test
```

## Breaking Changes
None. Existing legacy method names remain recognized.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed