### PR TITLE
Fix typo in to_authorized_http_client doc comment

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -3682,7 +3682,7 @@ impl OAuthState {
             Err(AuthError::InternalError("Not in session state".to_string()))
         }
     }
-    /// covert to authorized http client
+    /// convert to authorized http client
     pub async fn to_authorized_http_client(&mut self) -> Result<(), AuthError> {
         let placeholder = self.placeholder_state().await?;
         if let OAuthState::Authorized(manager) = std::mem::replace(self, placeholder) {


### PR DESCRIPTION
`covert` should be `convert`.

The doc comment sits directly above `to_authorized_http_client`, which replaces `OAuthState::Authorized` with `OAuthState::AuthorizedHttpClient`, so the intended word is clear from the code underneath it.

Only the comment is changed.
