### PR TITLE
chore: upgrade darling and syn

### DIFF
--- a/crates/rmcp-macros/Cargo.toml
+++ b/crates/rmcp-macros/Cargo.toml
@@ -16,11 +16,11 @@ documentation = "https://docs.rs/rmcp-macros"
 proc-macro = true
 
 [dependencies]
-syn = {version = "2", features = ["full"]}
+syn = {version = "3", features = ["full"]}
 quote = "1"
 proc-macro2 = "1"
 serde_json = "1.0"
-darling = { version = "0.23" }
+darling = { version = "0.24" }
 
 [features]
 local = []

--- a/crates/rmcp-macros/src/prompt.rs
+++ b/crates/rmcp-macros/src/prompt.rs
@@ -133,7 +133,7 @@ pub fn prompt(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream>
         let new_output = syn::parse2::<ReturnType>({
             let mut lt = quote! { 'static };
             if let Some(receiver) = fn_item.sig.receiver()
-                && let Some((_, receiver_lt)) = receiver.reference.as_ref()
+                && let syn::ReceiverKind::Reference(_, receiver_lt, _) = &receiver.kind
             {
                 if let Some(receiver_lt) = receiver_lt {
                     lt = quote! { #receiver_lt };
@@ -256,6 +256,20 @@ mod test {
         } else {
             assert!(result_str.contains("+ Send +"));
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_async_prompt_preserves_receiver_lifetime() -> syn::Result<()> {
+        let attr = quote! {};
+        let input = quote! {
+            async fn test_prompt_with_lifetime<'a>(&'a self) -> String {
+                "ok".to_string()
+            }
+        };
+        let result = prompt(attr, input)?;
+
+        assert!(result.to_string().contains("+ 'a"));
         Ok(())
     }
 

--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -284,7 +284,7 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
         let new_output = syn::parse2::<ReturnType>({
             let mut lt = quote! { 'static };
             if let Some(receiver) = fn_item.sig.receiver()
-                && let Some((_, receiver_lt)) = receiver.reference.as_ref()
+                && let syn::ReceiverKind::Reference(_, receiver_lt, _) = &receiver.kind
             {
                 if let Some(receiver_lt) = receiver_lt {
                     lt = quote! { #receiver_lt };
@@ -339,6 +339,20 @@ mod test {
         };
         let _input = tool(attr, input)?;
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_async_tool_preserves_receiver_lifetime() -> syn::Result<()> {
+        let attr = quote! {};
+        let input = quote! {
+            async fn test_tool_with_lifetime<'a>(&'a self) -> String {
+                "ok".to_string()
+            }
+        };
+        let result = tool(attr, input)?;
+
+        assert!(result.to_string().contains("+ 'a"));
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation and Context
Dependabot tried to update `syn` alone in #1014 and #1057, and `darling` alone in #1118, but all three updates failed. This PR manually upgrades both dependencies together because they depend on each other.

## How Has This Been Tested?

## Breaking Changes
No.

## Types of changes
<!-- Dependency maintenance; none of the listed categories applies exactly. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed