### PR TITLE
fix: fall back to legacy initialize on general errors

### DIFF
--- a/crates/rmcp/src/service/client.rs
+++ b/crates/rmcp/src/service/client.rs
@@ -568,7 +568,8 @@ pub enum ClientLifecycleMode {
     Discover {
         preferred_versions: Vec<ProtocolVersion>,
     },
-    /// Probe with `server/discover`, falling back only when the peer proves it is legacy.
+    /// Probe with `server/discover`, falling back to legacy initialization on failures that do
+    /// not identify a modern server.
     Auto {
         preferred_versions: Vec<ProtocolVersion>,
         legacy_version: Option<ProtocolVersion>,
@@ -718,9 +719,17 @@ where
             .await;
             match discover_result {
                 Ok(()) => {}
-                Err(ClientInitializeError::JsonRpcError(error))
-                    if error.code == crate::model::ErrorCode::METHOD_NOT_FOUND =>
-                {
+                // `UnsupportedProtocolVersionError` is handled by `discover_startup`, which
+                // retries with an advertised compatible version. Reaching this point with no
+                // compatible version therefore positively identifies a modern server and must
+                // not trigger the legacy handshake.
+                Err(error @ ClientInitializeError::NoCompatibleProtocolVersion { .. }) => {
+                    return Err(error);
+                }
+                // On stdio, legacy servers may reject an unknown pre-initialize request with
+                // any implementation-defined error (or not respond at all). Treat every
+                // failure not recognized as modern version negotiation as a legacy peer.
+                Err(_) => {
                     let mut legacy_info = client_info;
                     if let Some(version) = legacy_version {
                         legacy_info.protocol_version = version;
@@ -728,7 +737,6 @@ where
                     legacy_startup(&service, &mut transport, &id_provider, &peer, legacy_info)
                         .await?;
                 }
-                Err(error) => return Err(error),
             }
         }
     }

--- a/crates/rmcp/tests/test_client_lifecycle_modes.rs
+++ b/crates/rmcp/tests/test_client_lifecycle_modes.rs
@@ -338,6 +338,66 @@ async fn auto_startup_falls_back_after_discover_method_not_found() {
 }
 
 #[tokio::test]
+async fn auto_startup_falls_back_after_discover_invalid_params() {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+    let mut server = IntoTransport::<rmcp::RoleServer, _, _>::into_transport(server_transport);
+    let server_task = tokio::spawn(async move {
+        let ClientJsonRpcMessage::Request(discover) =
+            server.receive().await.expect("expected discover request")
+        else {
+            panic!("expected request");
+        };
+        assert!(matches!(
+            discover.request,
+            ClientRequest::DiscoverRequest(_)
+        ));
+        server
+            .send(ServerJsonRpcMessage::error(
+                ErrorData::new(ErrorCode::INVALID_PARAMS, "Invalid params", None),
+                Some(discover.id),
+            ))
+            .await
+            .expect("send invalid-params");
+
+        let ClientJsonRpcMessage::Request(initialize) =
+            server.receive().await.expect("expected initialize request")
+        else {
+            panic!("expected request");
+        };
+        assert!(matches!(
+            initialize.request,
+            ClientRequest::InitializeRequest(_)
+        ));
+        server
+            .send(ServerJsonRpcMessage::response(
+                ServerResult::InitializeResult(
+                    InitializeResult::new(ServerCapabilities::default()),
+                ),
+                initialize.id,
+            ))
+            .await
+            .expect("send initialize response");
+        assert!(matches!(
+            server.receive().await,
+            Some(ClientJsonRpcMessage::Notification(_))
+        ));
+    });
+
+    let client = DiscoverClient
+        .serve_with_lifecycle(
+            client_transport,
+            ClientLifecycleMode::Auto {
+                preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+                legacy_version: Some(ProtocolVersion::V_2025_11_25),
+            },
+        )
+        .await
+        .expect("auto client should fall back");
+    client.cancel().await.expect("cancel client");
+    server_task.await.expect("server task");
+}
+
+#[tokio::test]
 async fn discover_startup_retries_a_mutually_supported_version() {
     let unsupported: ProtocolVersion =
         serde_json::from_value(serde_json::json!("2099-01-01")).unwrap();


### PR DESCRIPTION
fixes #1040

## Motivation and Context
The fallback logic was too strict, only falling back on a single METHOD_NOT_FOUND error, while the spec states we should fall back on any error that does not indicate a modern server.

## How Has This Been Tested?
Tested against FastMCP+goose

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
