### PR TITLE
fix: stamp server info on graceful subscription results

### DIFF
--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -177,11 +177,7 @@ impl<H: ServerHandler> Service<RoleServer> for H {
                     // server teardown; explicit stdio cancellation remains a notification.
                     self.listen(subscription).await.map(|()| {
                         let mut result = SubscriptionsListenResult::complete(subscription_id);
-                        result.meta.insert(
-                            SERVER_INFO_META_KEY.to_owned(),
-                            serde_json::to_value(server_implementation)
-                                .expect("Implementation serialization cannot fail"),
-                        );
+                        result.meta.set_server_info(server_implementation);
                         ServerResult::SubscriptionsListenResult(result)
                     })
                 }

--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -154,7 +154,8 @@ impl<H: ServerHandler> Service<RoleServer> for H {
                             McpError::method_not_found::<SubscriptionsListenRequestMethod>(),
                         );
                     };
-                    let advertised = requested.supported_by(&self.get_info().capabilities);
+                    let server_info = self.get_info();
+                    let advertised = requested.supported_by(&server_info.capabilities);
                     let handler_accepted = requested.intersection(&candidate);
                     let accepted = handler_accepted.intersection(&advertised);
                     if accepted != handler_accepted {
@@ -168,15 +169,20 @@ impl<H: ServerHandler> Service<RoleServer> for H {
                             "subscription filter reduced to advertised server capabilities"
                         );
                     }
+                    let server_implementation = server_info.server_info;
                     let subscription_id = context.id.clone();
                     let subscription =
                         SubscriptionContext::establish(context, requested, accepted).await?;
                     // The 2026-07-28 schema defines a final result for graceful
                     // server teardown; explicit stdio cancellation remains a notification.
                     self.listen(subscription).await.map(|()| {
-                        ServerResult::SubscriptionsListenResult(
-                            SubscriptionsListenResult::complete(subscription_id),
-                        )
+                        let mut result = SubscriptionsListenResult::complete(subscription_id);
+                        result.meta.insert(
+                            SERVER_INFO_META_KEY.to_owned(),
+                            serde_json::to_value(server_implementation)
+                                .expect("Implementation serialization cannot fail"),
+                        );
+                        ServerResult::SubscriptionsListenResult(result)
                     })
                 }
             }

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1199,9 +1199,9 @@ pub struct DiscoverResult {
     pub meta: Option<MetaObject>,
 }
 
