### PR TITLE
fix(model): decode metadata-bearing input-required results affecting mrtr

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -3814,6 +3814,8 @@ pub struct CallToolResult {
 // 2. Requires at least one known field to be present, so that `CallToolResult` doesn't
 //    greedily match arbitrary JSON objects when used inside `#[serde(untagged)]` enums
 //    (e.g. `ServerResult`), which would shadow `CustomResult`.
+// 3. Rejects `resultType: "input_required"` so untagged `ServerResult`
+//    decoding selects `InputRequiredResult` and preserves input requests and state.
 impl<'de> Deserialize<'de> for CallToolResult {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -3832,6 +3834,16 @@ impl<'de> Deserialize<'de> for CallToolResult {
         }
 
         let helper = Helper::deserialize(deserializer)?;
+
+        if helper
+            .result_type
+            .as_ref()
+            .is_some_and(ResultType::is_input_required)
+        {
+            return Err(serde::de::Error::custom(
+                "CallToolResult cannot use resultType \"input_required\"",
+            ));
+        }
 
         if helper.content.is_none()
             && helper.structured_content.is_none()

--- a/crates/rmcp/src/model/mrtr.rs
+++ b/crates/rmcp/src/model/mrtr.rs
@@ -274,6 +274,12 @@ impl<'de> Deserialize<'de> for InputRequiredResult {
             }
         }
 
+        if helper.input_requests.is_none() && helper.request_state.is_none() {
+            return Err(serde::de::Error::custom(
+                "InputRequiredResult requires at least one of inputRequests or requestState",
+            ));
+        }
+
         Ok(InputRequiredResult {
             result_type: ResultType::INPUT_REQUIRED,
             input_requests: helper.input_requests,
@@ -448,6 +454,19 @@ mod tests {
             assert_eq!(
                 result.request_state.as_deref(),
                 Some("eyJwcm9ncmVzcyI6IjUwJSJ9")
+            );
+        }
+
+        #[test]
+        fn rejects_missing_input_requests_and_request_state() {
+            let json = serde_json::json!({
+                "resultType": "input_required",
+                "_meta": {}
+            });
+            let err = serde_json::from_value::<InputRequiredResult>(json).unwrap_err();
+            assert!(
+                err.to_string().contains("inputRequests or requestState"),
+                "error should mention the required continuation fields, got: {err}"
             );
         }
 

--- a/crates/rmcp/tests/test_deserialization.rs
+++ b/crates/rmcp/tests/test_deserialization.rs
@@ -71,6 +71,67 @@ mod untagged_server_result {
     }
 
     #[test]
+    fn input_required_result_with_meta_deserializes_to_correct_variant() {
+        let result = parse_result(wrap_response(json!({
+            "resultType": "input_required",
+            "inputRequests": {
+                "username": {
+                    "method": "elicitation/create",
+                    "params": {
+                        "message": "Please provide your username",
+                        "requestedSchema": {
+                            "type": "object",
+                            "properties": {
+                                "username": { "type": "string" }
+                            },
+                            "required": ["username"]
+                        }
+                    }
+                }
+            },
+            "requestState": "opaque-state",
+            "_meta": {
+                "io.modelcontextprotocol/serverInfo": {
+                    "name": "test-server",
+                    "version": "1.0.0"
+                }
+            }
+        })));
+
+        let ServerResult::InputRequiredResult(result) = result else {
+            panic!("expected InputRequiredResult, got {result:?}");
+        };
+        assert!(
+            result.input_requests.is_some_and(|requests| {
+                requests.len() == 1 && requests.contains_key("username")
+            })
+        );
+        assert_eq!(result.request_state.as_deref(), Some("opaque-state"));
+        assert_eq!(
+            result
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get("io.modelcontextprotocol/serverInfo")),
+            Some(&json!({
+                "name": "test-server",
+                "version": "1.0.0"
+            }))
+        );
+    }
+
+    #[test]
+    fn call_tool_result_rejects_input_required_discriminator() {
+        assert!(
+            serde_json::from_value::<CallToolResult>(json!({
+                "resultType": "input_required",
+                "requestState": "opaque-state",
+                "_meta": {}
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
     fn empty_object_deserializes_to_empty_result() {
         let result = parse_result(wrap_response(json!({})));
         assert!(

--- a/crates/rmcp/tests/test_deserialization.rs
+++ b/crates/rmcp/tests/test_deserialization.rs
@@ -132,6 +132,20 @@ mod untagged_server_result {
     }
 
     #[test]
+    fn invalid_input_required_result_falls_through_to_custom_result() {
+        let payload = json!({
+            "resultType": "input_required",
+            "_meta": {}
+        });
+        let result = parse_result(wrap_response(payload.clone()));
+
+        let ServerResult::CustomResult(result) = result else {
+            panic!("expected CustomResult, got {result:?}");
+        };
+        assert_eq!(result.0, payload);
+    }
+
+    #[test]
     fn empty_object_deserializes_to_empty_result() {
         let result = parse_result(wrap_response(json!({})));
         assert!(


### PR DESCRIPTION
  The draft permits every Result, including InputRequiredResult, to carry
  _meta and recommends that servers include
  io.modelcontextprotocol/serverInfo on every response. It also requires
  an InputRequiredResult to contain inputRequests or requestState so the
  client knows what to provide or how to resume the request.

  ServerResult uses untagged deserialization and attempts CallToolResult
  before InputRequiredResult. Because CallToolResult accepts _meta and
  defaults missing content to an empty list, it consumed valid
  input_required results carrying metadata. Unknown inputRequests and
  requestState fields were then discarded, leaving clients without the
  information needed to continue.

  Reject resultType input_required when deserializing CallToolResult so
  Serde proceeds to the InputRequiredResult variant. Add regression
  coverage proving that inputRequests, requestState, and serverInfo
  metadata are preserved.

  Spec:
  - https://github.com/modelcontextprotocol/modelcontextprotocol/blob/41d9e938e9a9edf23a69429be180cad172e00f4e/schema/draft/schema.ts#L137-L151
- https://github.com/modelcontextprotocol/modelcontextprotocol/blob/41d9e938e9a9edf23a69429be180cad172e00f4e/schema/draft/schema.ts#L198-L224
 - https://github.com/modelcontextprotocol/modelcontextprotocol/blob/41d9e938e9a9edf23a69429be180cad172e00f4e/schema/draft/schema.ts#L541-L565


Fixes https://github.com/modelcontextprotocol/rust-sdk/issues/1098

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Found while checking against the conformance tests and several of mrtr 2322 tests failed with missing inputRequests and/or requestState

A valid MRTR `InputRequiredResult` with result metadata can be misclassified as `CallToolResult` during untagged deserialization. The SDK then drops `inputRequests` and `requestState`, preventing clients from presenting the required elicitation or retrying with the server state.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Re-run the conformance tests after building locally and tests passed

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
