### PR TITLE
fix(auth): map 401/403 challenges on the SSE GET stream

### DIFF
--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -94,6 +94,37 @@ impl StreamableHttpClient for reqwest::Client {
         if response.status() == reqwest::StatusCode::METHOD_NOT_ALLOWED {
             return Err(StreamableHttpError::ServerDoesNotSupportSse);
         }
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED
+            && let Some(header) = response.headers().get(WWW_AUTHENTICATE)
+        {
+            let header = header
+                .to_str()
+                .map_err(|_| {
+                    StreamableHttpError::UnexpectedServerResponse(Cow::from(
+                        "invalid www-authenticate header value",
+                    ))
+                })?
+                .to_string();
+            return Err(StreamableHttpError::AuthRequired(AuthRequiredError {
+                www_authenticate_header: header,
+            }));
+        }
+        if response.status() == reqwest::StatusCode::FORBIDDEN
+            && let Some(header) = response.headers().get(WWW_AUTHENTICATE)
+        {
+            let header_str = header.to_str().map_err(|_| {
+                StreamableHttpError::UnexpectedServerResponse(Cow::from(
+                    "invalid www-authenticate header value",
+                ))
+            })?;
+            let scope = extract_scope_from_header(header_str);
+            return Err(StreamableHttpError::InsufficientScope(
+                InsufficientScopeError {
+                    www_authenticate_header: header_str.to_string(),
+                    required_scope: scope,
+                },
+            ));
+        }
         let response = response.error_for_status()?;
         match response.headers().get(reqwest::header::CONTENT_TYPE) {
             Some(ct) => {

--- a/crates/rmcp/tests/test_streamable_http_get_stream_auth_challenge.rs
+++ b/crates/rmcp/tests/test_streamable_http_get_stream_auth_challenge.rs
@@ -1,0 +1,105 @@
+#![cfg(all(
+    feature = "transport-streamable-http-client",
+    feature = "transport-streamable-http-client-reqwest",
+    not(feature = "local")
+))]
+
+use std::{collections::HashMap, sync::Arc};
+
+use rmcp::transport::streamable_http_client::{StreamableHttpClient, StreamableHttpError};
+
+/// Spin up a minimal axum server whose GET handler always responds with the given
+/// status and optional `WWW-Authenticate` header — no MCP logic involved.
+async fn spawn_mock_server(status: u16, www_authenticate: Option<&'static str>) -> String {
+    use axum::{Router, body::Body, http::Response, routing::get};
+
+    let router = Router::new().route(
+        "/mcp",
+        get(move || async move {
+            let mut builder = Response::builder().status(status);
+            if let Some(challenge) = www_authenticate {
+                builder = builder.header("www-authenticate", challenge);
+            }
+            builder.body(Body::empty()).unwrap()
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    format!("http://{addr}/mcp")
+}
+
+async fn get_stream_against(
+    status: u16,
+    www_authenticate: Option<&'static str>,
+) -> Result<(), StreamableHttpError<reqwest::Error>> {
+    let url = spawn_mock_server(status, www_authenticate).await;
+    reqwest::Client::new()
+        .get_stream(Arc::from(url.as_str()), None, None, None, HashMap::new())
+        .await
+        .map(|_| ())
+}
+
+/// A 401 carrying a `WWW-Authenticate` challenge must surface as `AuthRequired`,
+/// which is the variant `AuthClient::call_reacting_to_challenges` catches to
+/// refresh the token and retry. Classified as a plain `Client` error instead, the
+/// refresh never runs and the stream just fails.
+#[tokio::test]
+async fn get_stream_maps_401_challenge_to_auth_required() {
+    let result = get_stream_against(401, Some("Bearer realm=\"mcp\"")).await;
+
+    match result {
+        Err(StreamableHttpError::AuthRequired(err)) => {
+            assert_eq!(err.www_authenticate_header, "Bearer realm=\"mcp\"");
+        }
+        other => panic!("expected AuthRequired, got: {other:?}"),
+    }
+}
+
+/// A 403 carrying a challenge must surface as `InsufficientScope`, with the
+/// required scope extracted from the header.
+#[tokio::test]
+async fn get_stream_maps_403_challenge_to_insufficient_scope() {
+    let result = get_stream_against(
+        403,
+        Some("Bearer error=\"insufficient_scope\", scope=\"mcp:read\""),
+    )
+    .await;
+
+    match result {
+        Err(StreamableHttpError::InsufficientScope(err)) => {
+            assert_eq!(err.required_scope.as_deref(), Some("mcp:read"));
+        }
+        other => panic!("expected InsufficientScope, got: {other:?}"),
+    }
+}
+
+/// Without a `WWW-Authenticate` header there is no challenge to act on, so a 401
+/// must keep falling through to the ordinary error path rather than being
+/// reported as an auth challenge the caller can retry.
+#[tokio::test]
+async fn get_stream_401_without_challenge_is_not_auth_required() {
+    let result = get_stream_against(401, None).await;
+
+    assert!(
+        !matches!(result, Err(StreamableHttpError::AuthRequired(_))),
+        "401 with no challenge header must not be classified as AuthRequired"
+    );
+    assert!(result.is_err(), "401 must still be an error");
+}
+
+/// 405 keeps its dedicated meaning — the server does not support SSE on GET —
+/// and must not be swallowed by the new auth branches.
+#[tokio::test]
+async fn get_stream_405_still_reports_sse_unsupported() {
+    let result = get_stream_against(405, None).await;
+
+    assert!(
+        matches!(result, Err(StreamableHttpError::ServerDoesNotSupportSse)),
+        "expected ServerDoesNotSupportSse, got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

`post_message_with_max_sse_event_size` maps a 401 or 403 carrying a `WWW-Authenticate` header onto `StreamableHttpError::AuthRequired` / `InsufficientScope`. `get_stream_with_max_sse_event_size`, **in the same file**, handles only 405 and then falls straight through to `error_for_status()?`, so the identical challenge comes back as an opaque `StreamableHttpError::Client`.

`crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs`:

| | 401 + `WWW-Authenticate` | 403 + `WWW-Authenticate` |
|---|---|---|
| `post_message_…` (L181–211) | `AuthRequired` | `InsufficientScope` |
| `get_stream_…` (L94–97, before this PR) | `Client(Status(401))` | `Client(Status(403))` |
| `unix_socket.rs` `get_stream_…` (L441–472) | `AuthRequired` | `InsufficientScope` |

## Why it matters

`AuthClient::get_stream` routes through `call_reacting_to_challenges`, whose entire job is to catch `AuthRequired`, call `try_refresh_or_reauth()`, and retry once. It never receives that variant from this path, so **an expired token on the standalone SSE stream is never refreshed** — the stream just fails. The same expiry on `post_message` recovers silently, which makes this look like an intermittent SSE problem rather than an auth one.

## The change

The two blocks copied verbatim from `post_message` in the same file, inserted before `error_for_status()?`. No new imports — `WWW_AUTHENTICATE`, `Cow`, `extract_scope_from_header` and the error types are already in scope for the sibling.

## Testing

`crates/rmcp/tests/test_streamable_http_get_stream_auth_challenge.rs`, built on the harness in the existing `test_streamable_http_4xx_error_body.rs` (same axum mock-server shape).

| Test | Before | After |
|---|---|---|
| 401 + challenge → `AuthRequired` | ❌ `Err(Client(reqwest::Error { kind: Status(401, None) }))` | ✅ |
| 403 + challenge → `InsufficientScope`, scope extracted | ❌ `Err(Client(… Status(403, None) …))` | ✅ |
| 401 **without** challenge → *not* `AuthRequired` | ✅ | ✅ |
| 405 → `ServerDoesNotSupportSse` | ✅ | ✅ |

The bottom two pass either way on purpose: they exist to catch an over-broad fix, not to demonstrate the bug. Without a challenge header there is nothing for the caller to act on, so a bare 401 must keep falling through to the ordinary error path, and 405 must keep its dedicated meaning.

```
cargo test -p rmcp --test test_streamable_http_get_stream_auth_challenge \
  --features transport-streamable-http-client,transport-streamable-http-client-reqwest,client,auth

  with this change:  4 passed; 0 failed
  with only the source change reverted:  2 passed; 2 failed
```

`cargo test -p rmcp --lib` with the same features: **416 passed / 0 failed, identical to the baseline on `main`** — no regression, and the delta is entirely in the new integration binary. `cargo fmt -p rmcp -- --check` clean and touching only these files; `cargo clippy -p rmcp --lib` exits 0 with no errors.

## Notes

**Toolchain.** Built with stable **1.97.1**; `rust-toolchain.toml` pins **1.96** and `.githooks` runs `cargo +nightly fmt`. There is no rustup on this machine, so formatting was applied with stable rustfmt and the repo's nightly-only options (`imports_granularity`, `group_imports`) were skipped with a warning. This change adds no imports and the formatting is unchanged from the copied sibling, but CI on 1.96 is the authoritative check.

**Deliberately not fixed.** `get_stream` in `unix_socket.rs` already handles both cases, so nothing to do there. I have not touched `auth.rs` — #1102 is open against that file and this PR does not overlap it.

---

### AI assistance disclosure

Per the [modelcontextprotocol AI policy](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/AI_POLICY.md): **this change was made in conjunction with my pair programmer, Claude Code.**

Extent, so you know how much scrutiny to apply: the defect was surfaced by an automated sweep I run across MCP-ecosystem repos, and the patch was written with Claude Code working alongside me. I reviewed it before filing — the before/after test output, the baseline test counts, and the lint/format runs quoted above were executed on my machine, not pasted from a model. I understand what the change does and why, and replies on this PR are mine.
