### PR TITLE
fix: require metadata for modern HTTP requests

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -460,19 +460,27 @@ fn validate_request_protocol_version_meta(
         return Ok(());
     }
     let is_discover = matches!(&request.request, ClientRequest::DiscoverRequest(_));
-    let Some(meta_version) = request.request.get_meta().protocol_version() else {
-        if is_discover {
+    let meta = request.request.get_meta();
+    let header_version = headers
+        .get(HEADER_MCP_PROTOCOL_VERSION)
+        .and_then(|value| value.to_str().ok());
+    let Some(meta_version) = meta.protocol_version() else {
+        let requires_request_metadata = is_discover
+            || header_version
+                .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28.as_str());
+        if requires_request_metadata {
+            let missing = meta.missing_required_keys(&ProtocolVersion::V_2026_07_28);
             return Err(invalid_params_jsonrpc_response(
                 Some(request.id.clone()),
-                "Invalid params: server/discover requires protocolVersion in request _meta",
+                format!(
+                    "Invalid params: request _meta is missing or has malformed required fields: {}",
+                    missing.join(", ")
+                ),
             ));
         }
         return Ok(());
     };
-    let Some(header_version) = headers
-        .get(HEADER_MCP_PROTOCOL_VERSION)
-        .and_then(|value| value.to_str().ok())
-    else {
+    let Some(header_version) = header_version else {
         return Err(header_mismatch_jsonrpc_response(
             Some(request.id.clone()),
             "request _meta protocolVersion requires MCP-Protocol-Version header",

--- a/crates/rmcp/tests/test_streamable_http_protocol_version.rs
+++ b/crates/rmcp/tests/test_streamable_http_protocol_version.rs
@@ -1,10 +1,11 @@
 #![cfg(not(feature = "local"))]
-//! Regression tests for the `MCP-Protocol-Version` header / initialize body consistency check.
+//! Streamable HTTP protocol-version and request-metadata validation tests.
 use std::sync::Arc;
 
 use rmcp::transport::streamable_http_server::{
     StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
 };
+use serde_json::{Value, json};
 use tokio_util::sync::CancellationToken;
 
 mod common;
@@ -89,6 +90,31 @@ async fn post_non_initialize(client: &reqwest::Client, url: &str) -> reqwest::Re
         .send()
         .await
         .expect("send non-initialize request")
+}
+
+async fn post_modern_request(
+    client: &reqwest::Client,
+    url: &str,
+    method: &str,
+    name: Option<&str>,
+    params: Value,
+) -> reqwest::Response {
+    let mut request = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", method)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params,
+        }));
+    if let Some(name) = name {
+        request = request.header("Mcp-Name", name);
+    }
+    request.send().await.expect("send modern request")
 }
 
 #[tokio::test]
@@ -216,4 +242,141 @@ async fn stateless_missing_protocol_header_returns_header_mismatch() -> anyhow::
 
     ct.cancel();
     Ok(())
+}
+
+#[tokio::test]
+async fn stateless_tools_list_rejects_missing_request_meta() {
+    let (client, url, ct) = spawn_server(stateless_json_config()).await;
+
+    let response = post_modern_request(&client, &url, "tools/list", None, json!({})).await;
+
+    assert_eq!(response.status(), 400);
+    let body: Value = response.json().await.expect("response should be JSON");
+    assert_eq!(body["error"]["code"], -32602);
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("io.modelcontextprotocol/protocolVersion")),
+        "expected error message to mention protocolVersion, got: {body}"
+    );
+    ct.cancel();
+}
+
+#[tokio::test]
+async fn stateless_tools_call_rejects_missing_request_meta() {
+    let (client, url, ct) = spawn_server(stateless_json_config()).await;
+
+    let response = post_modern_request(
+        &client,
+        &url,
+        "tools/call",
+        Some("sum"),
+        json!({
+            "name": "sum",
+            "arguments": {
+                "a": 1,
+                "b": 2
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status(), 400);
+    let body: Value = response.json().await.expect("response should be JSON");
+    assert_eq!(body["error"]["code"], -32602);
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("io.modelcontextprotocol/protocolVersion")),
+        "expected error message to mention protocolVersion, got: {body}"
+    );
+    ct.cancel();
+}
+
+#[tokio::test]
+async fn stateless_request_rejects_missing_meta_protocol_version() {
+    let (client, url, ct) = spawn_server(stateless_json_config()).await;
+
+    let response = post_modern_request(
+        &client,
+        &url,
+        "tools/list",
+        None,
+        json!({
+            "_meta": {
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "test",
+                    "version": "1.0"
+                },
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status(), 400);
+    let body: Value = response.json().await.expect("response should be JSON");
+    assert_eq!(body["error"]["code"], -32602);
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("io.modelcontextprotocol/protocolVersion")),
+        "expected error message to mention protocolVersion, got: {body}"
+    );
+    ct.cancel();
+}
+
+#[tokio::test]
+async fn stateless_request_rejects_missing_meta_client_capabilities() {
+    let (client, url, ct) = spawn_server(stateless_json_config()).await;
+
+    let response = post_modern_request(
+        &client,
+        &url,
+        "tools/list",
+        None,
+        json!({
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "test",
+                    "version": "1.0"
+                }
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status(), 400);
+    let body: Value = response.json().await.expect("response should be JSON");
+    assert_eq!(body["error"]["code"], -32602);
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("io.modelcontextprotocol/clientCapabilities")),
+        "expected error message to mention clientCapabilities, got: {body}"
+    );
+    ct.cancel();
+}
+
+#[tokio::test]
+async fn stateless_request_accepts_missing_optional_meta_client_info() {
+    let (client, url, ct) = spawn_server(stateless_json_config()).await;
+
+    let response = post_modern_request(
+        &client,
+        &url,
+        "tools/list",
+        None,
+        json!({
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status(), 200);
+    ct.cancel();
 }


### PR DESCRIPTION
Fixes #1086. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Modern requests are self-contained, so the HTTP protocol-version header cannot make a request valid when the corresponding body `_meta` is incomplete. Previously, these requests reached tool handlers and returned successful responses.

Reject direct Streamable HTTP requests that select the `2026-07-28` protocol through the `MCP-Protocol-Version` header but omit required request metadata. Validation now returns HTTP 400 with JSON-RPC `-32602` before dispatch, and regression coverage exercises direct `tools/list`, direct `tools/call`, and individually missing metadata fields.

## How Has This Been Tested?

Add tests

Both suites pass. Focused Clippy checks, including `clippy::perf`, also pass for the changed targets.

## Breaking Changes

None.

Validation remains at the Streamable HTTP boundary so initialized legacy sessions retain their existing behavior. `clientInfo` remains optional for `2026-07-28`, matching the final specification; the tests explicitly preserve that behavior.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed