### PR TITLE
fix(transport): propagate real clientInfo to peer_info in stateless mode

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -306,6 +306,11 @@ required-features = ["server", "transport-streamable-http-server", "reqwest"]
 path = "tests/test_stateless_protocol_version.rs"
 
 [[test]]
+name = "test_stateless_client_info"
+required-features = ["server", "transport-streamable-http-server", "reqwest"]
+path = "tests/test_stateless_client_info.rs"
+
+[[test]]
 name = "test_protocol_version_negotiation"
 required-features = ["server", "client"]
 path = "tests/test_protocol_version_negotiation.rs"

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -2076,27 +2076,35 @@ where
     }
 
     /// Build a `ClientInfo` (peer_info) for a stateless request so that
-    /// `context.protocol_version()` returns the correct value inside handlers.
+    /// `context.protocol_version()` returns the correct value inside handlers,
+    /// and so that `Peer::peer_info()` (and therefore the `serve_inner`
+    /// "Service initialized as server"/"as client" log) reflects the real
+    /// client identity for a genuine handshake, instead of a placeholder.
     ///
     /// `serve_directly` skips the MCP handshake and accepts `peer_info = None`,
     /// which means `context.protocol_version()` is always `None` in stateless mode.
-    /// We reconstruct the protocol version from the available signal per request type:
-    /// - initialize: version is in the request body params (authoritative)
-    /// - all other requests: version is in the MCP-Protocol-Version header
-    ///   (validated before this point; absent header defaults to 2025-03-26)
+    /// We reconstruct the peer info from the available signal per request type:
+    /// - initialize: the full `InitializeRequestParams` — protocol version,
+    ///   capabilities, and client_info — is right there in the request body
+    ///   (authoritative), so it is used verbatim.
+    /// - all other requests: there is no session to recover the original
+    ///   handshake from, so only the protocol version can be reconstructed,
+    ///   from the MCP-Protocol-Version header (validated before this point;
+    ///   absent header defaults to 2025-03-26). `capabilities`/`client_info`
+    ///   remain placeholders in this case, since stateless mode has nowhere
+    ///   to persist the real values between requests.
     fn peer_info_for_stateless_request(
         request: &crate::model::JsonRpcRequest<ClientRequest>,
         headers: &HeaderMap,
     ) -> Option<InitializeRequestParams> {
-        let version = if let ClientRequest::InitializeRequest(ref init) = request.request {
-            init.params.protocol_version.clone()
-        } else {
-            headers
-                .get(HEADER_MCP_PROTOCOL_VERSION)
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| serde_json::from_value(serde_json::Value::String(s.to_owned())).ok())
-                .unwrap_or(ProtocolVersion::V_2025_03_26)
-        };
+        if let ClientRequest::InitializeRequest(ref init) = request.request {
+            return Some(init.params.clone());
+        }
+        let version = headers
+            .get(HEADER_MCP_PROTOCOL_VERSION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| serde_json::from_value(serde_json::Value::String(s.to_owned())).ok())
+            .unwrap_or(ProtocolVersion::V_2025_03_26);
         Some(InitializeRequestParams {
             meta: None,
             protocol_version: version,

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -2087,12 +2087,9 @@ where
     /// - initialize: the full `InitializeRequestParams` — protocol version,
     ///   capabilities, and client_info — is right there in the request body
     ///   (authoritative), so it is used verbatim.
-    /// - all other requests: there is no session to recover the original
-    ///   handshake from, so only the protocol version can be reconstructed,
-    ///   from the MCP-Protocol-Version header (validated before this point;
-    ///   absent header defaults to 2025-03-26). `capabilities`/`client_info`
-    ///   remain placeholders in this case, since stateless mode has nowhere
-    ///   to persist the real values between requests.
+    /// - all other requests: only the protocol version is reconstructed here,
+    ///   from the MCP-Protocol-Version header when present (otherwise it defaults
+    ///   to 2025-03-26); `capabilities`/`client_info` remain placeholders.
     fn peer_info_for_stateless_request(
         request: &crate::model::JsonRpcRequest<ClientRequest>,
         headers: &HeaderMap,

--- a/crates/rmcp/tests/test_stateless_client_info.rs
+++ b/crates/rmcp/tests/test_stateless_client_info.rs
@@ -1,0 +1,145 @@
+//! Regression test for stateless streamable HTTP discarding the real
+//! `clientInfo` from a genuine `initialize` request.
+//!
+//! Before the fix, `peer_info_for_stateless_request` always attached
+//! `Implementation::default()` (i.e. `{"name": "rmcp", "version": "<sdk
+//! version>"}`) to the synthesized `Peer`, regardless of what the client
+//! actually sent in its `initialize` body. That value is what
+//! `serve_inner` logs as "Service initialized as server"/"as client", and
+//! what any handler sees via `context.peer.peer_info()` — so every real
+//! client (regardless of its own identity) appeared identical, and
+//! indistinguishable from rmcp's own placeholder, in stateless mode.
+#![cfg(not(feature = "local"))]
+
+use rmcp::{
+    ErrorData, RoleServer, ServerHandler,
+    model::{
+        Implementation, InitializeRequestParams, InitializeResult, ServerCapabilities, ServerInfo,
+    },
+    service::RequestContext,
+    transport::streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    },
+};
+use tokio_util::sync::CancellationToken;
+
+/// Echoes both the `clientInfo` it received as a typed handler argument and
+/// the `clientInfo` visible via `context.peer.peer_info()` at that same
+/// instant, via `InitializeResult::instructions`, so a black-box HTTP test
+/// can compare the two without any shared in-process state.
+#[derive(Clone, Default)]
+struct EchoingPeerInfo;
+
+impl ServerHandler for EchoingPeerInfo {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::default())
+    }
+
+    async fn initialize(
+        &self,
+        request: InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, ErrorData> {
+        let peer_client_info: Option<Implementation> =
+            context.peer.peer_info().map(|p| p.client_info.clone());
+        let mut info = self.get_info();
+        info.instructions = Some(
+            serde_json::json!({
+                "request_client_info": request.client_info,
+                "peer_client_info": peer_client_info,
+            })
+            .to_string(),
+        );
+        Ok(info)
+    }
+}
+
+fn stateless_json_config() -> StreamableHttpServerConfig {
+    StreamableHttpServerConfig::default()
+        .with_legacy_session_mode(false)
+        .with_sse_keep_alive(None)
+        .with_cancellation_token(CancellationToken::new())
+        .with_json_response(true)
+}
+
+async fn spawn_server_of<H: ServerHandler + Default>(
+    config: StreamableHttpServerConfig,
+) -> (reqwest::Client, String, CancellationToken) {
+    let ct = config.cancellation_token.clone();
+    let service: StreamableHttpService<H, LocalSessionManager> =
+        StreamableHttpService::new(|| Ok(H::default()), Default::default(), config);
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = tcp_listener.local_addr().unwrap();
+
+    tokio::spawn({
+        let ct = ct.clone();
+        async move {
+            let _ = axum::serve(tcp_listener, router)
+                .with_graceful_shutdown(async move { ct.cancelled_owned().await })
+                .await;
+        }
+    });
+
+    (reqwest::Client::new(), format!("http://{addr}/mcp"), ct)
+}
+
+async fn post_init_with_client_info(
+    client: &reqwest::Client,
+    url: &str,
+    client_name: &str,
+    client_version: &str,
+) -> serde_json::Value {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": client_name, "version": client_version}
+        }
+    });
+    let resp = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(body.to_string())
+        .send()
+        .await
+        .expect("send request");
+    assert!(resp.status().is_success(), "HTTP {}", resp.status());
+    resp.json().await.expect("parse JSON")
+}
+
+#[tokio::test]
+async fn stateless_init_propagates_real_client_info_to_peer_info() {
+    let (client, url, ct) = spawn_server_of::<EchoingPeerInfo>(stateless_json_config()).await;
+
+    let resp = post_init_with_client_info(&client, &url, "totally-real-client", "42.0.0").await;
+
+    let instructions: serde_json::Value =
+        serde_json::from_str(resp["result"]["instructions"].as_str().unwrap())
+            .expect("instructions should contain the captured JSON");
+
+    // Sanity check: the handler's own typed argument really did carry the
+    // client's real identity — the request body was parsed correctly.
+    assert_eq!(
+        instructions["request_client_info"]["name"], "totally-real-client",
+        "sanity check failed — the handler never saw the real clientInfo"
+    );
+
+    // The fix: `context.peer.peer_info()` — the exact value `serve_inner`
+    // logs as "Service initialized as server" — must reflect the real
+    // client identity for a genuine `initialize` request, not
+    // `Implementation::default()`.
+    assert_eq!(
+        instructions["peer_client_info"]["name"], "totally-real-client",
+        "Peer::peer_info() should carry the real client_info from the \
+         initialize request, not a placeholder identity"
+    );
+    assert_eq!(instructions["peer_client_info"]["version"], "42.0.0");
+
+    ct.cancel();
+}


### PR DESCRIPTION
## Summary

Fixes #1172.

In stateless streamable-HTTP mode (`StreamableHttpServerConfig::legacy_session_mode = false`), `peer_info_for_stateless_request` reconstructs a synthetic `InitializeRequestParams` for every request so `context.protocol_version()` works inside handlers. It correctly reconstructs the protocol version, but always set `client_info`/`capabilities` to `Implementation::default()`/`ClientCapabilities::default()` — even for the literal `initialize` request, whose body *does* contain the real `clientInfo`.

That placeholder is exactly what `Peer::peer_info()` returns, and exactly what `serve_inner` logs via `tracing::info!(?peer_info, "Service initialized as server")` — so every real client (Claude Code, Gemini CLI, custom clients, ...) shows up identically as `client_info: { name: "rmcp", version: "<sdk version>" }` in server-side logs in stateless mode, regardless of what they actually sent. Any handler reading `context.peer.peer_info()` sees the same placeholder, even though the `initialize` handler's own typed `request` argument correctly carries the real value.

## Fix

For the `initialize` request specifically, the full `InitializeRequestParams` is already available in the request body — this PR uses it verbatim instead of only extracting `protocol_version` out of it. Non-`initialize` requests are unchanged: there's no session in stateless mode to recover the original handshake from, so they still fall back to the placeholder for `client_info`/`capabilities` (only `protocol_version` is reconstructed, from the `MCP-Protocol-Version` header).

```rust
fn peer_info_for_stateless_request(
    request: &crate::model::JsonRpcRequest<ClientRequest>,
    headers: &HeaderMap,
) -> Option<InitializeRequestParams> {
    if let ClientRequest::InitializeRequest(ref init) = request.request {
        return Some(init.params.clone());
    }
    let version = headers
        .get(HEADER_MCP_PROTOCOL_VERSION)
        .and_then(|v| v.to_str().ok())
        .and_then(|s| serde_json::from_value(serde_json::Value::String(s.to_owned())).ok())
        .unwrap_or(ProtocolVersion::V_2025_03_26);
    Some(InitializeRequestParams {
        meta: None,
        protocol_version: version,
        capabilities: ClientCapabilities::default(),
        client_info: Implementation::default(),
    })
}
```

## Testing

Adds `crates/rmcp/tests/test_stateless_client_info.rs`: spins up a real `StreamableHttpService` in stateless JSON-response mode with a handler that echoes both `request.client_info` (the handler's typed argument) and `context.peer.peer_info().map(|p| p.client_info)` (what `serve_inner` logs) back via `InitializeResult::instructions`, sends a real `initialize` request with a distinctive `clientInfo`, and asserts both match the client's real identity.

- Fails against the pre-fix code (`peer_client_info.name == "rmcp"` instead of the real client name) — verified locally by reverting just the `tower.rs` change and re-running.
- Passes with the fix.
- Existing `test_stateless_protocol_version.rs` and `test_stateless_server_requests.rs` (same module) still pass unchanged — this change doesn't touch the protocol-version reconstruction, only threads through `capabilities`/`client_info` alongside it for the `initialize` case.
- `cargo clippy -p rmcp --features server,client,transport-streamable-http-server,reqwest --lib` produces the same pre-existing warning set as `main` (verified via `git stash` diff), no new warnings from this change.
- `cargo +nightly fmt -p rmcp -- --check` clean.

## Scope

Deliberately narrow: only the `initialize` branch changes. Non-`initialize` requests in stateless mode still can't recover the original client identity (no session to persist it in), so their `client_info`/`capabilities` placeholder is unchanged — fixing that would need a broader design discussion (e.g. an explicit "this peer_info is synthetic" marker, or per-request capability propagation per SEP-2575) that felt out of scope for this fix.
