### PR TITLE
fix: expose MRTR state to tool handlers

### DIFF
--- a/crates/rmcp/src/handler/server/tool.rs
+++ b/crates/rmcp/src/handler/server/tool.rs
@@ -34,9 +34,13 @@ pub fn parse_json_object<T: DeserializeOwned>(input: JsonObject) -> Result<T, cr
 }
 #[non_exhaustive]
 pub struct ToolCallContext<'s, S> {
+    /// The request-specific context for this tool call.
     pub request_context: RequestContext<RoleServer>,
+    /// The server handling this tool call.
     pub service: &'s S,
+    /// The name of the tool being called.
     pub name: Cow<'static, str>,
+    /// The arguments supplied for the tool call.
     pub arguments: Option<JsonObject>,
     /// Client responses to input requests from the previous MRTR round.
     pub input_responses: Option<crate::model::InputResponses>,

--- a/crates/rmcp/src/handler/server/tool.rs
+++ b/crates/rmcp/src/handler/server/tool.rs
@@ -38,6 +38,10 @@ pub struct ToolCallContext<'s, S> {
     pub service: &'s S,
     pub name: Cow<'static, str>,
     pub arguments: Option<JsonObject>,
+    /// Client responses to input requests from the previous MRTR round.
+    pub input_responses: Option<crate::model::InputResponses>,
+    /// Opaque state returned by the server during the previous MRTR round.
+    pub request_state: Option<String>,
 }
 
 impl<'s, S> ToolCallContext<'s, S> {
@@ -47,6 +51,8 @@ impl<'s, S> ToolCallContext<'s, S> {
             meta: _,
             name,
             arguments,
+            input_responses,
+            request_state,
             ..
         }: CallToolRequestParams,
         request_context: RequestContext<RoleServer>,
@@ -56,6 +62,8 @@ impl<'s, S> ToolCallContext<'s, S> {
             service,
             name,
             arguments,
+            input_responses,
+            request_state,
         }
     }
     pub fn name(&self) -> &str {
@@ -95,6 +103,12 @@ impl IntoCallToolResult for CallToolResult {
 impl IntoCallToolResult for InputRequiredResult {
     fn into_call_tool_result(self) -> Result<CallToolResponse, crate::ErrorData> {
         Ok(self.into())
+    }
+}
+
+impl IntoCallToolResult for CallToolResponse {
+    fn into_call_tool_result(self) -> Result<CallToolResponse, crate::ErrorData> {
+        Ok(self)
     }
 }
 
@@ -190,6 +204,26 @@ pub struct ToolName(pub Cow<'static, str>);
 impl<S> FromContextPart<ToolCallContext<'_, S>> for ToolName {
     fn from_context_part(context: &mut ToolCallContext<S>) -> Result<Self, crate::ErrorData> {
         Ok(Self(context.name.clone()))
+    }
+}
+
+/// Extracts the opaque state returned by the server during the previous MRTR round.
+#[expect(clippy::exhaustive_structs, reason = "intentionally exhaustive")]
+pub struct RequestState(pub Option<String>);
+
+impl<S> FromContextPart<ToolCallContext<'_, S>> for RequestState {
+    fn from_context_part(context: &mut ToolCallContext<S>) -> Result<Self, crate::ErrorData> {
+        Ok(Self(context.request_state.take()))
+    }
+}
+
+/// Extracts client responses to input requests from the previous MRTR round.
+#[expect(clippy::exhaustive_structs, reason = "intentionally exhaustive")]
+pub struct InputResponses(pub Option<crate::model::InputResponses>);
+
+impl<S> FromContextPart<ToolCallContext<'_, S>> for InputResponses {
+    fn from_context_part(context: &mut ToolCallContext<S>) -> Result<Self, crate::ErrorData> {
+        Ok(Self(context.input_responses.take()))
     }
 }
 

