### PR TITLE
fix(auth): honor explicitly configured OAuth resource indicators

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -1029,6 +1029,8 @@ pub struct AuthorizationManager {
     www_auth_scopes: RwLock<Vec<String>>,
     /// scopes_supported from protected resource metadata (RFC 9728)
     resource_scopes: RwLock<Vec<String>>,
+    /// Explicit resource indicator supplied by the application (RFC 8707).
+    configured_resource: Option<String>,
     /// resource indicator from protected resource metadata, used for RFC 8707 `resource`
     discovered_resource: RwLock<Option<String>>,
     /// OIDC Dynamic Client Registration `application_type` (SEP-837)
@@ -1278,6 +1280,7 @@ impl AuthorizationManager {
             scope_upgrade_config: ScopeUpgradeConfig::default(),
             www_auth_scopes: RwLock::new(Vec::new()),
             resource_scopes: RwLock::new(Vec::new()),
+            configured_resource: None,
             discovered_resource: RwLock::new(None),
             application_type: Some(DEFAULT_APPLICATION_TYPE.to_string()),
             allow_missing_issuer: false,
@@ -1300,6 +1303,33 @@ impl AuthorizationManager {
     /// with authorization servers that return incomplete metadata.
     pub fn set_allow_missing_issuer(&mut self, allow: bool) {
         self.allow_missing_issuer = allow;
+    }
+
+    /// Set an explicit OAuth resource indicator for authorization and token requests.
+    ///
+    /// The value takes precedence over protected-resource metadata and the MCP
+    /// endpoint. Configure it before starting authorization or restoring cached
+    /// credentials so every request uses the same resource audience.
+    ///
+    /// Passing `None` restores the normal discovered-resource selection.
+    pub fn set_resource(&mut self, resource: Option<&str>) -> Result<(), AuthError> {
+        let Some(resource) = resource else {
+            self.configured_resource = None;
+            return Ok(());
+        };
+
+        let parsed = Url::parse(resource).map_err(|error| {
+            AuthError::MetadataError(format!("Invalid OAuth resource indicator: {error}"))
+        })?;
+        if !Self::is_http_url(&parsed) || parsed.fragment().is_some() {
+            return Err(AuthError::MetadataError(
+                "OAuth resource indicator must be an absolute HTTP(S) URL without a fragment"
+                    .to_string(),
+            ));
+        }
+
+        self.configured_resource = Some(resource.to_string());
+        Ok(())
     }
 
     /// Set a custom credential store
@@ -1787,6 +1817,10 @@ impl AuthorizationManager {
     }
 
     async fn oauth_resource(&self) -> String {
+        if let Some(resource) = &self.configured_resource {
+            return resource.clone();
+        }
+
         self.discovered_resource
             .read()
             .await
@@ -4154,8 +4188,17 @@ mod tests {
         );
     }
 
+    #[rstest]
+    #[case::discovered(None, "https://mcp.example.com")]
+    #[case::configured(
+        Some("https://api.example.com/tenant-a"),
+        "https://api.example.com/tenant-a"
+    )]
     #[tokio::test]
-    async fn refresh_token_uses_discovered_protected_resource() {
+    async fn refresh_token_uses_discovered_protected_resource(
+        #[case] configured_resource: Option<&str>,
+        #[case] expected_resource: &str,
+    ) {
         let challenge = oauth2::http::Response::builder()
             .status(401)
             .header(
@@ -4208,6 +4251,7 @@ mod tests {
         )
         .await
         .unwrap();
+        manager.set_resource(configured_resource).unwrap();
 
         let resolution = manager.resolve_metadata().await.unwrap();
         manager.set_metadata(resolution.metadata);
@@ -4253,9 +4297,48 @@ mod tests {
                 token_requests[0].get("resource").map(String::as_str),
                 token_requests[1].get("resource").map(String::as_str),
             ],
-            [Some("https://mcp.example.com"); 3],
-            "authorization, code exchange, and refresh must use the discovered resource audience"
+            [Some(expected_resource); 3],
+            "authorization, code exchange, and refresh must use the same resource audience"
         );
+    }
+
+    #[rstest]
+    #[case::relative("api/resource")]
+    #[case::non_http("file:///tmp/resource")]
+    #[case::fragment("https://api.example.com/resource#fragment")]
+    #[case::missing_host("https://")]
+    #[tokio::test]
+    async fn configured_resource_rejects_invalid_indicators(#[case] resource: &str) {
+        let mut manager = AuthorizationManager::new("https://mcp.example.com/mcp")
+            .await
+            .unwrap();
+        manager
+            .set_resource(Some("https://api.example.com/tenant-a"))
+            .unwrap();
+
+        let error = manager.set_resource(Some(resource)).unwrap_err();
+
+        assert!(matches!(error, AuthError::MetadataError(_)));
+        assert_eq!(
+            manager.oauth_resource().await,
+            "https://api.example.com/tenant-a",
+            "invalid input must not replace the previously configured resource"
+        );
+    }
+
+    #[tokio::test]
+    async fn clearing_configured_resource_restores_discovered_resource() {
+        let mut manager = AuthorizationManager::new("https://mcp.example.com/mcp")
+            .await
+            .unwrap();
+        *manager.discovered_resource.write().await = Some("https://mcp.example.com".to_string());
+        manager
+            .set_resource(Some("https://api.example.com/tenant-a"))
+            .unwrap();
+
+        manager.set_resource(None).unwrap();
+
+        assert_eq!(manager.oauth_resource().await, "https://mcp.example.com");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `AuthorizationManager::set_resource(Option<&str>)` for applications that need to configure an explicit OAuth 2.0 resource indicator.
- Use the configured audience consistently in the authorization URL, authorization-code exchange, and refresh-token requests.
- Give explicit configuration precedence over protected-resource metadata while preserving the existing discovered-resource and MCP-endpoint fallbacks.
- Reject relative URLs, unsupported schemes, missing hosts, and URI fragments without replacing a previously valid configuration.
- Restore the normal discovered-resource behavior when the override is cleared.

## Motivation

Applications sometimes know the required RFC 8707 resource audience before starting authorization, and that audience can differ from the MCP endpoint or the resource published in metadata. Without an SDK-level configuration API, downstream clients may append a `resource` parameter to the authorization URL while authorization-code exchange and refresh continue to use a different SDK-selected audience. That can produce duplicate resource parameters, inconsistent token audiences, or failed refreshes.

Keeping audience selection inside `AuthorizationManager` applies one validated value across the complete OAuth lifecycle. When no override is configured, existing behavior is unchanged.

This change is independent of #1110: it targets current `main` and does not depend on or modify cached-credential issuer/resource binding.

## Regression coverage

- End-to-end protected-resource discovery, authorization, authorization-code exchange, and token refresh with both discovered and explicitly configured audiences.
- Invalid relative, non-HTTP(S), fragment-bearing, and hostless resource indicators.
- Preservation of the previous valid audience after rejected configuration.
- Restoring the discovered audience after clearing an explicit override.

## Validation

- `cargo test --offline -p rmcp --features auth --lib transport::auth::tests` — **177 passed**.
- `cargo test --offline -p rmcp --features auth-client-credentials-jwt --lib transport::auth::tests` — **183 passed**.
- `cargo clippy --offline -p rmcp --all-targets --all-features -- -D warnings`.
- `rustfmt --check --edition 2024 crates/rmcp/src/transport/auth.rs`.
- `git diff --check`.
