### PR TITLE
chore: make async-trait optional

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -45,7 +45,7 @@ features = [
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-async-trait = "0.1.89"
+async-trait = { version = "0.1.89", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "2"
@@ -187,11 +187,12 @@ transport-streamable-http-server = [
 ]
 transport-streamable-http-server-session = [
   "transport-async-rw",
+  "dep:async-trait",
   "dep:tokio-stream",
 ]
 # transport-ws = ["transport-io", "dep:tokio-tungstenite"]
 tower = ["dep:tower-service"]
-auth = ["dep:oauth2", "__reqwest", "dep:url"]
+auth = ["dep:async-trait", "dep:oauth2", "__reqwest", "dep:url"]
 auth-client-credentials-jwt = ["auth", "dep:jsonwebtoken", "uuid"]
 schemars = ["dep:schemars"]
 


### PR DESCRIPTION
Closes #1112.

## Motivation and Context

The default `rmcp` feature set does not compile any code that uses `async-trait`, but the unconditional dependency still adds the proc-macro crate to every consumer's build graph. Moving the dependency behind the two features that use it keeps the build graph smaller without changing the public API or runtime behavior.

This PR makes `async-trait` optional. Consumers that do not enable OAuth or streamable HTTP server sessions will no longer compile an unused proc macro. The `auth` and `transport-streamable-http-server-session` features now enable the dependency explicitly.

## How Has This Been Tested?

- Verified `async-trait` is absent with `--no-default-features --features base64,macros,server`.
- Verified `async-trait` is present with `auth` and `transport-streamable-http-server-session` independently.

## Breaking Changes

None. Existing features continue to enable `async-trait` wherever it is required.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed