### PR TITLE
fix(rmcp): preserve elicitation requestedSchema $schema dialect

### DIFF
--- a/crates/rmcp/src/model/elicitation_schema.rs
+++ b/crates/rmcp/src/model/elicitation_schema.rs
@@ -1116,6 +1116,14 @@ impl EnumSchema {
 #[serde(rename_all = "camelCase", into = "ElicitationSchemaWire")]
 #[non_exhaustive]
 pub struct ElicitationSchema {
+    /// Optional JSON Schema dialect identifier (the `$schema` keyword).
+    ///
+    /// The 2025-11-25 protocol revision allows a `requestedSchema` to declare its
+    /// dialect. It is preserved verbatim so a declared dialect survives a
+    /// decode/re-encode round-trip instead of being silently dropped.
+    #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
+    pub schema: Option<Cow<'static, str>>,
+
     /// Always "object" for elicitation schemas
     #[serde(rename = "type")]
     pub type_: ObjectTypeConst,
@@ -1144,6 +1152,8 @@ pub struct ElicitationSchema {
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ElicitationSchemaWire {
+    #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
+    schema: Option<Cow<'static, str>>,
     #[serde(rename = "type")]
     type_: ObjectTypeConst,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1158,6 +1168,7 @@ struct ElicitationSchemaWire {
 impl From<ElicitationSchemaWire> for ElicitationSchema {
     fn from(schema: ElicitationSchemaWire) -> Self {
         Self {
+            schema: schema.schema,
             type_: schema.type_,
             title: schema.title,
             property_order: Some(schema.properties.keys().cloned().collect()),
@@ -1183,6 +1194,7 @@ impl From<ElicitationSchema> for ElicitationSchemaWire {
         properties.extend(remaining);
 
         Self {
+            schema: schema.schema,
             type_: schema.type_,
             title: schema.title,
             properties,
@@ -1206,6 +1218,7 @@ impl ElicitationSchema {
     pub fn new(properties: BTreeMap<String, PrimitiveSchemaDefinition>) -> Self {
         let property_order = Some(properties.keys().cloned().collect());
         Self {
+            schema: None,
             type_: ObjectTypeConst,
             title: None,
             properties,
@@ -1298,6 +1311,12 @@ impl ElicitationSchema {
     /// Set the description
     pub fn with_description(mut self, description: impl Into<Cow<'static, str>>) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    /// Set the JSON Schema dialect identifier (the `$schema` keyword).
+    pub fn with_schema(mut self, schema: impl Into<Cow<'static, str>>) -> Self {
+        self.schema = Some(schema.into());
         self
     }
 
@@ -1703,6 +1722,7 @@ impl ElicitationSchemaBuilder {
 
         let property_order = Some(self.properties.keys().cloned().collect());
         Ok(ElicitationSchema {
+            schema: None,
             type_: ObjectTypeConst,
             title: self.title,
             properties: self.properties,
@@ -1899,6 +1919,54 @@ mod tests {
             "firstName,lastName,email",
         );
         assert_eq!(serde_json::to_string(&ordered)?, input);
+        Ok(())
+    }
+
+    #[test]
+    fn test_elicitation_schema_preserves_schema_dialect_roundtrip() -> anyhow::Result<()> {
+        // Regression test for #1168: a top-level `$schema` dialect declaration on a
+        // `requestedSchema` was silently dropped, because the wire bridge struct had
+        // no field to hold it. It must survive a decode/re-encode round-trip.
+        let input = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            }
+        });
+        let schema: ElicitationSchema = serde_json::from_value(input.clone())?;
+        assert_eq!(
+            schema.schema.as_deref(),
+            Some("https://json-schema.org/draft/2020-12/schema"),
+        );
+        let output = serde_json::to_value(&schema)?;
+        assert_eq!(output, input);
+        Ok(())
+    }
+
+    #[test]
+    fn test_elicitation_schema_omits_schema_dialect_when_absent() -> anyhow::Result<()> {
+        // A schema with no dialect must not emit a `$schema` key (no `"$schema": null`).
+        let input = serde_json::json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" } }
+        });
+        let schema: ElicitationSchema = serde_json::from_value(input)?;
+        assert!(schema.schema.is_none());
+        let json = serde_json::to_value(&schema)?;
+        assert!(json.get("$schema").is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_elicitation_schema_with_schema_setter_serializes_dialect() -> anyhow::Result<()> {
+        let schema = ElicitationSchema::new(BTreeMap::new())
+            .with_schema("https://json-schema.org/draft/2020-12/schema");
+        let json = serde_json::to_value(&schema)?;
+        assert_eq!(
+            json["$schema"],
+            "https://json-schema.org/draft/2020-12/schema"
+        );
         Ok(())
     }
 

--- a/crates/rmcp/src/model/elicitation_schema.rs
+++ b/crates/rmcp/src/model/elicitation_schema.rs
@@ -1121,7 +1121,8 @@ pub struct ElicitationSchema {
     /// The 2025-11-25 protocol revision allows a `requestedSchema` to declare its
     /// dialect. It is preserved verbatim so a declared dialect survives a
     /// decode/re-encode round-trip instead of being silently dropped.
-    #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "$schema", default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub schema: Option<Cow<'static, str>>,
 
     /// Always "object" for elicitation schemas
@@ -1152,7 +1153,7 @@ pub struct ElicitationSchema {
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ElicitationSchemaWire {
-    #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "$schema", default, skip_serializing_if = "Option::is_none")]
     schema: Option<Cow<'static, str>>,
     #[serde(rename = "type")]
     type_: ObjectTypeConst,

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -963,6 +963,13 @@
       "description": "Type-safe elicitation schema for requesting structured user input.\n\nThis enforces the MCP 2025-06-18 specification that elicitation schemas\nmust be objects with primitive-typed properties.\n\n# Example\n\n```rust\nuse rmcp::model::*;\n\nlet schema = ElicitationSchema::builder()\n    .required_email(\"email\")\n    .required_integer(\"age\", 0, 150)\n    .optional_bool(\"newsletter\", false)\n    .build();\n```",
       "type": "object",
       "properties": {
+        "$schema": {
+          "description": "Optional JSON Schema dialect identifier (the `$schema` keyword).\n\nThe 2025-11-25 protocol revision allows a `requestedSchema` to declare its\ndialect. It is preserved verbatim so a declared dialect survives a\ndecode/re-encode round-trip instead of being silently dropped.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "description": {
           "description": "Optional description of what this schema represents",
           "type": [

--- a/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
+++ b/crates/rmcp/tests/test_message_schema/server_json_rpc_message_schema.json
@@ -965,10 +965,7 @@
       "properties": {
         "$schema": {
           "description": "Optional JSON Schema dialect identifier (the `$schema` keyword).\n\nThe 2025-11-25 protocol revision allows a `requestedSchema` to declare its\ndialect. It is preserved verbatim so a declared dialect survives a\ndecode/re-encode round-trip instead of being silently dropped.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "description": {
           "description": "Optional description of what this schema represents",


### PR DESCRIPTION
## What

`ElicitationSchema` (de)serializes through an internal `ElicitationSchemaWire`
bridge. The bridge had no field for the top-level `$schema` keyword, so a
dialect declared on an incoming `requestedSchema` was accepted but silently
dropped when the schema was re-serialized.

The 2025-11-25 protocol revision allows a `requestedSchema` to carry a
`$schema` dialect identifier, and `ElicitationSchema::from_type` already emits
one (schemars draft-07), so the value was being lost on any round-trip.

## Change

- Add a `schema: Option<Cow<'static, str>>` field (serde `rename = "$schema"`)
  to both `ElicitationSchema` and the `ElicitationSchemaWire` bridge.
- Thread it through the two `From` conversions.
- Add a `with_schema` setter, matching the existing `with_title` and
  `with_description` builders. The struct is `#[non_exhaustive]`, so an
  external caller needs a setter to populate the field.

The field uses `skip_serializing_if = "Option::is_none"`, so a schema without a
dialect serializes exactly as before. Adding a field to a `#[non_exhaustive]`
struct is semver compatible.

## Tests

Three unit tests in `elicitation_schema.rs`:

- a `$schema` value survives a deserialize then serialize round-trip,
- a schema without a dialect emits no `$schema` key,
- the `with_schema` setter serializes the dialect.

## Scope

This handles the `$schema` half of #1168. The other half (preserving unknown
property-level keywords) needs a data-model decision on where arbitrary
keywords should live, so I left it out of this change and kept the issue open
for it.

Refs #1168