-impl DiscoverResult {
-    const SERVER_INFO_META_KEY: &str = "io.modelcontextprotocol/serverInfo";
+pub(crate) const SERVER_INFO_META_KEY: &str = "io.modelcontextprotocol/serverInfo";
 
+impl DiscoverResult {
     /// Create a non-cacheable private discovery result.
     pub fn new(supported_versions: Vec<ProtocolVersion>, capabilities: ServerCapabilities) -> Self {
         Self {
@@ -1220,7 +1220,7 @@ impl DiscoverResult {
         self.meta
             .as_ref()?
             .0
-            .get(Self::SERVER_INFO_META_KEY)
+            .get(SERVER_INFO_META_KEY)
             .and_then(|value| serde_json::from_value(value.clone()).ok())
     }
 
@@ -1231,7 +1231,7 @@ impl DiscoverResult {
         self.meta
             .get_or_insert_default()
             .0
-            .insert(Self::SERVER_INFO_META_KEY.to_owned(), server_info);
+            .insert(SERVER_INFO_META_KEY.to_owned(), server_info);
     }
 
     /// Store server implementation information in result metadata.

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1199,7 +1199,18 @@ pub struct DiscoverResult {
     pub meta: Option<MetaObject>,
 }
 
-pub(crate) const SERVER_INFO_META_KEY: &str = "io.modelcontextprotocol/serverInfo";
+const SERVER_INFO_META_KEY: &str = "io.modelcontextprotocol/serverInfo";
+
+fn server_info_from_meta(meta: &MetaObject) -> Option<Implementation> {
+    meta.get(SERVER_INFO_META_KEY)
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+}
+
+fn set_server_info_on_meta(meta: &mut MetaObject, server_info: Implementation) {
+    let server_info =
+        serde_json::to_value(server_info).expect("Implementation serialization cannot fail");
+    meta.insert(SERVER_INFO_META_KEY.to_owned(), server_info);
+}
 
 impl DiscoverResult {
     /// Create a non-cacheable private discovery result.
@@ -1217,21 +1228,12 @@ impl DiscoverResult {
 
     /// Return the server implementation information stored in result metadata.
     pub fn server_info(&self) -> Option<Implementation> {
-        self.meta
-            .as_ref()?
-            .0
-            .get(SERVER_INFO_META_KEY)
-            .and_then(|value| serde_json::from_value(value.clone()).ok())
+        server_info_from_meta(self.meta.as_ref()?)
     }
 
     /// Store server implementation information in result metadata.
     pub fn set_server_info(&mut self, server_info: Implementation) {
-        let server_info =
-            serde_json::to_value(server_info).expect("Implementation serialization cannot fail");
-        self.meta
-            .get_or_insert_default()
-            .0
-            .insert(SERVER_INFO_META_KEY.to_owned(), server_info);
+        set_server_info_on_meta(self.meta.get_or_insert_default(), server_info);
     }
 
     /// Store server implementation information in result metadata.
@@ -2174,6 +2176,16 @@ impl SubscriptionsListenResultMeta {
             subscription_id.into_json_value(),
         );
     }
+
+    /// Return the server implementation information stored in result metadata.
+    pub fn server_info(&self) -> Option<Implementation> {
+        server_info_from_meta(&self.0)
+    }
+
+    /// Store server implementation information in result metadata.
+    pub fn set_server_info(&mut self, server_info: Implementation) {
+        set_server_info_on_meta(&mut self.0, server_info);
+    }
 }
 
 impl<'de> Deserialize<'de> for SubscriptionsListenResultMeta {
@@ -2212,9 +2224,14 @@ impl schemars::JsonSchema for SubscriptionsListenResultMeta {
 
     fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
         let subscription_id = generator.subschema_for::<RequestId>();
+        let server_info = generator.subschema_for::<Implementation>();
         schemars::json_schema!({
             "type": "object",
             "properties": {
+                "io.modelcontextprotocol/serverInfo": {
+                    "description": "Identifies the server software producing the response. Servers SHOULD include this field on every response unless specifically configured not to do so.",
+                    "allOf": [server_info],
+                },
                 "io.modelcontextprotocol/subscriptionId": subscription_id,
             },
             "required": ["io.modelcontextprotocol/subscriptionId"],

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -3450,6 +3450,14 @@
     "SubscriptionsListenResultMeta": {
       "type": "object",
       "properties": {
+        "io.modelcontextprotocol/serverInfo": {
+          "description": "Identifies the server software producing the response. Servers SHOULD include this field on every response unless specifically configured not to do so.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Implementation"
+            }
+          ]
+        },
         "io.modelcontextprotocol/subscriptionId": {
           "$ref": "#/definitions/NumberOrString"
         }

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema_current.json
@@ -3450,6 +3450,14 @@
     "SubscriptionsListenResultMeta": {
       "type": "object",
       "properties": {
+        "io.modelcontextprotocol/serverInfo": {
+          "description": "Identifies the server software producing the response. Servers SHOULD include this field on every response unless specifically configured not to do so.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Implementation"
+            }
+          ]
+        },
         "io.modelcontextprotocol/subscriptionId": {
           "$ref": "#/definitions/NumberOrString"
         }

--- a/crates/rmcp/tests/test_subscriptions.rs
+++ b/crates/rmcp/tests/test_subscriptions.rs
@@ -444,9 +444,9 @@ async fn listen_exposes_acknowledged_filter_and_graceful_result() -> anyhow::Res
     assert_eq!(
         result
             .meta
-            .get("io.modelcontextprotocol/serverInfo")
-            .and_then(|value| serde_json::from_value::<Implementation>(value.clone()).ok()),
-        Some(Implementation::new("tools-only-server", "1.0.0"))
+            .server_info()
+            .expect("graceful result should contain valid server info"),
+        Implementation::new("tools-only-server", "1.0.0")
     );
 
     client.cancel().await?;

--- a/crates/rmcp/tests/test_subscriptions.rs
+++ b/crates/rmcp/tests/test_subscriptions.rs
@@ -51,6 +51,7 @@ impl ServerHandler for ToolsOnlyServer {
                 .enable_tool_list_changed()
                 .build(),
         )
+        .with_server_info(Implementation::new("tools-only-server", "1.0.0"))
     }
 
     fn accepted_subscription_filter(
@@ -439,6 +440,13 @@ async fn listen_exposes_acknowledged_filter_and_graceful_result() -> anyhow::Res
     assert_eq!(
         result.meta.subscription_id().as_ref(),
         Some(subscription.id())
+    );
+    assert_eq!(
+        result
+            .meta
+            .get("io.modelcontextprotocol/serverInfo")
+            .and_then(|value| serde_json::from_value::<Implementation>(value.clone()).ok()),
+        Some(Implementation::new("tools-only-server", "1.0.0"))
     );
 
     client.cancel().await?;

--- a/crates/rmcp/tests/test_subscriptions_model.rs
+++ b/crates/rmcp/tests/test_subscriptions_model.rs
@@ -1,7 +1,7 @@
 use rmcp::model::{
-    ClientJsonRpcMessage, ClientRequest, GetMeta, JsonRpcNotification, JsonRpcRequest,
-    NotificationMetaObject, RequestId, RequestMetaObject, ServerJsonRpcMessage, ServerNotification,
-    SubscriptionFilter, SubscriptionsAcknowledgedNotification,
+    ClientJsonRpcMessage, ClientRequest, GetMeta, Implementation, JsonRpcNotification,
+    JsonRpcRequest, NotificationMetaObject, RequestId, RequestMetaObject, ServerJsonRpcMessage,
+    ServerNotification, SubscriptionFilter, SubscriptionsAcknowledgedNotification,
     SubscriptionsAcknowledgedNotificationParams, SubscriptionsListenRequest,
     SubscriptionsListenRequestParams, SubscriptionsListenResult, SubscriptionsListenResultMeta,
 };
@@ -155,6 +155,7 @@ fn acknowledged_notification_round_trips_numeric_subscription_id_and_metadata() 
 #[test]
 fn listen_result_requires_matching_string_subscription_id_and_preserves_metadata() {
     let mut meta = SubscriptionsListenResultMeta::new(RequestId::String("subscription-2".into()));
+    meta.set_server_info(Implementation::new("test-server", "1.0.0"));
     meta.insert("com.example/result".into(), json!({ "reason": "shutdown" }));
     let result = SubscriptionsListenResult::new(meta);
 
@@ -165,6 +166,10 @@ fn listen_result_requires_matching_string_subscription_id_and_preserves_metadata
             "resultType": "complete",
             "_meta": {
                 "io.modelcontextprotocol/subscriptionId": "subscription-2",
+                "io.modelcontextprotocol/serverInfo": {
+                    "name": "test-server",
+                    "version": "1.0.0",
+                },
                 "com.example/result": {
                     "reason": "shutdown",
                 },
@@ -177,6 +182,10 @@ fn listen_result_requires_matching_string_subscription_id_and_preserves_metadata
     assert_eq!(
         round_trip.meta.subscription_id(),
         Some(RequestId::String("subscription-2".into()))
+    );
+    assert_eq!(
+        round_trip.meta.server_info(),
+        Some(Implementation::new("test-server", "1.0.0"))
     );
     assert_eq!(
         round_trip.meta.get("com.example/result"),
@@ -231,6 +240,15 @@ fn subscription_schemas_mark_only_draft_required_fields_as_required() {
     assert_eq!(
         acknowledgment_schema["properties"]["_meta"]["$ref"],
         "#/$defs/NotificationMetaObject"
+    );
+    let result_meta_schema = &result_schema["$defs"]["SubscriptionsListenResultMeta"];
+    assert_eq!(
+        result_meta_schema["properties"]["io.modelcontextprotocol/serverInfo"]["allOf"][0]["$ref"],
+        "#/$defs/Implementation"
+    );
+    assert_eq!(
+        result_meta_schema["required"],
+        json!(["io.modelcontextprotocol/subscriptionId"])
     );
     assert_eq!(result_schema["required"], json!(["resultType", "_meta"]));
 }

--- a/crates/rmcp/tests/test_subscriptions_streamable_http.rs
+++ b/crates/rmcp/tests/test_subscriptions_streamable_http.rs
@@ -224,9 +224,9 @@ async fn modern_http_graceful_close_returns_final_listen_result() -> anyhow::Res
     assert_eq!(
         result
             .meta
-            .get("io.modelcontextprotocol/serverInfo")
-            .and_then(|value| serde_json::from_value::<Implementation>(value.clone()).ok()),
-        Some(Implementation::new("http-subscription-server", "1.0.0"))
+            .server_info()
+            .expect("graceful result should contain valid server info"),
+        Implementation::new("http-subscription-server", "1.0.0")
     );
 
     client.cancel().await?;

--- a/crates/rmcp/tests/test_subscriptions_streamable_http.rs
+++ b/crates/rmcp/tests/test_subscriptions_streamable_http.rs
@@ -18,8 +18,8 @@ use std::{
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt, ServerHandler,
     model::{
-        ClientInfo, ClientRequest, ListToolsRequest, ProtocolVersion, RequestMetaObject,
-        ServerCapabilities, ServerInfo, ServerNotification, SubscriptionFilter,
+        ClientInfo, ClientRequest, Implementation, ListToolsRequest, ProtocolVersion,
+        RequestMetaObject, ServerCapabilities, ServerInfo, ServerNotification, SubscriptionFilter,
     },
     service::{PeerRequestOptions, SubscriptionContext, SubscriptionEnd},
     transport::{
@@ -59,6 +59,7 @@ impl ServerHandler for HttpSubscriptionServer {
                 .enable_tool_list_changed()
                 .build(),
         )
+        .with_server_info(Implementation::new("http-subscription-server", "1.0.0"))
     }
 
     fn accepted_subscription_filter(
@@ -217,10 +218,16 @@ async fn modern_http_graceful_close_returns_final_listen_result() -> anyhow::Res
 
     assert!(subscription.next().await?.is_some());
     assert!(subscription.next().await?.is_none());
-    assert!(matches!(
-        subscription.end(),
-        Some(SubscriptionEnd::Graceful(_))
-    ));
+    let Some(SubscriptionEnd::Graceful(result)) = subscription.end() else {
+        panic!("expected graceful final result");
+    };
+    assert_eq!(
+        result
+            .meta
+            .get("io.modelcontextprotocol/serverInfo")
+            .and_then(|value| serde_json::from_value::<Implementation>(value.clone()).ok()),
+        Some(Implementation::new("http-subscription-server", "1.0.0"))
+    );
 
     client.cancel().await?;
     server_ct.cancel();


### PR DESCRIPTION
Stamp the server implementation identity into the final result produced when a
`subscriptions/listen` handler completes gracefully.

## Motivation and Context

The MCP 2026-07-28 specification says servers SHOULD include
[`io.modelcontextprotocol/serverInfo` in every result's `_meta`](https://modelcontextprotocol.io/specification/2026-07-28/basic#general-fields).
`ServerHandler::listen` returns `Result<(), McpError>`, and rmcp constructs the
final `SubscriptionsListenResult` only after the handler returns. Applications
therefore cannot add this metadata themselves.

This PR intentionally covers only the graceful `subscriptions/listen` result
synthesized by rmcp after the application handler returns. SDK-wide stamping of
application-produced results is a separate concern.

## How Has This Been Tested?

- Added a stdio regression test that asserts the graceful final result contains
  the server implementation identity.
- Added the same assertion to the real Streamable HTTP/SSE graceful-close test.
- Ran the full repository test recipe, including the all-features and
  non-local-feature passes.
- Ran `cargo clippy --all-targets --all-features -- -D warnings`.
- Ran `cargo +nightly fmt --all -- --check`.

## Breaking Changes

None. This adds missing response metadata without changing the handler API.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The request path captures `ServerInfo` once before establishing the
subscription, so capability filtering and the eventual server identity come
from the same snapshot. Cancellation, abrupt transport closure, and handler
errors keep their existing behavior.
