### PR TITLE
fix: return header mismatch for missing protocol header

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -427,9 +427,9 @@ fn validate_request_protocol_version_meta(
         .get(HEADER_MCP_PROTOCOL_VERSION)
         .and_then(|value| value.to_str().ok())
     else {
-        return Err(invalid_request_jsonrpc_response(
+        return Err(header_mismatch_jsonrpc_response(
             Some(request.id.clone()),
-            "Invalid Request: request _meta protocolVersion requires MCP-Protocol-Version header",
+            "request _meta protocolVersion requires MCP-Protocol-Version header",
         ));
     };
     if header_version != meta_version.as_str() {

--- a/crates/rmcp/tests/test_streamable_http_protocol_version.rs
+++ b/crates/rmcp/tests/test_streamable_http_protocol_version.rs
@@ -185,3 +185,35 @@ async fn stateful_rejected_initial_posts_do_not_create_sessions() -> anyhow::Res
     ct.cancel();
     Ok(())
 }
+
+#[tokio::test]
+async fn stateless_missing_protocol_header_returns_header_mismatch() -> anyhow::Result<()> {
+    let (client, url, ct) = spawn_server(stateless_json_config()).await;
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"test","version":"1.0"},"io.modelcontextprotocol/clientCapabilities":{}}}}"#;
+    let response = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("Mcp-Method", "tools/list")
+        .body(body)
+        .send()
+        .await
+        .expect("send non-initialize request");
+
+    assert_eq!(response.status(), 400);
+
+    let body: serde_json::Value = response.json().await?;
+    assert_eq!(body["jsonrpc"], "2.0");
+    assert_eq!(body["id"], 1);
+    assert_eq!(body["error"]["code"], -32020);
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("requires MCP-Protocol-Version header")),
+        "expected missing protocol header message, got: {body}"
+    );
+
+    ct.cancel();
+    Ok(())
+}


### PR DESCRIPTION
Return `HeaderMismatch` (`-32020`) when request `_meta` declares a protocol version but the required `MCP-Protocol-Version` header is absent. Add a stateless HTTP regression test covering the complete JSON-RPC error response.

## Motivation and Context

The 2026-07-28 per-request protocol mirrors request metadata into HTTP headers. Required headers that are missing, malformed, or disagree with the request body are header-validation failures.

The missing `MCP-Protocol-Version` branch previously returned `Invalid Request` (`-32600`), unlike the adjacent header/body mismatch branch, which correctly returns `HeaderMismatch` (`-32020`).

This change is intentionally limited to that modern per-request validation branch:

- a missing required field in `server/discover` remains `Invalid Params` (`-32602`)
- legacy `initialize` header/body validation remains `Invalid Request` (`-32600`)

References:

- [MCP 2026-07-28 transport metadata](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports#request-metadata)
- [SEP-2243 header validation](https://modelcontextprotocol.io/seps/2243-http-standardization#server-behavior)

## How Has This Been Tested?

Added a stateless HTTP regression test that verifies:

- HTTP 400
- JSON-RPC version and request ID
- error code `-32020`
- a branch-specific missing-header diagnostic

Ran:

```text
cargo test -p rmcp \
  --test test_streamable_http_protocol_version \
  --test test_server_discover_http \
  --test test_streamable_http_standard_headers \
  --features 'server client transport-streamable-http-server reqwest'
```

Result: 28 passed, 0 failed.

`cargo fmt --all -- --check` also passes with the installed stable formatter. It reports the repository's existing warnings for nightly-only rustfmt settings.

## Breaking Changes

None. This corrects the error classification for an already-invalid request.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The regression request includes the required `Mcp-Method` header so the only missing modern routing header is `MCP-Protocol-Version`. The assertion matches a stable message fragment rather than the full diagnostic text.