--- a/crates/rmcp/tests/test_mrtr_behavior.rs
+++ b/crates/rmcp/tests/test_mrtr_behavior.rs
@@ -13,9 +13,16 @@ use std::sync::{
 
 use rmcp::{
     ClientHandler, ServerHandler,
+    handler::server::{
+        tool::{InputResponses as ToolInputResponses, RequestState},
+        wrapper::Parameters,
+    },
     model::*,
-    service::{RequestContext, RoleClient, RoleServer, ServiceError, serve_directly},
+    service::{RequestContext, RoleClient, RoleServer, Service, ServiceError, serve_directly},
+    tool, tool_handler, tool_router,
 };
+use schemars::JsonSchema;
+use serde::Deserialize;
 use serde_json::json;
 
 /// A `requestState` value with characters that must survive a byte-exact echo:
@@ -64,6 +71,54 @@ fn single_elicitation(state: &str) -> InputRequiredResult {
     let mut requests = InputRequests::new();
     requests.insert("answer".to_string(), elicitation_request("Name?"));
     InputRequiredResult::new(Some(requests), Some(state.into()))
+}
+
+#[derive(Clone)]
+struct MacroMrtrServer;
+
+#[derive(Deserialize, JsonSchema)]
+struct MacroMrtrArguments {
+    greeting: String,
+}
+
+#[tool_router]
+impl MacroMrtrServer {
+    #[tool(description = "Greet a user after collecting their name")]
+    async fn greet(
+        &self,
+        Parameters(arguments): Parameters<MacroMrtrArguments>,
+        RequestState(request_state): RequestState,
+        ToolInputResponses(input_responses): ToolInputResponses,
+    ) -> Result<CallToolResponse, ErrorData> {
+        match request_state.as_deref() {
+            None => Ok(single_elicitation("macro-state").into()),
+            Some("macro-state") => {
+                let name = input_responses
+                    .as_ref()
+                    .and_then(|responses| responses.get("answer"))
+                    .and_then(|response| response["content"]["name"].as_str())
+                    .ok_or_else(|| ErrorData::invalid_params("missing name response", None))?;
+                Ok(CallToolResult::success(vec![ContentBlock::text(format!(
+                    "{}, {name}",
+                    arguments.greeting
+                ))])
+                .into())
+            }
+            Some(other) => Err(ErrorData::invalid_params(
+                format!("unexpected request state {other:?}"),
+                None,
+            )),
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for MacroMrtrServer {
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+        info.protocol_version = ProtocolVersion::V_2026_07_28;
+        info
+    }
 }
 
 impl MrtrServer {
@@ -289,12 +344,13 @@ fn server_info(protocol_version: ProtocolVersion) -> ServerInfo {
 
 /// Runs `body` inside a `LocalSet` so `spawn_local` (used when the `local`
 /// feature is active) is available, wiring up a connected client/server pair.
-async fn with_pair<F, Fut>(
-    server: MrtrServer,
+async fn with_pair<S, F, Fut>(
+    server: S,
     client_protocol: ProtocolVersion,
     body: F,
 ) -> anyhow::Result<()>
 where
+    S: Service<RoleServer>,
     F: FnOnce(rmcp::service::RunningService<RoleClient, MrtrClient>) -> Fut,
     Fut: std::future::Future<Output = anyhow::Result<()>>,
 {
@@ -343,6 +399,23 @@ async fn client_auto_fulfills_input_required_tool_call() -> anyhow::Result<()> {
         assert_eq!(calls.load(Ordering::SeqCst), 2);
         Ok(())
     })
+    .await
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tool_macro_receives_mrtr_retry_fields() -> anyhow::Result<()> {
+    with_pair(
+        MacroMrtrServer,
+        ProtocolVersion::V_2026_07_28,
+        |client| async move {
+            let arguments = serde_json::from_value(json!({ "greeting": "hello" })).unwrap();
+            let result = client
+                .call_tool(CallToolRequestParams::new("greet").with_arguments(arguments))
+                .await?;
+            assert_eq!(result.content[0].as_text().unwrap().text, "hello, Ferris");
+            Ok(())
+        },
+    )
     .await
 }
 


### PR DESCRIPTION
Fixes #1095.

## Motivation and Context

`ToolCallContext::new` was dropping `request_state` and `input_responses`, so `#[tool]` handlers could not continue an MRTR call after the client completed its input requests. Because of that, servers had to bypass the macro routing path and implement `ServerHandler::call_tool` manually.

This PR preserves the SEP-2322 retry state and input responses when macro-generated tool handlers route calls through `ToolCallContext`. It also adds extractors for both values and lets `#[tool]` handlers return `CallToolResponse`. This allows a single handler to produce both `input_required` responses and completed results.


## How Has This Been Tested?

Added regression tests


## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed