### PR TITLE
OAuth refresh uses MCP endpoint instead of discovered protected-resource audience

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2180,7 +2180,7 @@ impl AuthorizationManager {
         let mut refresh_request = oauth_client
             .exchange_refresh_token(&refresh_token_value)
             // RFC 8707: the resource indicator is required on token requests, including refreshes
-            .add_extra_param("resource", self.base_url.to_string());
+            .add_extra_param("resource", self.oauth_resource().await);
         let mut refresh_scopes = stored_credentials.granted_scopes;
         self.add_offline_access_if_supported(&mut refresh_scopes);
         for scope in refresh_scopes {
@@ -4151,6 +4151,110 @@ mod tests {
                     body: Vec::new(),
                 },
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_token_uses_discovered_protected_resource() {
+        let challenge = oauth2::http::Response::builder()
+            .status(401)
+            .header(
+                "www-authenticate",
+                r#"Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource""#,
+            )
+            .body(Vec::new())
+            .unwrap();
+        let client = RecordingOAuthHttpClient::with_responses(vec![
+            challenge,
+            http_response(
+                200,
+                serde_json::json!({
+                    "resource": "https://mcp.example.com",
+                    "authorization_servers": ["https://auth.example.com"]
+                }),
+            ),
+            http_response(
+                200,
+                serde_json::json!({
+                    "issuer": "https://auth.example.com",
+                    "authorization_endpoint": "https://auth.example.com/authorize",
+                    "token_endpoint": "https://auth.example.com/token",
+                    "response_types_supported": ["code"],
+                    "code_challenge_methods_supported": ["S256"]
+                }),
+            ),
+            http_response(
+                200,
+                serde_json::json!({
+                    "access_token": "initial-access-token",
+                    "token_type": "bearer",
+                    "refresh_token": "initial-refresh-token",
+                    "expires_in": 3600
+                }),
+            ),
+            http_response(
+                200,
+                serde_json::json!({
+                    "access_token": "refreshed-access-token",
+                    "token_type": "bearer",
+                    "refresh_token": "refreshed-refresh-token",
+                    "expires_in": 3600
+                }),
+            ),
+        ]);
+        let mut manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/mcp",
+            Arc::new(client.clone()),
+        )
+        .await
+        .unwrap();
+
+        let resolution = manager.resolve_metadata().await.unwrap();
+        manager.set_metadata(resolution.metadata);
+        manager.configure_client_id("test-client-id").unwrap();
+
+        let authorization_url = manager.get_authorization_url(&[]).await.unwrap();
+        let authorization_params: HashMap<String, String> = Url::parse(&authorization_url)
+            .unwrap()
+            .query_pairs()
+            .into_owned()
+            .collect();
+        let state = authorization_params.get("state").unwrap();
+
+        manager
+            .exchange_code_for_token("authorization-code", state)
+            .await
+            .unwrap();
+        manager.refresh_token().await.unwrap();
+
+        let token_requests: Vec<HashMap<String, String>> = client
+            .requests()
+            .into_iter()
+            .filter(|request| request.uri == "https://auth.example.com/token")
+            .map(|request| {
+                url::form_urlencoded::parse(&request.body)
+                    .into_owned()
+                    .collect()
+            })
+            .collect();
+
+        assert_eq!(token_requests.len(), 2);
+        assert_eq!(
+            token_requests[0].get("grant_type").map(String::as_str),
+            Some("authorization_code")
+        );
+        assert_eq!(
+            token_requests[1].get("grant_type").map(String::as_str),
+            Some("refresh_token")
+        );
+        assert_eq!(
+            [
+                authorization_params.get("resource").map(String::as_str),
+                token_requests[0].get("resource").map(String::as_str),
+                token_requests[1].get("resource").map(String::as_str),
+            ],
+            [Some("https://mcp.example.com"); 3],
+            "authorization, code exchange, and refresh must use the discovered resource audience"
         );
     }
 


### PR DESCRIPTION
### Description

`AuthorizationManager` correctly resolves the OAuth resource from protected-resource metadata:

```rust
async fn oauth_resource(&self) -> String {
    self.discovered_resource
        .read()
        .await
        .clone()
        .unwrap_or_else(|| self.base_url.to_string())
}
```

Both initial authorization and authorization-code exchange correctly use:

```rust
.add_extra_param("resource", self.oauth_resource().await)
```

However, `AuthorizationManager::refresh_token()` uses:

```rust
.add_extra_param("resource", self.base_url.to_string())
```

Consequently, refresh can request a different token audience than the one used for the original authorization.

### Reproduction

1. Configure an MCP endpoint:

   ```text
   https://server.example/mcp
   ```

2. Return protected-resource metadata identifying:

   ```json
   {
     "resource": "https://server.example",
     "authorization_servers": [
       "https://auth.example"
     ]
   }
   ```

3. Complete OAuth authorization successfully.
4. Refresh the resulting access token.

### Actual behavior

The refresh request contains:

```text
grant_type=refresh_token
resource=https://server.example/mcp
```

Authorization servers enforcing audience binding can reject this with:

```text
invalid_target
```

### Expected behavior

The refresh request should use the validated, discovered protected-resource identifier:

```text
grant_type=refresh_token
resource=https://server.example
```

This preserves the same audience across authorization, code exchange, and refresh, consistent with [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) and [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728).

### Fix

```diff
 let mut refresh_request = oauth_client
     .exchange_refresh_token(&refresh_token_value)
-    .add_extra_param("resource", self.base_url.to_string());
+    .add_extra_param("resource", self.oauth_resource().await);
```

The existing endpoint fallback remains unchanged when protected-resource metadata does not provide a discovered resource.

### Regression coverage

Add `refresh_token_uses_discovered_protected_resource`, which runs the complete protected-resource discovery, authorization, authorization-code exchange, and refresh flow using the existing recording OAuth HTTP client. It verifies:

- The discovered root resource differs from the `/mcp` endpoint.
- Initial authorization, authorization-code exchange, and refresh all use exactly the same discovered audience.
- The existing `refresh_token_includes_resource_parameter` test continues to cover endpoint fallback when no resource is discovered.

The new regression test fails before the fix because the refresh audience is `https://mcp.example.com/mcp` while the other two audiences are `https://mcp.example.com`.

### Downstream impact

Clients currently have to intercept and rewrite SDK-generated refresh requests to maintain the correct audience. Fixing this upstream allows that workaround to be removed.

### Validation

- `cargo test -p rmcp --features auth --lib`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
