### PR TITLE
fix(model): deprecate ServerInfo and ClientInfo aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ Use [`ClientServiceExt::serve_with_lifecycle`](crates/rmcp/src/service/client.rs
 select another lifecycle explicitly:
 
 ```rust, ignore
-use rmcp::{ClientInfo, ClientLifecycleMode, ClientServiceExt, ProtocolVersion};
+use rmcp::{ClientLifecycleMode, ClientServiceExt, InitializeRequestParams, ProtocolVersion};
 
 // Start directly with server/discover and include client metadata on every request.
-let client = ClientInfo::default()
+let client = InitializeRequestParams::default()
     .serve_with_lifecycle(
         transport,
         ClientLifecycleMode::Discover {
@@ -113,7 +113,7 @@ let client = ClientInfo::default()
 
 // Or probe the discover lifecycle and fall back when a legacy server reports
 // that server/discover is not implemented or does not respond within 10 seconds.
-let client = ClientInfo::default()
+let client = InitializeRequestParams::default()
     .serve_with_lifecycle(
         transport,
         ClientLifecycleMode::Auto {
@@ -369,8 +369,8 @@ use serde_json::json;
 struct MyServer;
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_resources()
                 .build(),
@@ -582,8 +582,8 @@ impl MyServer {
 
 #[prompt_handler]
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_prompts().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_prompts().build())
     }
 }
 ```
@@ -934,8 +934,8 @@ Enable the logging capability, handle level changes from the client, and send lo
 use rmcp::{ServerHandler, model::*, service::RequestContext};
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_logging()
                 .build(),
@@ -1007,8 +1007,8 @@ Enable the completions capability and implement the `complete()` handler. Use `r
 use rmcp::{ErrorData as McpError, ServerHandler, model::*, service::RequestContext, RoleServer};
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_completions()
                 .enable_prompts()
@@ -1253,8 +1253,8 @@ use rmcp::{
 };
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -1574,7 +1574,7 @@ use rmcp::transport::StreamableHttpClientTransport;
 
 // Defaults are stateless-friendly.
 let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
-let client = ClientInfo::default().serve(transport).await?;
+let client = InitializeRequestParams::default().serve(transport).await?;
 ```
 
 **Example:** [`examples/servers/src/counter_streamhttp.rs`](examples/servers/src/counter_streamhttp.rs) (server), [`examples/clients/src/streamable_http.rs`](examples/clients/src/streamable_http.rs) (client)
@@ -1628,7 +1628,7 @@ server example). The client transport connects with a single URI:
 use rmcp::transport::StreamableHttpClientTransport;
 
 let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
-let client = ClientInfo::default().serve(transport).await?;
+let client = InitializeRequestParams::default().serve(transport).await?;
 ```
 
 #### Server-Sent Events (SSE)
@@ -1714,10 +1714,10 @@ knows what the other supports. Declare yours with the `ServerCapabilities`
 builder in `get_info()`:
 
 ```rust,ignore
-use rmcp::model::{ServerCapabilities, ServerInfo};
+use rmcp::model::{InitializeResult, ServerCapabilities};
 
-fn get_info(&self) -> ServerInfo {
-    ServerInfo::new(
+fn get_info(&self) -> InitializeResult {
+    InitializeResult::new(
         ServerCapabilities::builder()
             .enable_tools()
             .enable_prompts()

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ Use [`ClientServiceExt::serve_with_lifecycle`](crates/rmcp/src/service/client.rs
 select another lifecycle explicitly:
 
 ```rust, ignore
-use rmcp::{ClientInfo, ClientLifecycleMode, ClientServiceExt, ProtocolVersion};
+use rmcp::{ClientLifecycleMode, ClientServiceExt, InitializeRequestParams, ProtocolVersion};
 
 // Start directly with server/discover and include client metadata on every request.
-let client = ClientInfo::default()
+let client = InitializeRequestParams::default()
     .serve_with_lifecycle(
         transport,
         ClientLifecycleMode::Discover {
@@ -113,7 +113,7 @@ let client = ClientInfo::default()
 
 // Or probe the discover lifecycle and fall back when a legacy server reports
 // that server/discover is not implemented or does not respond within 10 seconds.
-let client = ClientInfo::default()
+let client = InitializeRequestParams::default()
     .serve_with_lifecycle(
         transport,
         ClientLifecycleMode::Auto {
@@ -369,8 +369,8 @@ use serde_json::json;
 struct MyServer;
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_resources()
                 .build(),
@@ -582,8 +582,8 @@ impl MyServer {
 
 #[prompt_handler]
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_prompts().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_prompts().build())
     }
 }
 ```
@@ -934,8 +934,8 @@ Enable the logging capability, handle level changes from the client, and send lo
 use rmcp::{ServerHandler, model::*, service::RequestContext};
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_logging()
                 .build(),
@@ -1007,8 +1007,8 @@ Enable the completions capability and implement the `complete()` handler. Use `r
 use rmcp::{ErrorData as McpError, ServerHandler, model::*, service::RequestContext, RoleServer};
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_completions()
                 .enable_prompts()
@@ -1253,8 +1253,8 @@ use rmcp::{
 };
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -1584,7 +1584,7 @@ use rmcp::transport::StreamableHttpClientTransport;
 
 // Defaults are stateless-friendly.
 let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
-let client = ClientInfo::default().serve(transport).await?;
+let client = InitializeRequestParams::default().serve(transport).await?;
 ```
 
 **Example:** [`examples/servers/src/counter_streamhttp.rs`](examples/servers/src/counter_streamhttp.rs) (server), [`examples/clients/src/streamable_http.rs`](examples/clients/src/streamable_http.rs) (client)
@@ -1638,7 +1638,7 @@ server example). The client transport connects with a single URI:
 use rmcp::transport::StreamableHttpClientTransport;
 
 let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
-let client = ClientInfo::default().serve(transport).await?;
+let client = InitializeRequestParams::default().serve(transport).await?;
 ```
 
 The client allows up to 16 ordinary http POSTs at once. Configure this with
@@ -1742,10 +1742,10 @@ knows what the other supports. Declare yours with the `ServerCapabilities`
 builder in `get_info()`:
 
 ```rust,ignore
-use rmcp::model::{ServerCapabilities, ServerInfo};
+use rmcp::model::{InitializeResult, ServerCapabilities};
 
-fn get_info(&self) -> ServerInfo {
-    ServerInfo::new(
+fn get_info(&self) -> InitializeResult {
+    InitializeResult::new(
         ServerCapabilities::builder()
             .enable_tools()
             .enable_prompts()

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -55,8 +55,8 @@ impl ClientHandler for BasicClientHandler {}
 struct ElicitationDefaultsClientHandler;
 
 impl ClientHandler for ElicitationDefaultsClientHandler {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.capabilities.elicitation = Some(
             ElicitationCapability::new()
                 .with_form(FormElicitationCapability::new().with_schema_validation(true)),
@@ -144,8 +144,8 @@ impl ClientHandler for ElicitationDefaultsClientHandler {
 struct FullClientHandler;
 
 impl ClientHandler for FullClientHandler {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.capabilities.elicitation = Some(
             ElicitationCapability::new()
                 .with_form(FormElicitationCapability::new().with_schema_validation(true)),

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -74,8 +74,8 @@ impl ClientHandler for BasicClientHandler {}
 struct ElicitationDefaultsClientHandler;
 
 impl ClientHandler for ElicitationDefaultsClientHandler {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.capabilities.elicitation = Some(
             ElicitationCapability::new()
                 .with_form(FormElicitationCapability::new().with_schema_validation(true)),
@@ -163,8 +163,8 @@ impl ClientHandler for ElicitationDefaultsClientHandler {
 struct FullClientHandler;
 
 impl ClientHandler for FullClientHandler {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.capabilities.elicitation = Some(
             ElicitationCapability::new()
                 .with_form(FormElicitationCapability::new().with_schema_validation(true)),

--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -700,8 +700,8 @@ impl ServerHandler for ConformanceServer {
         (name == "test_custom_header").then(custom_header_tool)
     }
 
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_prompts()
                 .enable_prompts_list_changed()

--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -704,8 +704,8 @@ impl ServerHandler for ConformanceServer {
         (name == "test_custom_header").then(custom_header_tool)
     }
 
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_prompts()
                 .enable_prompts_list_changed()

--- a/crates/rmcp-macros/src/lib.rs
+++ b/crates/rmcp-macros/src/lib.rs
@@ -185,8 +185,8 @@ pub fn tool_router(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// ```rust,ignore
 /// #[tool_handler]
 /// impl ServerHandler for MyToolHandler {
-///     fn get_info(&self) -> ServerInfo {
-///         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+///     fn get_info(&self) -> InitializeResult {
+///         InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
 ///     }
 /// }
 /// ```

--- a/crates/rmcp-macros/src/lib.rs
+++ b/crates/rmcp-macros/src/lib.rs
@@ -217,8 +217,8 @@ pub fn tool_router(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// ```rust,ignore
 /// #[tool_handler]
 /// impl ServerHandler for MyToolHandler {
-///     fn get_info(&self) -> ServerInfo {
-///         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+///     fn get_info(&self) -> InitializeResult {
+///         InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
 ///     }
 /// }
 /// ```

--- a/crates/rmcp-macros/src/tool_handler.rs
+++ b/crates/rmcp-macros/src/tool_handler.rs
@@ -116,7 +116,7 @@ pub(crate) enum CallerCapability {
     Prompts,
 }
 
-/// Build a `get_info()` method that returns `ServerInfo` with the appropriate capabilities.
+/// Build a `get_info()` method that returns `InitializeResult` with the appropriate capabilities.
 ///
 /// The caller declares its own capability via `caller`. Sibling handler attributes
 /// (`prompt_handler`, `tool_handler`) are detected automatically
@@ -157,8 +157,8 @@ pub(crate) fn build_get_info(
     }
 
     syn::parse2::<ImplItem>(quote! {
-        fn get_info(&self) -> rmcp::model::ServerInfo {
-            rmcp::model::ServerInfo::new(
+        fn get_info(&self) -> rmcp::model::InitializeResult {
+            rmcp::model::InitializeResult::new(
                 rmcp::model::ServerCapabilities::builder()
                     #(#capability_calls)*
                     .build()

--- a/crates/rmcp/src/handler/client.rs
+++ b/crates/rmcp/src/handler/client.rs
@@ -274,8 +274,8 @@ macro_rules! client_handler_methods {
             std::future::ready(())
         }
 
-        fn get_info(&self) -> ClientInfo {
-            ClientInfo::default()
+        fn get_info(&self) -> InitializeRequestParams {
+            InitializeRequestParams::default()
         }
     };
 }
@@ -296,8 +296,8 @@ pub trait ClientHandler: Sized + 'static {
 impl ClientHandler for () {}
 
 /// Do nothing, with a specific client info.
-impl ClientHandler for ClientInfo {
-    fn get_info(&self) -> ClientInfo {
+impl ClientHandler for InitializeRequestParams {
+    fn get_info(&self) -> InitializeRequestParams {
         self.clone()
     }
 }
@@ -422,7 +422,7 @@ macro_rules! impl_client_handler_for_wrapper {
                 (**self).on_custom_notification(notification, context)
             }
 
-            fn get_info(&self) -> ClientInfo {
+            fn get_info(&self) -> InitializeRequestParams {
                 (**self).get_info()
             }
         }

--- a/crates/rmcp/src/handler/client.rs
+++ b/crates/rmcp/src/handler/client.rs
@@ -274,7 +274,7 @@ macro_rules! client_handler_methods {
             std::future::ready(())
         }
 
-        fn get_info(&self) -> InitializeRequestParams {
+        fn get_info(&self) -> ClientInfo {
             InitializeRequestParams::default()
         }
     };
@@ -296,8 +296,8 @@ pub trait ClientHandler: Sized + 'static {
 impl ClientHandler for () {}
 
 /// Do nothing, with a specific client info.
-impl ClientHandler for InitializeRequestParams {
-    fn get_info(&self) -> InitializeRequestParams {
+impl ClientHandler for ClientInfo {
+    fn get_info(&self) -> ClientInfo {
         self.clone()
     }
 }
@@ -422,7 +422,7 @@ macro_rules! impl_client_handler_for_wrapper {
                 (**self).on_custom_notification(notification, context)
             }
 
-            fn get_info(&self) -> InitializeRequestParams {
+            fn get_info(&self) -> ClientInfo {
                 (**self).get_info()
             }
         }

--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -550,8 +550,8 @@ macro_rules! server_handler_methods {
             std::future::ready(())
         }
 
-        fn get_info(&self) -> ServerInfo {
-            ServerInfo::default()
+        fn get_info(&self) -> InitializeResult {
+            InitializeResult::default()
         }
 
         /// SEP-2663 `tasks/get`: return the current [`DetailedTask`] state.
@@ -782,7 +782,7 @@ macro_rules! impl_server_handler_for_wrapper {
                 (**self).on_custom_notification(notification, context)
             }
 
-            fn get_info(&self) -> ServerInfo {
+            fn get_info(&self) -> InitializeResult {
                 (**self).get_info()
             }
 

--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -550,7 +550,7 @@ macro_rules! server_handler_methods {
             std::future::ready(())
         }
 
-        fn get_info(&self) -> InitializeResult {
+        fn get_info(&self) -> ServerInfo {
             InitializeResult::default()
         }
 
@@ -782,7 +782,7 @@ macro_rules! impl_server_handler_for_wrapper {
                 (**self).on_custom_notification(notification, context)
             }
 
-            fn get_info(&self) -> InitializeResult {
+            fn get_info(&self) -> ServerInfo {
                 (**self).get_info()
             }
 

--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -600,8 +600,8 @@ macro_rules! server_handler_methods {
             std::future::ready(())
         }
 
-        fn get_info(&self) -> ServerInfo {
-            ServerInfo::default()
+        fn get_info(&self) -> InitializeResult {
+            InitializeResult::default()
         }
 
         /// SEP-2663 `tasks/get`: return the current [`DetailedTask`] state.
@@ -839,7 +839,7 @@ macro_rules! impl_server_handler_for_wrapper {
                 (**self).on_custom_notification(notification, context)
             }
 
-            fn get_info(&self) -> ServerInfo {
+            fn get_info(&self) -> InitializeResult {
                 (**self).get_info()
             }
 

--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -600,7 +600,7 @@ macro_rules! server_handler_methods {
             std::future::ready(())
         }
 
-        fn get_info(&self) -> InitializeResult {
+        fn get_info(&self) -> ServerInfo {
             InitializeResult::default()
         }
 
@@ -839,7 +839,7 @@ macro_rules! impl_server_handler_for_wrapper {
                 (**self).on_custom_notification(notification, context)
             }
 
-            fn get_info(&self) -> InitializeResult {
+            fn get_info(&self) -> ServerInfo {
                 (**self).get_info()
             }
 

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1086,6 +1086,14 @@ impl InitializeResult {
 ///
 /// Prefer [`InitializeResult`]. The name collides with the protocol's
 /// `serverInfo` field, which is only the [`Implementation`] identity (#1082).
+//
+// The signatures this crate publishes (`ServerHandler::get_info`,
+// `DiscoverResult::from_server_info`, and the `ClientInfo` equivalents below)
+// keep spelling the alias. It resolves to the same type, so the spelling makes
+// no difference to callers, but rustdoc records the name as written and the
+// public API check treats a respelling as a changed item. Moving those
+// signatures onto the canonical names is a documented API change and belongs in
+// the next major release.
 #[deprecated(note = "use `InitializeResult` instead")]
 pub type ServerInfo = InitializeResult;
 
@@ -1256,7 +1264,7 @@ impl DiscoverResult {
     /// Create a discovery result from the server's initialization information.
     pub fn from_server_info(
         supported_versions: Vec<ProtocolVersion>,
-        server_info: InitializeResult,
+        server_info: ServerInfo,
     ) -> Self {
         let InitializeResult {
             capabilities,

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1082,7 +1082,18 @@ impl InitializeResult {
     }
 }
 
+/// Full server initialize payload (`InitializeResult`).
+///
+/// Prefer [`InitializeResult`]. The name collides with the protocol's
+/// `serverInfo` field, which is only the [`Implementation`] identity (#1082).
+#[deprecated(note = "use `InitializeResult` instead")]
 pub type ServerInfo = InitializeResult;
+
+/// Full client initialize params (`InitializeRequestParams`).
+///
+/// Prefer [`InitializeRequestParams`]. The name collides with the protocol's
+/// `clientInfo` field, which is only the [`Implementation`] identity (#1082).
+#[deprecated(note = "use `InitializeRequestParams` instead")]
 pub type ClientInfo = InitializeRequestParams;
 
 /// Information negotiated about a server peer.
@@ -1245,9 +1256,9 @@ impl DiscoverResult {
     /// Create a discovery result from the server's initialization information.
     pub fn from_server_info(
         supported_versions: Vec<ProtocolVersion>,
-        server_info: ServerInfo,
+        server_info: InitializeResult,
     ) -> Self {
-        let ServerInfo {
+        let InitializeResult {
             capabilities,
             server_info,
             instructions,
@@ -1295,9 +1306,9 @@ impl ServerPeerInfo {
 }
 
 #[allow(clippy::derivable_impls)]
-impl Default for ServerInfo {
+impl Default for InitializeResult {
     fn default() -> Self {
-        ServerInfo {
+        InitializeResult {
             protocol_version: ProtocolVersion::default(),
             capabilities: ServerCapabilities::default(),
             server_info: Implementation::from_build_env(),
@@ -1308,9 +1319,9 @@ impl Default for ServerInfo {
 }
 
 #[allow(clippy::derivable_impls)]
-impl Default for ClientInfo {
+impl Default for InitializeRequestParams {
     fn default() -> Self {
-        ClientInfo {
+        InitializeRequestParams {
             meta: None,
             protocol_version: ProtocolVersion::default(),
             capabilities: ClientCapabilities::default(),

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1123,6 +1123,14 @@ impl InitializeResult {
 ///
 /// Prefer [`InitializeResult`]. The name collides with the protocol's
 /// `serverInfo` field, which is only the [`Implementation`] identity (#1082).
+//
+// The signatures this crate publishes (`ServerHandler::get_info`,
+// `DiscoverResult::from_server_info`, and the `ClientInfo` equivalents below)
+// keep spelling the alias. It resolves to the same type, so the spelling makes
+// no difference to callers, but rustdoc records the name as written and the
+// public API check treats a respelling as a changed item. Moving those
+// signatures onto the canonical names is a documented API change and belongs in
+// the next major release.
 #[deprecated(note = "use `InitializeResult` instead")]
 pub type ServerInfo = InitializeResult;
 
@@ -1293,7 +1301,7 @@ impl DiscoverResult {
     /// Create a discovery result from the server's initialization information.
     pub fn from_server_info(
         supported_versions: Vec<ProtocolVersion>,
-        server_info: InitializeResult,
+        server_info: ServerInfo,
     ) -> Self {
         let InitializeResult {
             capabilities,

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1119,7 +1119,18 @@ impl InitializeResult {
     }
 }
 
+/// Full server initialize payload (`InitializeResult`).
+///
+/// Prefer [`InitializeResult`]. The name collides with the protocol's
+/// `serverInfo` field, which is only the [`Implementation`] identity (#1082).
+#[deprecated(note = "use `InitializeResult` instead")]
 pub type ServerInfo = InitializeResult;
+
+/// Full client initialize params (`InitializeRequestParams`).
+///
+/// Prefer [`InitializeRequestParams`]. The name collides with the protocol's
+/// `clientInfo` field, which is only the [`Implementation`] identity (#1082).
+#[deprecated(note = "use `InitializeRequestParams` instead")]
 pub type ClientInfo = InitializeRequestParams;
 
 /// Information negotiated about a server peer.
@@ -1282,9 +1293,9 @@ impl DiscoverResult {
     /// Create a discovery result from the server's initialization information.
     pub fn from_server_info(
         supported_versions: Vec<ProtocolVersion>,
-        server_info: ServerInfo,
+        server_info: InitializeResult,
     ) -> Self {
-        let ServerInfo {
+        let InitializeResult {
             capabilities,
             server_info,
             instructions,
@@ -1332,9 +1343,9 @@ impl ServerPeerInfo {
 }
 
 #[allow(clippy::derivable_impls)]
-impl Default for ServerInfo {
+impl Default for InitializeResult {
     fn default() -> Self {
-        ServerInfo {
+        InitializeResult {
             protocol_version: ProtocolVersion::default(),
             capabilities: ServerCapabilities::default(),
             server_info: Implementation::from_build_env(),
@@ -1345,9 +1356,9 @@ impl Default for ServerInfo {
 }
 
 #[allow(clippy::derivable_impls)]
-impl Default for ClientInfo {
+impl Default for InitializeRequestParams {
     fn default() -> Self {
-        ClientInfo {
+        InitializeRequestParams {
             meta: None,
             protocol_version: ProtocolVersion::default(),
             capabilities: ClientCapabilities::default(),

--- a/crates/rmcp/src/service/client.rs
+++ b/crates/rmcp/src/service/client.rs
@@ -13,13 +13,13 @@ use crate::{
     model::{
         ArgumentInfo, CacheScope, CallToolRequest, CallToolRequestParams, CallToolResponse,
         CallToolResult, CancelTaskParams, CancelTaskRequest, CancelledNotification,
-        CancelledNotificationParam, ClientInfo, ClientJsonRpcMessage, ClientNotification,
-        ClientRequest, ClientResult, CompleteRequest, CompleteRequestParams, CompleteResult,
-        CompletionContext, CompletionInfo, DEFAULT_MRTR_MAX_ROUNDS, DiscoverRequest,
-        DiscoverRequestParams, DiscoverResult, ErrorData, GetExtensions, GetMeta, GetPromptRequest,
+        CancelledNotificationParam, ClientJsonRpcMessage, ClientNotification, ClientRequest,
+        ClientResult, CompleteRequest, CompleteRequestParams, CompleteResult, CompletionContext,
+        CompletionInfo, DEFAULT_MRTR_MAX_ROUNDS, DiscoverRequest, DiscoverRequestParams,
+        DiscoverResult, ErrorData, GetExtensions, GetMeta, GetPromptRequest,
         GetPromptRequestParams, GetPromptResponse, GetPromptResult, GetTaskParams, GetTaskRequest,
-        GetTaskResult, InitializeRequest, InitializedNotification, InputRequest,
-        InputRequiredResult, InputResponses, JsonRpcResponse, ListPromptsRequest,
+        GetTaskResult, InitializeRequest, InitializeRequestParams, InitializedNotification,
+        InputRequest, InputRequiredResult, InputResponses, JsonRpcResponse, ListPromptsRequest,
         ListPromptsResult, ListResourceTemplatesRequest, ListResourceTemplatesResult,
         ListResourcesRequest, ListResourcesResult, ListToolsRequest, ListToolsResult,
         NumberOrString, PaginatedRequestParams, ProgressNotification, ProgressNotificationParam,
@@ -266,7 +266,7 @@ impl ServiceRole for RoleClient {
     type PeerReq = ServerRequest;
     type PeerResp = ServerResult;
     type PeerNot = ServerNotification;
-    type Info = ClientInfo;
+    type Info = InitializeRequestParams;
     type PeerInfo = ServerPeerInfo;
     type InitializeError = ClientInitializeError;
     const IS_CLIENT: bool = true;
@@ -870,7 +870,7 @@ async fn legacy_startup<S, T>(
     transport: &mut T,
     id_provider: &Arc<AtomicU32RequestIdProvider>,
     peer: &Peer<RoleClient>,
-    client_info: ClientInfo,
+    client_info: InitializeRequestParams,
 ) -> Result<(), ClientInitializeError>
 where
     S: Service<RoleClient>,
@@ -919,7 +919,7 @@ async fn discover_startup<S, T>(
     transport: &mut T,
     id_provider: &Arc<AtomicU32RequestIdProvider>,
     peer: &Peer<RoleClient>,
-    client_info: &ClientInfo,
+    client_info: &InitializeRequestParams,
     preferred_versions: Vec<ProtocolVersion>,
 ) -> Result<DiscoverOutcome, ClientInitializeError>
 where

--- a/crates/rmcp/src/service/server.rs
+++ b/crates/rmcp/src/service/server.rs
@@ -13,14 +13,15 @@ use super::*;
 use crate::model::{ElicitRequest, ElicitRequestParams, ElicitResult, ElicitationAction};
 use crate::{
     model::{
-        CancelledNotification, CancelledNotificationParam, ClientInfo, ClientJsonRpcMessage,
+        CancelledNotification, CancelledNotificationParam, ClientJsonRpcMessage,
         ClientNotification, ClientRequest, ClientResult, CreateMessageRequest,
-        CreateMessageRequestParams, CreateMessageResult, EmptyResult, ErrorData, ListRootsRequest,
-        ListRootsResult, LoggingMessageNotification, LoggingMessageNotificationParam,
-        ProgressNotification, ProgressNotificationParam, PromptListChangedNotification,
-        ProtocolVersion, ResourceListChangedNotification, ResourceUpdatedNotification,
-        ResourceUpdatedNotificationParam, ServerInfo, ServerNotification, ServerRequest,
-        ServerResult, SubscriptionFilter, SubscriptionsAcknowledgedNotification,
+        CreateMessageRequestParams, CreateMessageResult, EmptyResult, ErrorData,
+        InitializeRequestParams, InitializeResult, ListRootsRequest, ListRootsResult,
+        LoggingMessageNotification, LoggingMessageNotificationParam, ProgressNotification,
+        ProgressNotificationParam, PromptListChangedNotification, ProtocolVersion,
+        ResourceListChangedNotification, ResourceUpdatedNotification,
+        ResourceUpdatedNotificationParam, ServerNotification, ServerRequest, ServerResult,
+        SubscriptionFilter, SubscriptionsAcknowledgedNotification,
         SubscriptionsAcknowledgedNotificationParams, ToolListChangedNotification,
     },
     transport::DynamicTransportError,
@@ -37,8 +38,8 @@ impl ServiceRole for RoleServer {
     type PeerReq = ClientRequest;
     type PeerResp = ClientResult;
     type PeerNot = ClientNotification;
-    type Info = ServerInfo;
-    type PeerInfo = ClientInfo;
+    type Info = InitializeResult;
+    type PeerInfo = InitializeRequestParams;
 
     type InitializeError = ServerInitializeError;
     const IS_CLIENT: bool = false;

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -27,8 +27,8 @@ use crate::{
     model::{
         ClientCapabilities, ClientJsonRpcMessage, ClientNotification, ClientRequest, ErrorCode,
         ErrorData, GetExtensions, GetMeta, Implementation, InitializeRequest,
-        InitializeRequestParams, InitializedNotification, JsonObject, JsonRpcError,
-        ProtocolVersion, RequestId, ServerInfo, ServerJsonRpcMessage, ServerResult,
+        InitializeRequestParams, InitializeResult, InitializedNotification, JsonObject,
+        JsonRpcError, ProtocolVersion, RequestId, ServerJsonRpcMessage, ServerResult,
     },
     serve_server,
     service::{
@@ -340,7 +340,7 @@ impl<S: Service<RoleServer>> Service<RoleServer> for NegotiatingStatelessHttpSer
         self.0.handle_notification(notification, context).await
     }
 
-    fn get_info(&self) -> ServerInfo {
+    fn get_info(&self) -> InitializeResult {
         self.0.get_info()
     }
 
@@ -2075,7 +2075,7 @@ where
         Ok(accepted_response())
     }
 
-    /// Build a `ClientInfo` (peer_info) for a stateless request so that
+    /// Build a `InitializeRequestParams` (peer_info) for a stateless request so that
     /// `context.protocol_version()` returns the correct value inside handlers.
     ///
     /// `serve_directly` skips the MCP handshake and accepts `peer_info = None`,

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -27,8 +27,8 @@ use crate::{
     model::{
         ClientCapabilities, ClientJsonRpcMessage, ClientNotification, ClientRequest, ErrorCode,
         ErrorData, GetExtensions, GetMeta, Implementation, InitializeRequest,
-        InitializeRequestParams, InitializedNotification, JsonObject, JsonRpcError,
-        ProtocolVersion, RequestId, ServerInfo, ServerJsonRpcMessage, ServerResult,
+        InitializeRequestParams, InitializeResult, InitializedNotification, JsonObject,
+        JsonRpcError, ProtocolVersion, RequestId, ServerJsonRpcMessage, ServerResult,
     },
     serve_server,
     service::{
@@ -355,7 +355,7 @@ impl<S: Service<RoleServer>> Service<RoleServer> for NegotiatingStatelessHttpSer
         self.0.handle_notification(notification, context).await
     }
 
-    fn get_info(&self) -> ServerInfo {
+    fn get_info(&self) -> InitializeResult {
         self.0.get_info()
     }
 
@@ -2059,7 +2059,7 @@ where
         Ok(accepted_response())
     }
 
-    /// Build a `ClientInfo` (peer_info) for a stateless request so that
+    /// Build a `InitializeRequestParams` (peer_info) for a stateless request so that
     /// `context.protocol_version()` returns the correct value inside handlers.
     ///
     /// `serve_directly` skips the MCP handshake and accepts `peer_info = None`,

--- a/crates/rmcp/tests/common/calculator.rs
+++ b/crates/rmcp/tests/common/calculator.rs
@@ -2,7 +2,7 @@
 use rmcp::{
     ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{ServerCapabilities, ServerInfo},
+    model::{InitializeResult, ServerCapabilities},
     schemars, tool, tool_router,
 };
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -52,8 +52,8 @@ impl Calculator {
 }
 
 impl ServerHandler for Calculator {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions("A simple calculator")
     }
 }

--- a/crates/rmcp/tests/common/handlers.rs
+++ b/crates/rmcp/tests/common/handlers.rs
@@ -115,8 +115,8 @@ impl TestServer {
 
 impl ServerHandler for TestServer {
     #[allow(deprecated)]
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_logging().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_logging().build())
     }
 
     #[allow(deprecated)]

--- a/crates/rmcp/tests/test_cancelled_response.rs
+++ b/crates/rmcp/tests/test_cancelled_response.rs
@@ -8,8 +8,8 @@ use std::{collections::BTreeSet, process::Stdio, time::Duration};
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler, ServiceExt,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ServerCapabilities,
-        ServerInfo,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, InitializeResult,
+        ServerCapabilities,
     },
     service::RequestContext,
 };
@@ -91,8 +91,8 @@ async fn cancelled_request_receives_no_response() -> anyhow::Result<()> {
 struct WaitForCancelServer;
 
 impl ServerHandler for WaitForCancelServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_custom_headers.rs
+++ b/crates/rmcp/tests/test_custom_headers.rs
@@ -719,7 +719,7 @@ async fn test_server_rejects_unsupported_protocol_version() {
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
-        model::{ServerCapabilities, ServerInfo},
+        model::{InitializeResult, ServerCapabilities},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
@@ -730,8 +730,8 @@ async fn test_server_rejects_unsupported_protocol_version() {
     struct TestHandler;
 
     impl ServerHandler for TestHandler {
-        fn get_info(&self) -> ServerInfo {
-            ServerInfo::new(ServerCapabilities::builder().build())
+        fn get_info(&self) -> InitializeResult {
+            InitializeResult::new(ServerCapabilities::builder().build())
         }
     }
 
@@ -891,7 +891,7 @@ async fn test_server_validates_host_header_for_dns_rebinding_protection() {
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
-        model::{ServerCapabilities, ServerInfo},
+        model::{InitializeResult, ServerCapabilities},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
@@ -902,8 +902,8 @@ async fn test_server_validates_host_header_for_dns_rebinding_protection() {
     struct TestHandler;
 
     impl ServerHandler for TestHandler {
-        fn get_info(&self) -> ServerInfo {
-            ServerInfo::new(ServerCapabilities::builder().build())
+        fn get_info(&self) -> InitializeResult {
+            InitializeResult::new(ServerCapabilities::builder().build())
         }
     }
 
@@ -974,7 +974,7 @@ async fn test_server_validates_host_header_port_for_dns_rebinding_protection() {
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
-        model::{ServerCapabilities, ServerInfo},
+        model::{InitializeResult, ServerCapabilities},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
@@ -985,8 +985,8 @@ async fn test_server_validates_host_header_port_for_dns_rebinding_protection() {
     struct TestHandler;
 
     impl ServerHandler for TestHandler {
-        fn get_info(&self) -> ServerInfo {
-            ServerInfo::new(ServerCapabilities::builder().build())
+        fn get_info(&self) -> InitializeResult {
+            InitializeResult::new(ServerCapabilities::builder().build())
         }
     }
 
@@ -1045,7 +1045,7 @@ async fn test_server_falls_back_to_uri_authority_when_host_header_missing() {
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
-        model::{ServerCapabilities, ServerInfo},
+        model::{InitializeResult, ServerCapabilities},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
@@ -1056,8 +1056,8 @@ async fn test_server_falls_back_to_uri_authority_when_host_header_missing() {
     struct TestHandler;
 
     impl ServerHandler for TestHandler {
-        fn get_info(&self) -> ServerInfo {
-            ServerInfo::new(ServerCapabilities::builder().build())
+        fn get_info(&self) -> InitializeResult {
+            InitializeResult::new(ServerCapabilities::builder().build())
         }
     }
 
@@ -1131,7 +1131,7 @@ mod origin_validation {
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
-        model::{ServerCapabilities, ServerInfo},
+        model::{InitializeResult, ServerCapabilities},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
@@ -1142,8 +1142,8 @@ mod origin_validation {
     struct TestHandler;
 
     impl ServerHandler for TestHandler {
-        fn get_info(&self) -> ServerInfo {
-            ServerInfo::new(ServerCapabilities::builder().build())
+        fn get_info(&self) -> InitializeResult {
+            InitializeResult::new(ServerCapabilities::builder().build())
         }
     }
 

--- a/crates/rmcp/tests/test_discover_http_client_startup.rs
+++ b/crates/rmcp/tests/test_discover_http_client_startup.rs
@@ -16,7 +16,7 @@ use axum::{
 };
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt, ServerHandler,
-    model::{ClientInfo, DiscoverResult, ErrorCode, ErrorData, ProtocolVersion},
+    model::{DiscoverResult, ErrorCode, ErrorData, InitializeRequestParams, ProtocolVersion},
     service::{MaybeSendFuture, RequestContext, RoleServer},
     transport::{
         StreamableHttpClientTransport,
@@ -132,7 +132,7 @@ async fn discover_http_client_bootstraps_headers_without_initialize() {
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!("http://{address}/mcp")),
     );
-    let client = ClientInfo::default()
+    let client = InitializeRequestParams::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {
@@ -176,7 +176,7 @@ async fn auto_http_client_falls_back_to_stateful_legacy_startup() {
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!("http://{address}/mcp")),
     );
-    let client = ClientInfo::default()
+    let client = InitializeRequestParams::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Auto {

--- a/crates/rmcp/tests/test_discover_http_client_startup.rs
+++ b/crates/rmcp/tests/test_discover_http_client_startup.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt, ServerHandler,
-    model::{ClientInfo, DiscoverResult, ErrorCode, ErrorData, ProtocolVersion},
+    model::{DiscoverResult, ErrorCode, ErrorData, InitializeRequestParams, ProtocolVersion},
     service::{MaybeSendFuture, RequestContext, RoleServer},
     transport::{
         StreamableHttpClientTransport,
@@ -75,7 +75,7 @@ async fn discover_http_client_bootstraps_headers_without_initialize() {
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!("http://{address}/mcp")),
     );
-    let client = ClientInfo::default()
+    let client = InitializeRequestParams::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {
@@ -119,7 +119,7 @@ async fn auto_http_client_falls_back_to_stateful_legacy_startup() {
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!("http://{address}/mcp")),
     );
-    let client = ClientInfo::default()
+    let client = InitializeRequestParams::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Auto {

--- a/crates/rmcp/tests/test_discover_http_client_startup.rs
+++ b/crates/rmcp/tests/test_discover_http_client_startup.rs
@@ -217,7 +217,7 @@ async fn auto_http_client_falls_back_after_plain_text_4xx_rejection() {
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!("http://{address}/mcp")),
     );
-    let client = ClientInfo::default()
+    let client = InitializeRequestParams::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Auto {

--- a/crates/rmcp/tests/test_handler_cache_hints.rs
+++ b/crates/rmcp/tests/test_handler_cache_hints.rs
@@ -4,7 +4,9 @@
 use rmcp::{
     ClientHandler, ServerHandler, ServiceExt,
     handler::server::router::{prompt::PromptRouter, tool::ToolRouter},
-    model::{CacheScope, ClientInfo, ListPromptsResult, ListToolsResult, ProtocolVersion},
+    model::{
+        CacheScope, InitializeRequestParams, ListPromptsResult, ListToolsResult, ProtocolVersion,
+    },
     prompt_handler, tool_handler,
 };
 
@@ -33,8 +35,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }

--- a/crates/rmcp/tests/test_handler_cache_hints.rs
+++ b/crates/rmcp/tests/test_handler_cache_hints.rs
@@ -5,7 +5,8 @@ use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler,
     handler::server::router::{prompt::PromptRouter, tool::ToolRouter},
     model::{
-        CacheScope, ClientInfo, ListPromptsResult, ListToolsResult, ProtocolVersion, ServerInfo,
+        CacheScope, InitializeRequestParams, InitializeResult, ListPromptsResult, ListToolsResult,
+        ProtocolVersion,
     },
     prompt_handler,
     service::serve_directly,
@@ -37,8 +38,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }
@@ -53,7 +54,7 @@ async fn list_results(protocol_version: ProtocolVersion) -> (ListToolsResult, Li
     let client_handler = VersionedClient {
         protocol_version: protocol_version.clone(),
     };
-    let mut server_peer_info = ServerInfo::default();
+    let mut server_peer_info = InitializeResult::default();
     server_peer_info.protocol_version = protocol_version;
 
     let server = serve_directly::<RoleServer, _, _, _, _>(

--- a/crates/rmcp/tests/test_inflight_response_drain.rs
+++ b/crates/rmcp/tests/test_inflight_response_drain.rs
@@ -14,7 +14,7 @@ use std::{
 use rmcp::{
     ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolRequestParams, ClientInfo, ServerCapabilities, ServerInfo},
+    model::{CallToolRequestParams, InitializeRequestParams, InitializeResult, ServerCapabilities},
     service::QuitReason,
     tool, tool_handler, tool_router,
 };
@@ -55,8 +55,8 @@ impl SlowToolServer {
 
 #[tool_handler]
 impl ServerHandler for SlowToolServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 }
 
@@ -64,8 +64,8 @@ impl ServerHandler for SlowToolServer {
 struct DummyClientHandler;
 
 impl rmcp::ClientHandler for DummyClientHandler {
-    fn get_info(&self) -> ClientInfo {
-        ClientInfo::default()
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::default()
     }
 }
 

--- a/crates/rmcp/tests/test_mrtr_behavior.rs
+++ b/crates/rmcp/tests/test_mrtr_behavior.rs
@@ -114,8 +114,8 @@ impl MacroMrtrServer {
 
 #[tool_handler]
 impl ServerHandler for MacroMrtrServer {
-    fn get_info(&self) -> ServerInfo {
-        let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+    fn get_info(&self) -> InitializeResult {
+        let mut info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
     }
@@ -221,8 +221,8 @@ impl MrtrServer {
 }
 
 impl ServerHandler for MrtrServer {
-    fn get_info(&self) -> ServerInfo {
-        let mut info = ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        let mut info = InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_prompts()
@@ -328,16 +328,16 @@ impl ClientHandler for MrtrClient {
 // Harness
 // =============================================================================
 
-fn client_info(protocol_version: ProtocolVersion) -> ClientInfo {
-    ClientInfo::new(
+fn client_info(protocol_version: ProtocolVersion) -> InitializeRequestParams {
+    InitializeRequestParams::new(
         ClientCapabilities::builder().enable_elicitation().build(),
         Implementation::new("mrtr-test-client", "0.0.0"),
     )
     .with_protocol_version(protocol_version)
 }
 
-fn server_info(protocol_version: ProtocolVersion) -> ServerInfo {
-    let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+fn server_info(protocol_version: ProtocolVersion) -> InitializeResult {
+    let mut info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
     info.protocol_version = protocol_version;
     info
 }
@@ -605,8 +605,9 @@ async fn request_state_codec_seals_and_verifies_through_the_loop() -> anyhow::Re
     struct SealingServer;
 
     impl ServerHandler for SealingServer {
-        fn get_info(&self) -> ServerInfo {
-            let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+        fn get_info(&self) -> InitializeResult {
+            let mut info =
+                InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
             info.protocol_version = ProtocolVersion::V_2026_07_28;
             info
         }

--- a/crates/rmcp/tests/test_mrtr_behavior.rs
+++ b/crates/rmcp/tests/test_mrtr_behavior.rs
@@ -114,8 +114,8 @@ impl MacroMrtrServer {
 
 #[tool_handler]
 impl ServerHandler for MacroMrtrServer {
-    fn get_info(&self) -> ServerInfo {
-        let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+    fn get_info(&self) -> InitializeResult {
+        let mut info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
     }
@@ -221,8 +221,8 @@ impl MrtrServer {
 }
 
 impl ServerHandler for MrtrServer {
-    fn get_info(&self) -> ServerInfo {
-        let mut info = ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        let mut info = InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_prompts()
@@ -328,16 +328,16 @@ impl ClientHandler for MrtrClient {
 // Harness
 // =============================================================================
 
-fn client_info(protocol_version: ProtocolVersion) -> ClientInfo {
-    ClientInfo::new(
+fn client_info(protocol_version: ProtocolVersion) -> InitializeRequestParams {
+    InitializeRequestParams::new(
         ClientCapabilities::builder().enable_elicitation().build(),
         Implementation::new("mrtr-test-client", "0.0.0"),
     )
     .with_protocol_version(protocol_version)
 }
 
-fn server_info(protocol_version: ProtocolVersion) -> ServerInfo {
-    let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+fn server_info(protocol_version: ProtocolVersion) -> InitializeResult {
+    let mut info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
     info.protocol_version = protocol_version;
     info
 }
@@ -609,8 +609,9 @@ async fn request_state_codec_seals_and_verifies_through_the_loop() -> anyhow::Re
     struct SealingServer;
 
     impl ServerHandler for SealingServer {
-        fn get_info(&self) -> ServerInfo {
-            let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+        fn get_info(&self) -> InitializeResult {
+            let mut info =
+                InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
             info.protocol_version = ProtocolVersion::V_2026_07_28;
             info
         }

--- a/crates/rmcp/tests/test_notification.rs
+++ b/crates/rmcp/tests/test_notification.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use rmcp::{
     ClientHandler, ServerHandler, ServiceExt,
     model::{
-        ClientNotification, CustomNotification, ResourceUpdatedNotificationParam,
-        ServerCapabilities, ServerInfo, ServerNotification, SubscribeRequestParams,
+        ClientNotification, CustomNotification, InitializeResult, ResourceUpdatedNotificationParam,
+        ServerCapabilities, ServerNotification, SubscribeRequestParams,
     },
 };
 use serde_json::json;
@@ -16,8 +16,8 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 struct Server {}
 
 impl ServerHandler for Server {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_resources()
                 .enable_resources_subscribe()

--- a/crates/rmcp/tests/test_prompt_macros.rs
+++ b/crates/rmcp/tests/test_prompt_macros.rs
@@ -7,8 +7,8 @@ use rmcp::{
     ClientHandler, RoleServer, ServerHandler, ServiceExt,
     handler::server::{router::prompt::PromptRouter, wrapper::Parameters},
     model::{
-        ClientInfo, ContentBlock, GetPromptRequestParams, GetPromptResult, ListPromptsResult,
-        PaginatedRequestParams, PromptMessage, Role,
+        ContentBlock, GetPromptRequestParams, GetPromptResult, InitializeRequestParams,
+        ListPromptsResult, PaginatedRequestParams, PromptMessage, Role,
     },
     prompt, prompt_handler, prompt_router,
     service::RequestContext,
@@ -299,8 +299,8 @@ fn test_optional_field_schema_generation_via_macro() {
 struct DummyClientHandler {}
 
 impl ClientHandler for DummyClientHandler {
-    fn get_info(&self) -> ClientInfo {
-        ClientInfo::default()
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::default()
     }
 }
 

--- a/crates/rmcp/tests/test_prompt_macros.rs
+++ b/crates/rmcp/tests/test_prompt_macros.rs
@@ -7,7 +7,8 @@ use rmcp::{
     ClientHandler, ServerHandler, ServiceExt,
     handler::server::{router::prompt::PromptRouter, wrapper::Parameters},
     model::{
-        ClientInfo, ContentBlock, GetPromptRequestParams, GetPromptResult, PromptMessage, Role,
+        ContentBlock, GetPromptRequestParams, GetPromptResult, InitializeRequestParams,
+        PromptMessage, Role,
     },
     prompt, prompt_handler, prompt_router,
 };
@@ -297,8 +298,8 @@ fn test_optional_field_schema_generation_via_macro() {
 struct DummyClientHandler {}
 
 impl ClientHandler for DummyClientHandler {
-    fn get_info(&self) -> ClientInfo {
-        ClientInfo::default()
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::default()
     }
 }
 

--- a/crates/rmcp/tests/test_protocol_version_negotiation.rs
+++ b/crates/rmcp/tests/test_protocol_version_negotiation.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 
 use rmcp::{
     ClientHandler, ErrorData, RoleServer, ServerHandler, ServiceExt,
-    model::{ClientInfo, InitializeRequestParams, InitializeResult, ProtocolVersion, ServerInfo},
+    model::{InitializeRequestParams, InitializeResult, ProtocolVersion},
     service::RequestContext,
 };
 
@@ -16,8 +16,8 @@ use rmcp::{
 struct EchoServer;
 
 impl ServerHandler for EchoServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::default()
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::default()
     }
 }
 
@@ -34,8 +34,8 @@ const NARROWED_VERSIONS: &[ProtocolVersion] = &[
 struct NarrowedServer;
 
 impl ServerHandler for NarrowedServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::default()
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::default()
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
@@ -50,8 +50,8 @@ impl ServerHandler for NarrowedServer {
 struct NarrowedOverridingServer;
 
 impl ServerHandler for NarrowedOverridingServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::default()
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::default()
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
@@ -73,8 +73,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }

--- a/crates/rmcp/tests/test_protocol_version_negotiation.rs
+++ b/crates/rmcp/tests/test_protocol_version_negotiation.rs
@@ -16,8 +16,8 @@ use std::{
 use rmcp::{
     ClientHandler, ErrorData, RoleServer, ServerHandler, ServiceExt,
     model::{
-        ClientCapabilities, ClientInfo, ErrorCode, Implementation, InitializeRequestParams,
-        InitializeResult, ProtocolVersion, ServerInfo,
+        ClientCapabilities, ErrorCode, Implementation, InitializeRequestParams, InitializeResult,
+        ProtocolVersion,
     },
     service::{ClientInitializeError, RequestContext},
 };
@@ -26,8 +26,8 @@ use rmcp::{
 struct EchoServer;
 
 impl ServerHandler for EchoServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::default()
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::default()
     }
 }
 
@@ -45,8 +45,8 @@ const HANDSHAKE_VERSIONS: &[ProtocolVersion] = &[
 struct NarrowedServer;
 
 impl ServerHandler for NarrowedServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::default()
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::default()
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
@@ -61,8 +61,8 @@ struct ModernOnlyServer;
 const MODERN_ONLY_VERSIONS: &[ProtocolVersion] = &[ProtocolVersion::V_2026_07_28];
 
 impl ServerHandler for ModernOnlyServer {
-    fn get_info(&self) -> ServerInfo {
-        let mut info = ServerInfo::default();
+    fn get_info(&self) -> InitializeResult {
+        let mut info = InitializeResult::default();
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
     }
@@ -79,8 +79,8 @@ impl ServerHandler for ModernOnlyServer {
 struct NarrowedOverridingServer;
 
 impl ServerHandler for NarrowedOverridingServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::default()
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::default()
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
@@ -102,8 +102,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }
@@ -247,8 +247,8 @@ struct DelegatingServer {
 }
 
 impl ServerHandler for DelegatingServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::default()
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::default()
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {

--- a/crates/rmcp/tests/test_resource_not_found_version.rs
+++ b/crates/rmcp/tests/test_resource_not_found_version.rs
@@ -8,7 +8,7 @@
 use rmcp::{
     ClientHandler, RoleServer, ServerHandler, ServiceError, ServiceExt,
     model::{
-        ClientInfo, ErrorCode, ErrorData, ProtocolVersion, ReadResourceRequestParams,
+        ErrorCode, ErrorData, InitializeRequestParams, ProtocolVersion, ReadResourceRequestParams,
         ReadResourceResponse,
     },
     service::RequestContext,
@@ -33,8 +33,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }

--- a/crates/rmcp/tests/test_resource_not_found_version.rs
+++ b/crates/rmcp/tests/test_resource_not_found_version.rs
@@ -8,8 +8,8 @@
 use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler, ServiceError,
     model::{
-        ClientInfo, ErrorCode, ErrorData, ProtocolVersion, ReadResourceRequestParams,
-        ReadResourceResponse, ServerInfo,
+        ErrorCode, ErrorData, InitializeRequestParams, InitializeResult, ProtocolVersion,
+        ReadResourceRequestParams, ReadResourceResponse,
     },
     service::{RequestContext, serve_directly},
 };
@@ -33,8 +33,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }
@@ -49,7 +49,7 @@ async fn not_found_code(client_version: ProtocolVersion) -> ErrorCode {
     let client_handler = VersionedClient {
         protocol_version: client_version.clone(),
     };
-    let mut server_peer_info = ServerInfo::default();
+    let mut server_peer_info = InitializeResult::default();
     server_peer_info.protocol_version = client_version;
 
     let server = serve_directly::<RoleServer, _, _, _, _>(

--- a/crates/rmcp/tests/test_result_type_version.rs
+++ b/crates/rmcp/tests/test_result_type_version.rs
@@ -8,8 +8,8 @@
 use rmcp::{
     ClientHandler, RoleServer, ServerHandler, ServiceExt,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ClientInfo, ContentBlock,
-        ErrorData, ProtocolVersion, ResultType,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+        InitializeRequestParams, ProtocolVersion, ResultType,
     },
     service::RequestContext,
 };
@@ -33,8 +33,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }

--- a/crates/rmcp/tests/test_result_type_version.rs
+++ b/crates/rmcp/tests/test_result_type_version.rs
@@ -8,8 +8,8 @@
 use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ClientInfo, ContentBlock,
-        ErrorData, ProtocolVersion, ResultType, ServerInfo,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+        InitializeRequestParams, InitializeResult, ProtocolVersion, ResultType,
     },
     service::{RequestContext, serve_directly},
 };
@@ -33,8 +33,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }
@@ -49,7 +49,7 @@ async fn call_tool_result_type(client_version: ProtocolVersion) -> Option<Result
     let client_handler = VersionedClient {
         protocol_version: client_version.clone(),
     };
-    let mut server_peer_info = ServerInfo::default();
+    let mut server_peer_info = InitializeResult::default();
     server_peer_info.protocol_version = client_version;
 
     let server = serve_directly::<RoleServer, _, _, _, _>(

--- a/crates/rmcp/tests/test_sep_2260_request_association.rs
+++ b/crates/rmcp/tests/test_sep_2260_request_association.rs
@@ -6,9 +6,10 @@ use std::sync::{Arc, Mutex};
 use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler, ServiceError, ServiceExt,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ClientInfo, ContentBlock,
-        CreateMessageRequest, CreateMessageRequestParams, CreateMessageResult, ProtocolVersion,
-        SamplingMessage, ServerCapabilities, ServerInfo, ServerRequest,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
+        CreateMessageRequest, CreateMessageRequestParams, CreateMessageResult,
+        InitializeRequestParams, InitializeResult, ProtocolVersion, SamplingMessage,
+        ServerCapabilities, ServerRequest,
     },
     service::RequestContext,
 };
@@ -24,8 +25,8 @@ struct SamplingServer {
 }
 
 impl ServerHandler for SamplingServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(
@@ -88,8 +89,8 @@ impl ClientHandler for SamplingClient {
         .with_stop_reason(CreateMessageResult::STOP_REASON_END_TURN))
     }
 
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
     }

--- a/crates/rmcp/tests/test_sep_2260_request_association.rs
+++ b/crates/rmcp/tests/test_sep_2260_request_association.rs
@@ -9,9 +9,10 @@ use std::sync::{Arc, Mutex};
 use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler, ServiceError, ServiceExt,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ClientInfo, ContentBlock,
-        CreateMessageRequest, CreateMessageRequestParams, CreateMessageResult, ProtocolVersion,
-        SamplingMessage, ServerCapabilities, ServerInfo, ServerRequest,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
+        CreateMessageRequest, CreateMessageRequestParams, CreateMessageResult,
+        InitializeRequestParams, InitializeResult, ProtocolVersion, SamplingMessage,
+        ServerCapabilities, ServerRequest,
     },
     service::{RequestContext, RunningService, serve_directly},
 };
@@ -29,8 +30,8 @@ struct SamplingServer {
 }
 
 impl ServerHandler for SamplingServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(
@@ -93,8 +94,8 @@ impl ClientHandler for SamplingClient {
         .with_stop_reason(CreateMessageResult::STOP_REASON_END_TURN))
     }
 
-    fn get_info(&self) -> ClientInfo {
-        let mut info = ClientInfo::default();
+    fn get_info(&self) -> InitializeRequestParams {
+        let mut info = InitializeRequestParams::default();
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
     }

--- a/crates/rmcp/tests/test_sep_2260_stream_enforcement.rs
+++ b/crates/rmcp/tests/test_sep_2260_stream_enforcement.rs
@@ -26,8 +26,9 @@ use http::{HeaderName, HeaderValue};
 use rmcp::{
     ClientHandler,
     model::{
-        ClientInfo, ClientJsonRpcMessage, CreateMessageRequestParams, CreateMessageResult,
-        ProtocolVersion, SamplingMessage, ServerCapabilities, ServerInfo, ServerJsonRpcMessage,
+        ClientJsonRpcMessage, CreateMessageRequestParams, CreateMessageResult,
+        InitializeRequestParams, InitializeResult, ProtocolVersion, SamplingMessage,
+        ServerCapabilities, ServerJsonRpcMessage,
     },
     service::{ClientLifecycleMode, RequestContext, RoleClient, serve_client_with_lifecycle},
     transport::streamable_http_client::{
@@ -80,7 +81,7 @@ impl StreamableHttpClient for ScriptedServer {
         // Receiver drop is normal at test teardown; never panic in the transport task.
         let _ = self.posted.send(value.clone());
         if value["method"] == "initialize" {
-            let mut info = ServerInfo::new(ServerCapabilities::default());
+            let mut info = InitializeResult::new(ServerCapabilities::default());
             info.protocol_version = ProtocolVersion::V_2026_07_28;
             let response = ServerJsonRpcMessage::response(
                 rmcp::model::ServerResult::InitializeResult(info),
@@ -152,8 +153,8 @@ impl ClientHandler for SamplingClient {
         ))
     }
 
-    fn get_info(&self) -> ClientInfo {
-        ClientInfo::default()
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::default()
     }
 }
 

--- a/crates/rmcp/tests/test_sep_2260_stream_routing.rs
+++ b/crates/rmcp/tests/test_sep_2260_stream_routing.rs
@@ -9,7 +9,7 @@ use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     model::{
         CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ElicitRequestParams,
-        ElicitationSchema, ServerCapabilities, ServerInfo,
+        ElicitationSchema, InitializeResult, ServerCapabilities,
     },
     service::RequestContext,
     transport::streamable_http_server::{
@@ -23,8 +23,8 @@ use tokio_util::sync::CancellationToken;
 struct ElicitingServer;
 
 impl ServerHandler for ElicitingServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_server_discover_client.rs
+++ b/crates/rmcp/tests/test_server_discover_client.rs
@@ -3,8 +3,8 @@
 use rmcp::{
     ClientHandler, ServerHandler, ServiceExt,
     model::{
-        ClientCapabilities, Implementation, ProtocolVersion, RequestMetaObject, ServerCapabilities,
-        ServerInfo,
+        ClientCapabilities, Implementation, InitializeResult, ProtocolVersion, RequestMetaObject,
+        ServerCapabilities,
     },
     select_protocol_version,
 };
@@ -13,8 +13,8 @@ use rmcp::{
 struct DiscoveryServer;
 
 impl ServerHandler for DiscoveryServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("discovery-server", "1.0.0"))
     }
 }

--- a/crates/rmcp/tests/test_server_discover_http.rs
+++ b/crates/rmcp/tests/test_server_discover_http.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 
 use rmcp::{
     ServerHandler,
-    model::{Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
+    model::{Implementation, InitializeResult, ProtocolVersion, ServerCapabilities},
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     },
@@ -20,8 +20,8 @@ use tokio_util::sync::CancellationToken;
 struct DiscoveryServer;
 
 impl ServerHandler for DiscoveryServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("discovery-server", "1.0.0"))
             .with_instructions("Use the tools carefully")
     }

--- a/crates/rmcp/tests/test_server_initialization.rs
+++ b/crates/rmcp/tests/test_server_initialization.rs
@@ -6,7 +6,7 @@ use common::handlers::TestServer;
 use rmcp::{
     ServerHandler, ServiceExt,
     model::{
-        ClientJsonRpcMessage, ProtocolVersion, ServerCapabilities, ServerInfo,
+        ClientJsonRpcMessage, InitializeResult, ProtocolVersion, ServerCapabilities,
         ServerJsonRpcMessage, ServerResult,
     },
     transport::{IntoTransport, Transport},
@@ -281,8 +281,8 @@ async fn server_falls_back_when_client_protocol_version_unknown() {
 struct PinnedServer;
 
 impl ServerHandler for PinnedServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().build())
             .with_protocol_version(ProtocolVersion::V_2025_06_18)
     }
 }

--- a/crates/rmcp/tests/test_sse_concurrent_streams.rs
+++ b/crates/rmcp/tests/test_sse_concurrent_streams.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use rmcp::{
     RoleServer, ServerHandler,
-    model::{Implementation, ServerCapabilities, ServerInfo, ToolsCapability},
+    model::{Implementation, InitializeResult, ServerCapabilities, ToolsCapability},
     service::NotificationContext,
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
@@ -45,8 +45,8 @@ impl TestServer {
 }
 
 impl ServerHandler for TestServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools_with({
                     let mut tools = ToolsCapability::default();

--- a/crates/rmcp/tests/test_stateless_protocol_version.rs
+++ b/crates/rmcp/tests/test_stateless_protocol_version.rs
@@ -9,9 +9,7 @@ use std::borrow::Cow;
 
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
-    model::{
-        InitializeRequestParams, InitializeResult, ProtocolVersion, ServerCapabilities, ServerInfo,
-    },
+    model::{InitializeRequestParams, InitializeResult, ProtocolVersion, ServerCapabilities},
     service::RequestContext,
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
@@ -23,8 +21,8 @@ use tokio_util::sync::CancellationToken;
 struct OverridingInitialize;
 
 impl ServerHandler for OverridingInitialize {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::default())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::default())
     }
 
     async fn initialize(
@@ -51,8 +49,8 @@ const NARROWED_VERSIONS: &[ProtocolVersion] = &[
 struct NarrowedOverridingInitialize;
 
 impl ServerHandler for NarrowedOverridingInitialize {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::default())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::default())
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {

--- a/crates/rmcp/tests/test_stateless_protocol_version.rs
+++ b/crates/rmcp/tests/test_stateless_protocol_version.rs
@@ -10,9 +10,7 @@ use std::borrow::Cow;
 
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
-    model::{
-        InitializeRequestParams, InitializeResult, ProtocolVersion, ServerCapabilities, ServerInfo,
-    },
+    model::{InitializeRequestParams, InitializeResult, ProtocolVersion, ServerCapabilities},
     service::RequestContext,
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
@@ -24,8 +22,8 @@ use tokio_util::sync::CancellationToken;
 struct OverridingInitialize;
 
 impl ServerHandler for OverridingInitialize {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::default())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::default())
     }
 
     async fn initialize(
@@ -53,8 +51,8 @@ const HANDSHAKE_VERSIONS: &[ProtocolVersion] = &[
 struct NarrowedOverridingInitialize;
 
 impl ServerHandler for NarrowedOverridingInitialize {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::default())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::default())
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {

--- a/crates/rmcp/tests/test_stdio_response_concurrency.rs
+++ b/crates/rmcp/tests/test_stdio_response_concurrency.rs
@@ -5,8 +5,8 @@ use std::{collections::BTreeSet, process::Stdio, time::Duration};
 use rmcp::{
     ErrorData as McpError, ServerHandler, ServiceExt,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ServerCapabilities,
-        ServerInfo,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, InitializeResult,
+        ServerCapabilities,
     },
 };
 use serde_json::{Value, json};
@@ -82,8 +82,8 @@ struct LargeResponseServer;
 
 impl ServerHandler for LargeResponseServer {
     #[allow(deprecated)]
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_streamable_http_client_concurrency.rs
+++ b/crates/rmcp/tests/test_streamable_http_client_concurrency.rs
@@ -16,9 +16,9 @@ use futures::{StreamExt, stream::BoxStream};
 use http::{HeaderName, HeaderValue};
 use rmcp::{
     model::{
-        CallToolRequestParams, CancelledNotificationParam, ClientInfo, ClientJsonRpcMessage,
-        ClientRequest, DiscoverResult, ProtocolVersion, Request, RequestId, RequestMetaObject,
-        ServerJsonRpcMessage,
+        CallToolRequestParams, CancelledNotificationParam, ClientJsonRpcMessage, ClientRequest,
+        DiscoverResult, InitializeRequestParams, ProtocolVersion, Request, RequestId,
+        RequestMetaObject, ServerJsonRpcMessage,
     },
     service::{
         ClientLifecycleMode, PeerRequestOptions, RequestHandle, RoleClient, RunningService,
@@ -345,7 +345,7 @@ impl StreamableHttpClient for ScriptedClient {
 }
 
 struct Harness {
-    client: RunningService<RoleClient, ClientInfo>,
+    client: RunningService<RoleClient, InitializeRequestParams>,
     started: mpsc::UnboundedReceiver<Posted>,
     controls: mpsc::UnboundedReceiver<ControlPost>,
     incoming: mpsc::UnboundedSender<Result<Sse, SseError>>,
@@ -402,7 +402,8 @@ impl Harness {
             config,
         );
         let client =
-            serve_client_with_lifecycle(ClientInfo::default(), transport, lifecycle).await?;
+            serve_client_with_lifecycle(InitializeRequestParams::default(), transport, lifecycle)
+                .await?;
         Ok(Self {
             client,
             started: requests,
@@ -601,7 +602,12 @@ async fn common_stream_response_keeps_numeric_and_string_ids_distinct() -> anyho
         config(),
     );
     for message in [
-        json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": ClientInfo::default() }),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": InitializeRequestParams::default()
+        }),
         json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
     ] {
         timeout(
@@ -820,7 +826,12 @@ async fn dropping_a_parked_barrier_send_unblocks_the_ordinary_queue() -> anyhow:
         config,
     );
     for message in [
-        json!({ "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": ClientInfo::default() }),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": InitializeRequestParams::default()
+        }),
         json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
     ] {
         timeout(

--- a/crates/rmcp/tests/test_streamable_http_connection_reuse.rs
+++ b/crates/rmcp/tests/test_streamable_http_connection_reuse.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use rmcp::{
     ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolRequestParams, ClientInfo, ServerCapabilities, ServerInfo},
+    model::{CallToolRequestParams, InitializeRequestParams, InitializeResult, ServerCapabilities},
     schemars, tool, tool_handler, tool_router,
     transport::{
         StreamableHttpClientTransport,
@@ -46,8 +46,8 @@ impl SumServer {
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for SumServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 }
 
@@ -83,7 +83,7 @@ async fn test_subsequent_tool_calls_reuse_connections() -> anyhow::Result<()> {
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
     );
-    let client = ClientInfo::default().serve(transport).await?;
+    let client = InitializeRequestParams::default().serve(transport).await?;
 
     // Warm up: first call may include one-time setup costs.
     let args: serde_json::Map<String, serde_json::Value> =

--- a/crates/rmcp/tests/test_streamable_http_disconnect_cancel.rs
+++ b/crates/rmcp/tests/test_streamable_http_disconnect_cancel.rs
@@ -18,8 +18,8 @@ use std::{sync::Arc, time::Duration};
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ServerCapabilities,
-        ServerInfo,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, InitializeResult,
+        ServerCapabilities,
     },
     service::RequestContext,
     transport::streamable_http_server::{
@@ -37,8 +37,8 @@ struct CancelProbe {
 
 impl ServerHandler for CancelProbe {
     #[allow(deprecated)]
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_streamable_http_event_store.rs
+++ b/crates/rmcp/tests/test_streamable_http_event_store.rs
@@ -18,8 +18,8 @@ use futures::StreamExt;
 use rmcp::{
     ErrorData, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
-        ProgressNotificationParam, ServerCapabilities, ServerInfo,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, InitializeResult,
+        ProgressNotificationParam, ServerCapabilities,
     },
     service::RequestContext,
     transport::streamable_http_server::{
@@ -109,8 +109,8 @@ impl EventStore for InMemoryEventStore {
 struct ProgressServer;
 
 impl ServerHandler for ProgressServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_streamable_http_json_response.rs
+++ b/crates/rmcp/tests/test_streamable_http_json_response.rs
@@ -2,8 +2,8 @@
 use rmcp::{
     ErrorData, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
-        ProgressNotificationParam, ServerCapabilities, ServerInfo,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, InitializeResult,
+        ProgressNotificationParam, ServerCapabilities,
     },
     service::RequestContext,
     transport::streamable_http_server::{
@@ -57,8 +57,8 @@ const NEGOTIATED_CALL_WITH_PROGRESS_BODY: &str = r#"{
 struct ProgressServer;
 
 impl ServerHandler for ProgressServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_streamable_http_protocol_version.rs
+++ b/crates/rmcp/tests/test_streamable_http_protocol_version.rs
@@ -418,8 +418,8 @@ impl CountingServer {
 }
 
 impl ServerHandler for CountingServer {
-    fn get_info(&self) -> rmcp::model::ServerInfo {
-        rmcp::model::ServerInfo::new(
+    fn get_info(&self) -> rmcp::model::InitializeResult {
+        rmcp::model::InitializeResult::new(
             rmcp::model::ServerCapabilities::builder()
                 .enable_tools()
                 .build(),

--- a/crates/rmcp/tests/test_streamable_http_protocol_version.rs
+++ b/crates/rmcp/tests/test_streamable_http_protocol_version.rs
@@ -481,8 +481,8 @@ impl CountingServer {
 }
 
 impl ServerHandler for CountingServer {
-    fn get_info(&self) -> rmcp::model::ServerInfo {
-        rmcp::model::ServerInfo::new(
+    fn get_info(&self) -> rmcp::model::InitializeResult {
+        rmcp::model::InitializeResult::new(
             rmcp::model::ServerCapabilities::builder()
                 .enable_tools()
                 .build(),

--- a/crates/rmcp/tests/test_streamable_http_stale_session.rs
+++ b/crates/rmcp/tests/test_streamable_http_stale_session.rs
@@ -15,9 +15,9 @@ use http::{HeaderName, HeaderValue};
 use rmcp::{
     ServiceError, ServiceExt,
     model::{
-        CallToolRequestParams, ClientInfo, ClientJsonRpcMessage, ClientRequest, ErrorCode,
-        ErrorData, InitializeResult, PingRequest, ProtocolVersion, RequestId, ServerCapabilities,
-        ServerJsonRpcMessage, ServerResult,
+        CallToolRequestParams, ClientJsonRpcMessage, ClientRequest, ErrorCode, ErrorData,
+        InitializeRequestParams, InitializeResult, PingRequest, ProtocolVersion, RequestId,
+        ServerCapabilities, ServerJsonRpcMessage, ServerResult,
     },
     transport::{
         StreamableHttpClientTransport,
@@ -205,7 +205,7 @@ async fn test_reinitialization_completes_accepted_sse_request_instead_of_hanging
         mock_client,
         StreamableHttpClientTransportConfig::with_uri("mock://mcp"),
     );
-    let mut client = ClientInfo::default().serve(transport).await?;
+    let mut client = InitializeRequestParams::default().serve(transport).await?;
 
     let peer = client.peer().clone();
     let pending_call = tokio::spawn(async move {

--- a/crates/rmcp/tests/test_streamable_http_standard_headers.rs
+++ b/crates/rmcp/tests/test_streamable_http_standard_headers.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use rmcp::{
     ServerHandler,
-    model::{ServerCapabilities, ServerInfo, Tool},
+    model::{InitializeResult, ServerCapabilities, Tool},
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     },
@@ -18,8 +18,8 @@ const SEP_VERSION: &str = "2026-07-28";
 struct HeaderValidationServer;
 
 impl ServerHandler for HeaderValidationServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     fn get_tool(&self, name: &str) -> Option<Tool> {

--- a/crates/rmcp/tests/test_subscriptions.rs
+++ b/crates/rmcp/tests/test_subscriptions.rs
@@ -18,8 +18,8 @@ use rmcp::{
     ClientHandler, ClientServiceExt, ServerHandler, ServiceExt,
     model::{
         ClientNotification, ClientRequest, DiscoverResult, GetMeta, Implementation,
-        NotificationMetaObject, PromptListChangedNotification, ProtocolVersion, ServerCapabilities,
-        ServerInfo, ServerNotification, ServerResult, SubscriptionFilter,
+        InitializeResult, NotificationMetaObject, PromptListChangedNotification, ProtocolVersion,
+        ServerCapabilities, ServerNotification, ServerResult, SubscriptionFilter,
         SubscriptionsAcknowledgedNotification, SubscriptionsAcknowledgedNotificationParams,
         SubscriptionsListenResult,
     },
@@ -44,8 +44,8 @@ impl ClientHandler for CountingClient {
 }
 
 impl ServerHandler for ToolsOnlyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -80,8 +80,8 @@ impl ServerHandler for ToolsOnlyServer {
 struct ToolsAndPromptsServer;
 
 impl ServerHandler for ToolsAndPromptsServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -120,8 +120,8 @@ impl ServerHandler for ToolsAndPromptsServer {
 struct ResourceSubscriptionServer;
 
 impl ServerHandler for ResourceSubscriptionServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_resources()
                 .enable_resources_subscribe()
@@ -182,8 +182,8 @@ impl ServerHandler for RemoteCancellationServer {
 struct FloodServer;
 
 impl ServerHandler for FloodServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -217,8 +217,8 @@ struct ClosedSinkServer {
 struct LeakyServer;
 
 impl ServerHandler for LeakyServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -314,14 +314,14 @@ impl rmcp::service::Service<RoleServer> for MalformedAcknowledgmentServer {
         Ok(())
     }
 
-    fn get_info(&self) -> rmcp::model::ServerInfo {
-        ServerInfo::default()
+    fn get_info(&self) -> rmcp::model::InitializeResult {
+        InitializeResult::default()
     }
 }
 
 impl ServerHandler for ClosedSinkServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()

--- a/crates/rmcp/tests/test_subscriptions_streamable_http.rs
+++ b/crates/rmcp/tests/test_subscriptions_streamable_http.rs
@@ -18,8 +18,9 @@ use std::{
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt, ServerHandler,
     model::{
-        ClientInfo, ClientRequest, Implementation, ListToolsRequest, ProtocolVersion,
-        RequestMetaObject, ServerCapabilities, ServerInfo, ServerNotification, SubscriptionFilter,
+        ClientRequest, Implementation, InitializeRequestParams, InitializeResult, ListToolsRequest,
+        ProtocolVersion, RequestMetaObject, ServerCapabilities, ServerNotification,
+        SubscriptionFilter,
     },
     service::{PeerRequestOptions, SubscriptionContext, SubscriptionEnd},
     transport::{
@@ -52,8 +53,8 @@ impl ServerHandler for HttpSubscriptionServer {
         Cow::Borrowed(&[ProtocolVersion::V_2026_07_28, ProtocolVersion::V_2025_11_25])
     }
 
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -159,7 +160,7 @@ async fn modern_http_listen_uses_post_stream_and_cancels_by_closing_it() -> anyh
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(url.clone()),
     );
-    let client = ClientInfo::default()
+    let client = InitializeRequestParams::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {
@@ -204,7 +205,7 @@ async fn modern_http_graceful_close_returns_final_listen_result() -> anyhow::Res
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(url),
     );
-    let client = ClientInfo::default()
+    let client = InitializeRequestParams::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {
@@ -240,7 +241,7 @@ async fn modern_http_stream_close_without_result_is_abrupt() -> anyhow::Result<(
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(url),
     );
-    let client = ClientInfo::default()
+    let client = InitializeRequestParams::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {
@@ -273,7 +274,7 @@ async fn modern_http_lifecycle_stays_sessionless_for_older_application_version()
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(url),
     );
-    let client = ClientInfo::default()
+    let client = InitializeRequestParams::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {

--- a/crates/rmcp/tests/test_task.rs
+++ b/crates/rmcp/tests/test_task.rs
@@ -107,8 +107,8 @@ impl ServerHandler for TaskServer {
         self.tasks.cancel_task(&request.task_id)
     }
 
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tasks()
@@ -117,8 +117,8 @@ impl ServerHandler for TaskServer {
     }
 }
 
-fn tasks_client_info() -> ClientInfo {
-    ClientInfo::new(
+fn tasks_client_info() -> InitializeRequestParams {
+    InitializeRequestParams::new(
         ClientCapabilities::builder().enable_tasks().build(),
         Implementation::from_build_env(),
     )
@@ -275,8 +275,8 @@ impl ServerHandler for AlwaysTaskServer {
         Ok(CallToolResponse::Task(CreateTaskResult::new(task)))
     }
 
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tasks()

--- a/crates/rmcp/tests/test_tool_disable_notification.rs
+++ b/crates/rmcp/tests/test_tool_disable_notification.rs
@@ -9,7 +9,7 @@ use std::sync::{
 use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRoute, tool::ToolCallContext},
-    model::{CallToolResponse, CallToolResult, ServerCapabilities, ServerInfo, Tool},
+    model::{CallToolResponse, CallToolResult, InitializeResult, ServerCapabilities, Tool},
     service::{MaybeSendFuture, NotificationContext},
 };
 use tokio::sync::{Notify, RwLock};
@@ -41,8 +41,8 @@ impl TestToolServer {
 }
 
 impl ServerHandler for TestToolServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_tool_macros.rs
+++ b/crates/rmcp/tests/test_tool_macros.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use rmcp::{
     ClientHandler, ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolRequestParams, ClientInfo, ServerCapabilities, ServerInfo},
+    model::{CallToolRequestParams, InitializeRequestParams, InitializeResult, ServerCapabilities},
     tool, tool_handler, tool_router,
 };
 use schemars::JsonSchema;
@@ -287,8 +287,8 @@ fn test_optional_field_schema_generation_via_macro() {
 struct DummyClientHandler {}
 
 impl ClientHandler for DummyClientHandler {
-    fn get_info(&self) -> ClientInfo {
-        ClientInfo::default()
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::default()
     }
 }
 
@@ -549,8 +549,8 @@ impl ManualInfoServer {
 
 #[tool_handler]
 impl ServerHandler for ManualInfoServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_resources()

--- a/docs/OAUTH_SUPPORT.md
+++ b/docs/OAUTH_SUPPORT.md
@@ -252,7 +252,7 @@ let transport = StreamableHttpClientTransport::with_client(
 );
 
 // create client and connect to MCP server
-let client_service = ClientInfo::default();
+let client_service = InitializeRequestParams::default();
 let client = client_service.serve(transport).await?;
 ```
 

--- a/docs/OAUTH_SUPPORT.md
+++ b/docs/OAUTH_SUPPORT.md
@@ -253,7 +253,7 @@ let transport = StreamableHttpClientTransport::with_client(
 );
 
 // create client and connect to MCP server
-let client_service = ClientInfo::default();
+let client_service = InitializeRequestParams::default();
 let client = client_service.serve(transport).await?;
 ```
 

--- a/examples/clients/src/auth/client_credentials.rs
+++ b/examples/clients/src/auth/client_credentials.rs
@@ -3,7 +3,7 @@ use std::env;
 use anyhow::{Context, Result};
 use rmcp::{
     ServiceExt,
-    model::ClientInfo,
+    model::InitializeRequestParams,
     transport::{
         StreamableHttpClientTransport,
         auth::{AuthClient, ClientCredentialsConfig, OAuthState},
@@ -73,7 +73,7 @@ async fn main() -> Result<()> {
     );
 
     // Connect to MCP server and list tools
-    let client_service = ClientInfo::default();
+    let client_service = InitializeRequestParams::default();
     let client = client_service.serve(transport).await?;
     tracing::info!("Connected to MCP server");
 

--- a/examples/clients/src/auth/oauth_client.rs
+++ b/examples/clients/src/auth/oauth_client.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use rmcp::{
     RoleClient, ServiceExt,
-    model::ClientInfo,
+    model::InitializeRequestParams,
     service::RunningService,
     transport::{
         StreamableHttpClientTransport,
@@ -58,7 +58,7 @@ async fn callback_handler(
 
 enum ConnectOutcome {
     /// The server accepted the unauthenticated connection.
-    Connected(RunningService<RoleClient, ClientInfo>),
+    Connected(RunningService<RoleClient, InitializeRequestParams>),
     /// The server answered 401; authorize with this `WWW-Authenticate`
     /// challenge and reconnect.
     AuthRequired(String),
@@ -72,7 +72,7 @@ async fn try_connect(http_client: reqwest::Client, server_url: &str) -> Result<C
         http_client,
         StreamableHttpClientTransportConfig::with_uri(server_url),
     );
-    match ClientInfo::default().serve(transport).await {
+    match InitializeRequestParams::default().serve(transport).await {
         Ok(client) => Ok(ConnectOutcome::Connected(client)),
         Err(error) => match error.auth_challenge() {
             Some(challenge) => Ok(ConnectOutcome::AuthRequired(challenge.to_string())),
@@ -90,7 +90,7 @@ async fn authorize_and_connect(
     client_metadata_url: &str,
     code_receiver: oneshot::Receiver<CallbackParams>,
     output: &mut BufWriter<tokio::io::Stdout>,
-) -> Result<RunningService<RoleClient, ClientInfo>> {
+) -> Result<RunningService<RoleClient, InitializeRequestParams>> {
     tracing::info!("Server requires authorization: {challenge}");
 
     // initialize oauth state machine
@@ -156,7 +156,7 @@ async fn authorize_and_connect(
         auth_client,
         StreamableHttpClientTransportConfig::with_uri(server_url),
     );
-    Ok(ClientInfo::default().serve(transport).await?)
+    Ok(InitializeRequestParams::default().serve(transport).await?)
 }
 
 #[tokio::main]

--- a/examples/clients/src/progress_client.rs
+++ b/examples/clients/src/progress_client.rs
@@ -8,7 +8,7 @@ use clap::{Parser, ValueEnum};
 use rmcp::{
     ClientHandler, ServiceExt,
     model::{
-        CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation,
+        CallToolRequestParams, ClientCapabilities, Implementation, InitializeRequestParams,
         ProgressNotificationParam,
     },
     service::{NotificationContext, RoleClient},
@@ -121,8 +121,8 @@ impl ClientHandler for ProgressAwareClient {
         }
     }
 
-    fn get_info(&self) -> ClientInfo {
-        ClientInfo::new(
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::new(
             ClientCapabilities::default(),
             Implementation::new("progress-test-client", "1.0.0"),
         )

--- a/examples/clients/src/streamable_http.rs
+++ b/examples/clients/src/streamable_http.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use rmcp::{
     ServiceExt,
-    model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation},
+    model::{CallToolRequestParams, ClientCapabilities, Implementation, InitializeRequestParams},
     transport::StreamableHttpClientTransport,
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
     let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
-    let client_info = ClientInfo::new(
+    let client_info = InitializeRequestParams::new(
         ClientCapabilities::default(),
         Implementation::new("test sse client", "0.0.1"),
     );

--- a/examples/clients/src/streamable_http.rs
+++ b/examples/clients/src/streamable_http.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt,
     model::{
-        CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation, ProtocolVersion,
+        CallToolRequestParams, ClientCapabilities, Implementation, InitializeRequestParams,
+        ProtocolVersion,
     },
     transport::StreamableHttpClientTransport,
 };
@@ -18,7 +19,7 @@ async fn main() -> Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
     let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
-    let client_info = ClientInfo::new(
+    let client_info = InitializeRequestParams::new(
         ClientCapabilities::default(),
         Implementation::new("streamable-http-client", "0.0.1"),
     );

--- a/examples/clients/src/subscriptions_streamhttp.rs
+++ b/examples/clients/src/subscriptions_streamhttp.rs
@@ -1,6 +1,6 @@
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt,
-    model::{ClientInfo, ProtocolVersion, SubscriptionFilter},
+    model::{InitializeRequestParams, ProtocolVersion, SubscriptionFilter},
     transport::StreamableHttpClientTransport,
 };
 
@@ -13,7 +13,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let transport = StreamableHttpClientTransport::from_uri("http://127.0.0.1:8000/mcp");
-    let client = ClientInfo::default()
+    let client = InitializeRequestParams::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {

--- a/examples/clients/src/task_stdio.rs
+++ b/examples/clients/src/task_stdio.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Declare the tasks extension in our client capabilities (SEP-2663).
-    let client_info = rmcp::model::ClientInfo::new(
+    let client_info = rmcp::model::InitializeRequestParams::new(
         ClientCapabilities::builder().enable_tasks().build(),
         rmcp::model::Implementation::from_build_env(),
     );

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -206,8 +206,8 @@ impl Counter {
 #[tool_handler(meta = MetaObject(rmcp::object!({"tool_meta_key": "tool_meta_value"})))]
 #[prompt_handler(meta = MetaObject(rmcp::object!({"router_meta_key": "router_meta_value"})))]
 impl ServerHandler for Counter {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_prompts()
                 .enable_resources()

--- a/examples/servers/src/common/progress_demo.rs
+++ b/examples/servers/src/common/progress_demo.rs
@@ -131,8 +131,8 @@ impl ProgressDemo {
 
 #[tool_handler]
 impl ServerHandler for ProgressDemo {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_protocol_version(ProtocolVersion::V_2024_11_05)
             .with_server_info(Implementation::from_build_env())
             .with_instructions(

--- a/examples/servers/src/common/task_demo.rs
+++ b/examples/servers/src/common/task_demo.rs
@@ -151,8 +151,8 @@ impl ServerHandler for TaskDemo {
         self.tasks.cancel_task(&request.task_id)
     }
 
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tasks()

--- a/examples/servers/src/completion_stdio.rs
+++ b/examples/servers/src/completion_stdio.rs
@@ -310,8 +310,8 @@ impl SqlQueryServer {
 
 #[prompt_handler]
 impl ServerHandler for SqlQueryServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_completions()
                 .enable_prompts()

--- a/examples/servers/src/completion_stdio.rs
+++ b/examples/servers/src/completion_stdio.rs
@@ -310,8 +310,8 @@ impl SqlQueryServer {
 
 #[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for SqlQueryServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_completions()
                 .enable_prompts()

--- a/examples/servers/src/elicitation_enum_inference.rs
+++ b/examples/servers/src/elicitation_enum_inference.rs
@@ -155,8 +155,8 @@ impl ElicitationEnumFormServer {
 
 #[tool_handler]
 impl ServerHandler for ElicitationEnumFormServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::from_build_env())
             .with_instructions(
                 "Simple server demonstrating elicitation for enum selection".to_string(),

--- a/examples/servers/src/elicitation_enum_inference.rs
+++ b/examples/servers/src/elicitation_enum_inference.rs
@@ -155,8 +155,8 @@ impl ElicitationEnumFormServer {
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for ElicitationEnumFormServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::from_build_env())
             .with_instructions(
                 "Simple server demonstrating elicitation for enum selection".to_string(),

--- a/examples/servers/src/elicitation_stdio.rs
+++ b/examples/servers/src/elicitation_stdio.rs
@@ -147,8 +147,8 @@ impl ElicitationServer {
 
 #[tool_handler]
 impl ServerHandler for ElicitationServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::from_build_env())
             .with_instructions(
                 "Simple server demonstrating elicitation for user name collection".to_string(),

--- a/examples/servers/src/elicitation_stdio.rs
+++ b/examples/servers/src/elicitation_stdio.rs
@@ -147,8 +147,8 @@ impl ElicitationServer {
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for ElicitationServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::from_build_env())
             .with_instructions(
                 "Simple server demonstrating elicitation for user name collection".to_string(),

--- a/examples/servers/src/mrtr.rs
+++ b/examples/servers/src/mrtr.rs
@@ -113,8 +113,8 @@ fn finish_weather_request(
 }
 
 impl ServerHandler for WeatherServer {
-    fn get_info(&self) -> ServerInfo {
-        let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+    fn get_info(&self) -> InitializeResult {
+        let mut info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
         // MRTR requires 2026-07-28 or newer.
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
@@ -173,8 +173,8 @@ impl ServerHandler for WeatherServer {
 struct InteractiveClient;
 
 impl ClientHandler for InteractiveClient {
-    fn get_info(&self) -> ClientInfo {
-        ClientInfo::new(
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::new(
             ClientCapabilities::builder().enable_elicitation().build(),
             Implementation::new("mrtr-example-client", env!("CARGO_PKG_VERSION")),
         )

--- a/examples/servers/src/mrtr.rs
+++ b/examples/servers/src/mrtr.rs
@@ -60,8 +60,8 @@ impl Default for WeatherServer {
 }
 
 impl ServerHandler for WeatherServer {
-    fn get_info(&self) -> ServerInfo {
-        let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+    fn get_info(&self) -> InitializeResult {
+        let mut info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
         // MRTR requires 2026-07-28 or newer.
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
@@ -128,8 +128,8 @@ impl ServerHandler for WeatherServer {
 struct InteractiveClient;
 
 impl ClientHandler for InteractiveClient {
-    fn get_info(&self) -> ClientInfo {
-        ClientInfo::new(
+    fn get_info(&self) -> InitializeRequestParams {
+        InitializeRequestParams::new(
             ClientCapabilities::builder().enable_elicitation().build(),
             Implementation::new("mrtr-example-client", env!("CARGO_PKG_VERSION")),
         )

--- a/examples/servers/src/prompt_stdio.rs
+++ b/examples/servers/src/prompt_stdio.rs
@@ -363,12 +363,13 @@ impl PromptServer {
 
 #[prompt_handler]
 impl ServerHandler for PromptServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_prompts().build()).with_instructions(
-            "This server provides various prompt templates for code review, data analysis, \
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_prompts().build())
+            .with_instructions(
+                "This server provides various prompt templates for code review, data analysis, \
                  writing assistance, debugging help, and personalized learning paths. \
                  All prompts are designed to provide structured, context-aware assistance.",
-        )
+            )
     }
 }
 

--- a/examples/servers/src/prompt_stdio.rs
+++ b/examples/servers/src/prompt_stdio.rs
@@ -363,12 +363,13 @@ impl PromptServer {
 
 #[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for PromptServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_prompts().build()).with_instructions(
-            "This server provides various prompt templates for code review, data analysis, \
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_prompts().build())
+            .with_instructions(
+                "This server provides various prompt templates for code review, data analysis, \
                  writing assistance, debugging help, and personalized learning paths. \
                  All prompts are designed to provide structured, context-aware assistance.",
-        )
+            )
     }
 }
 

--- a/examples/servers/src/sampling_stdio.rs
+++ b/examples/servers/src/sampling_stdio.rs
@@ -18,8 +18,8 @@ use tracing_subscriber::{self, EnvFilter};
 pub struct SamplingDemoServer;
 
 impl ServerHandler for SamplingDemoServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(concat!(
                 "This is a demo server that requests sampling from clients. It provides tools that use LLM capabilities.\n\n",
                 "IMPORTANT: This server requires a client that supports the 'sampling/createMessage' method. ",

--- a/examples/servers/src/sampling_stdio.rs
+++ b/examples/servers/src/sampling_stdio.rs
@@ -21,8 +21,8 @@ use tracing_subscriber::{self, EnvFilter};
 pub struct SamplingDemoServer;
 
 impl ServerHandler for SamplingDemoServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(concat!(
                 "This is a demo server that requests sampling from clients. It provides tools that use LLM capabilities.\n\n",
                 "IMPORTANT: This server requires a client that supports the 'sampling/createMessage' method. ",

--- a/examples/servers/src/subscriptions_streamhttp.rs
+++ b/examples/servers/src/subscriptions_streamhttp.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, time::Duration};
 
 use rmcp::{
     ErrorData, ServerHandler,
-    model::{ProtocolVersion, ServerCapabilities, ServerInfo, SubscriptionFilter},
+    model::{InitializeResult, ProtocolVersion, ServerCapabilities, SubscriptionFilter},
     service::SubscriptionContext,
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
@@ -18,8 +18,8 @@ impl ServerHandler for SubscriptionServer {
         Cow::Borrowed(&[ProtocolVersion::V_2026_07_28])
     }
 
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()


### PR DESCRIPTION
## Summary

`ServerInfo` and `ClientInfo` are aliases for the full initialize payloads, but
the MCP wire names `serverInfo` / `clientInfo` mean only the `Implementation`
identity. That collision makes code like `server_info.server_info` easy to
misread.

- Mark both type aliases `#[deprecated]` pointing at `InitializeResult` and
  `InitializeRequestParams`
- Move internal call sites and `Default` impls onto the real type names
- Keep the aliases as shims so existing downstream code still compiles

## Test plan

- `cargo check -p rmcp --features server,client`
- `cargo test -p rmcp --features server,client --lib` (204 passed)

Fixes #1082
