### PR TITLE
fix: disambiguate input-required results with metadata

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -3814,8 +3814,7 @@ pub struct CallToolResult {
 // 2. Requires at least one known field to be present, so that `CallToolResult` doesn't
 //    greedily match arbitrary JSON objects when used inside `#[serde(untagged)]` enums
 //    (e.g. `ServerResult`), which would shadow `CustomResult`.
-// 3. Rejects `resultType: "input_required"` so untagged `ServerResult`
-//    decoding selects `InputRequiredResult` and preserves input requests and state.
+// 3. Rejects non-`complete` result types so other `ServerResult` variants can match.
 impl<'de> Deserialize<'de> for CallToolResult {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -3838,10 +3837,10 @@ impl<'de> Deserialize<'de> for CallToolResult {
         if helper
             .result_type
             .as_ref()
-            .is_some_and(ResultType::is_input_required)
+            .is_some_and(|result_type| !result_type.is_complete())
         {
             return Err(serde::de::Error::custom(
-                "CallToolResult cannot use resultType \"input_required\"",
+                "CallToolResult requires resultType to be \"complete\" when present",
             ));
         }
 

--- a/crates/rmcp/tests/test_result_type_wire.rs
+++ b/crates/rmcp/tests/test_result_type_wire.rs
@@ -87,6 +87,68 @@ fn legacy_call_tool_result_round_trips_without_result_type() {
 }
 
 #[test]
+fn call_tool_result_should_reject_non_complete_result_type() {
+    let input_required = json!({
+        "resultType": "input_required",
+        "_meta": {
+            "example.com/replica": "r1",
+        },
+    });
+
+    assert!(serde_json::from_value::<CallToolResult>(input_required).is_err());
+}
+
+#[test]
+fn server_result_should_preserve_input_required_result_when_meta_present() {
+    let input_required = json!({
+        "resultType": "input_required",
+        "requestState": "sealed",
+        "_meta": {
+            "example.com/replica": "r1",
+        },
+    });
+
+    let result =
+        serde_json::from_value::<ServerResult>(input_required).expect("deserialize ServerResult");
+
+    match result {
+        ServerResult::InputRequiredResult(result) => {
+            assert_eq!(
+                (result.request_state.as_deref(), result.meta.is_some()),
+                (Some("sealed"), true)
+            );
+        }
+        _ => panic!("expected InputRequiredResult"),
+    }
+}
+
+#[test]
+fn server_result_should_accept_legacy_call_tool_result_when_only_meta_present() {
+    let legacy = json!({
+        "_meta": {
+            "example.com/replica": "r1",
+        },
+    });
+
+    let result =
+        serde_json::from_value::<ServerResult>(legacy).expect("deserialize legacy CallToolResult");
+
+    match result {
+        ServerResult::CallToolResult(result) => {
+            assert_eq!(
+                (
+                    result.result_type,
+                    result.content.is_empty(),
+                    result.meta.is_some()
+                ),
+                (None, true, true)
+            );
+        }
+        _ => panic!("expected CallToolResult"),
+    }
+}
+
+#[test]
 fn strip_removes_complete_result_type() {
     let mut result =
         ServerResult::CallToolResult(CallToolResult::success(vec![ContentBlock::text("ok")]));


### PR DESCRIPTION
Fixes #1094.

## Motivation and Context

`ServerResult` is an untagged Serde union, and `CallToolResult` comes before `InputRequiredResult`. Since the `CallToolResult` deserializer accepted `_meta` without checking `resultType`, an intermediate result with metadata was incorrectly treated as an empty, completed tool call. As a result, its input requests and request state were dropped.

This PR prevents metadata-bearing `InputRequiredResult` values from being silently deserialized as completed tool results. It preserves legacy tool results that don't include `resultType` and adds regression coverage for both wire formats.

## How Has This Been Tested?

Added coverage

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed