### PR TITLE
fix(client): fall back on legacy JSON-RPC errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ let client = ClientInfo::default()
     )
     .await?;
 
-// Or probe the discover lifecycle and fall back when a legacy server reports
-// that server/discover is not implemented.
+// Or probe the discover lifecycle and fall back when the response does not
+// positively identify a modern server.
 let client = ClientInfo::default()
     .serve_with_lifecycle(
         transport,
@@ -127,7 +127,9 @@ let client = ClientInfo::default()
 `ClientLifecycleMode::Initialize` is equivalent to the existing `serve()` behavior.
 Discover startup does not send `notifications/initialized`; discovery completes
 startup, and each subsequent request carries its protocol version, client
-information, and capabilities in `_meta`.
+information, and capabilities in `_meta`. Auto mode preserves authentication,
+transport, and recognized modern-protocol errors instead of treating them as
+legacy-server signals.
 
 ### Build a Server
 

--- a/crates/rmcp/src/service/client.rs
+++ b/crates/rmcp/src/service/client.rs
@@ -740,7 +740,7 @@ where
             match discover_result {
                 Ok(()) => {}
                 Err(ClientInitializeError::JsonRpcError(error))
-                    if error.code == crate::model::ErrorCode::METHOD_NOT_FOUND =>
+                    if !is_modern_server_json_rpc_error(&error) =>
                 {
                     let mut legacy_info = client_info;
                     if let Some(version) = legacy_version {
@@ -754,6 +754,17 @@ where
         }
     }
     Ok(serve_inner(service, transport, peer, peer_rx, ct))
+}
+
+// Only specification-defined modern errors prove that the peer understands
+// per-request metadata; other JSON-RPC errors are legacy fallback signals.
+fn is_modern_server_json_rpc_error(error: &ErrorData) -> bool {
+    matches!(
+        error.code,
+        crate::model::ErrorCode::UNSUPPORTED_PROTOCOL_VERSION
+            | crate::model::ErrorCode::MISSING_REQUIRED_CLIENT_CAPABILITY
+            | crate::model::ErrorCode::HEADER_MISMATCH
+    )
 }
 
 async fn legacy_startup<S, T>(

--- a/crates/rmcp/tests/test_client_lifecycle_modes.rs
+++ b/crates/rmcp/tests/test_client_lifecycle_modes.rs
@@ -277,8 +277,7 @@ async fn discover_startup_omits_initialize() {
     server_task.await.expect("server task");
 }
 
-#[tokio::test]
-async fn auto_startup_falls_back_after_discover_method_not_found() {
+async fn run_auto_discover_error_scenario(error: ErrorData, expect_fallback: bool) {
     let (server_transport, client_transport) = tokio::io::duplex(4096);
     let mut server = IntoTransport::<rmcp::RoleServer, _, _>::into_transport(server_transport);
     let server_task = tokio::spawn(async move {
@@ -292,38 +291,39 @@ async fn auto_startup_falls_back_after_discover_method_not_found() {
             ClientRequest::DiscoverRequest(_)
         ));
         server
-            .send(ServerJsonRpcMessage::error(
-                ErrorData::new(ErrorCode::METHOD_NOT_FOUND, "Method not found", None),
-                Some(discover.id),
-            ))
+            .send(ServerJsonRpcMessage::error(error, Some(discover.id)))
             .await
-            .expect("send method-not-found");
+            .expect("send discover error");
 
-        let ClientJsonRpcMessage::Request(initialize) =
-            server.receive().await.expect("expected initialize request")
-        else {
-            panic!("expected request");
-        };
-        assert!(matches!(
-            initialize.request,
-            ClientRequest::InitializeRequest(_)
-        ));
-        server
-            .send(ServerJsonRpcMessage::response(
-                ServerResult::InitializeResult(
-                    InitializeResult::new(ServerCapabilities::default()),
-                ),
-                initialize.id,
-            ))
-            .await
-            .expect("send initialize response");
-        assert!(matches!(
-            server.receive().await,
-            Some(ClientJsonRpcMessage::Notification(_))
-        ));
+        if expect_fallback {
+            let ClientJsonRpcMessage::Request(initialize) =
+                server.receive().await.expect("expected initialize request")
+            else {
+                panic!("expected request");
+            };
+            assert!(matches!(
+                initialize.request,
+                ClientRequest::InitializeRequest(_)
+            ));
+            server
+                .send(ServerJsonRpcMessage::response(
+                    ServerResult::InitializeResult(InitializeResult::new(
+                        ServerCapabilities::default(),
+                    )),
+                    initialize.id,
+                ))
+                .await
+                .expect("send initialize response");
+            assert!(matches!(
+                server.receive().await,
+                Some(ClientJsonRpcMessage::Notification(_))
+            ));
+        } else if let Some(message) = server.receive().await {
+            panic!("modern discover error should close the client, got {message:?}");
+        }
     });
 
-    let client = DiscoverClient
+    let client_result = DiscoverClient
         .serve_with_lifecycle(
             client_transport,
             ClientLifecycleMode::Auto {
@@ -331,10 +331,62 @@ async fn auto_startup_falls_back_after_discover_method_not_found() {
                 legacy_version: Some(ProtocolVersion::V_2025_11_25),
             },
         )
-        .await
-        .expect("auto client should fall back");
-    client.cancel().await.expect("cancel client");
+        .await;
+
+    if expect_fallback {
+        let client = client_result.expect("auto client should fall back");
+        client.cancel().await.expect("cancel client");
+    } else {
+        assert!(
+            client_result.is_err(),
+            "modern discover error should be surfaced"
+        );
+    }
     server_task.await.expect("server task");
+}
+
+#[tokio::test]
+async fn auto_startup_falls_back_after_discover_method_not_found() {
+    run_auto_discover_error_scenario(
+        ErrorData::new(ErrorCode::METHOD_NOT_FOUND, "Method not found", None),
+        true,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn auto_startup_falls_back_after_discover_implementation_defined_error() {
+    run_auto_discover_error_scenario(
+        ErrorData::new(
+            ErrorCode(-32000),
+            "Bad Request: The MCP-Protocol-Version header value '2026-07-28' is not supported.",
+            None,
+        ),
+        true,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn auto_startup_does_not_fall_back_after_missing_required_capability() {
+    run_auto_discover_error_scenario(
+        ErrorData::new(
+            ErrorCode::MISSING_REQUIRED_CLIENT_CAPABILITY,
+            "Missing required client capability",
+            None,
+        ),
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn auto_startup_does_not_fall_back_after_header_mismatch() {
+    run_auto_discover_error_scenario(
+        ErrorData::new(ErrorCode::HEADER_MISMATCH, "Header mismatch", None),
+        false,
+    )
+    .await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Fall back from `server/discover` to legacy `initialize` for JSON-RPC errors that do not positively identify a modern server.
- Keep authentication, transport, lifecycle configuration, and recognized modern-protocol errors actionable instead of downgrading them.
- Add a regression test for the deployed `-32000` unsupported `MCP-Protocol-Version` response, plus guards for modern capability and header errors.
- Clarify `ClientLifecycleMode::Auto` behavior in the README.

This addresses the JSON-RPC interoperability cases in #1040 and is a narrower alternative to #1133 after the review concern that `Err(_)` also catches 401/403 and client-side failures.

## Motivation and Context

The 2026-07-28 compatibility guidance says a client should fall back when a legacy server returns an error that is not a recognized modern JSON-RPC error. Some deployed legacy servers reject the modern protocol header before dispatch with an implementation-defined response such as:

```text
-32000 Bad Request: The MCP-Protocol-Version header value 2026-07-28 is not supported.
```

Current `Auto` handling only falls back for `METHOD_NOT_FOUND`, so these servers fail even though the configured legacy protocol works. This change limits the broader fallback to `JsonRpcError`; transport and authorization failures still surface unchanged.

## How Has This Been Tested?

- `cargo fmt --all --check`
- `cargo test -p rmcp --test test_client_lifecycle_modes --features client`
- `cargo test -p rmcp --test test_discover_http_client_startup --features client,reqwest,transport-streamable-http-client-reqwest,transport-streamable-http-server`
- `cargo clippy -p rmcp --test test_client_lifecycle_modes --features client -- -D warnings`

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the MCP Documentation
- [x] My code follows the repository style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed