### PR TITLE
fix(auth): ignore query parameters in protected resource matching

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2559,14 +2559,12 @@ impl AuthorizationManager {
         let expected_path = expected.path();
         let actual_path = actual.path();
 
-        // URL query part supported, even if it is discouraged in RFC 8707
-        if expected_path == actual_path && expected.query() == actual.query() {
+        // Query parameters may carry transport hints rather than resource identity.
+        if expected_path == actual_path {
             return true;
         }
 
         expected_path.starts_with(actual_path)
-            && expected.query().is_none()
-            && actual.query().is_none()
             && (actual_path.ends_with('/')
                 || expected_path.as_bytes().get(actual_path.len()) == Some(&b'/'))
     }
@@ -4914,6 +4912,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn preregistered_client_uses_metadata_resource_when_server_url_has_query() {
+        let client = RecordingOAuthHttpClient::with_responses(preregistered_discovery_responses());
+        let mut state = super::OAuthState::new_with_oauth_http_client(
+            "https://mcp.example.com/mcp?oauth=initialize",
+            Arc::new(client.clone()),
+        )
+        .await
+        .unwrap();
+
+        let request = AuthorizationRequest::new("http://localhost:8080/callback")
+            .with_preregistered_client("preregistered-client");
+        state.start_authorization(request).await.unwrap();
+
+        let auth_url = state.get_authorization_url().await.unwrap();
+        let query = auth_url_query(&auth_url);
+        assert_eq!(
+            query.get("resource").map(String::as_str),
+            Some("https://mcp.example.com/mcp")
+        );
+        assert_eq!(
+            client.requests()[0].uri,
+            "https://mcp.example.com/mcp?oauth=initialize"
+        );
+    }
+
+    #[tokio::test]
     async fn authorization_session_selects_default_scopes_when_none_provided() {
         let client = RecordingOAuthHttpClient::with_responses(preregistered_discovery_responses());
         let mut manager = AuthorizationManager::new_with_oauth_http_client(
@@ -5549,6 +5573,22 @@ mod tests {
             &Url::parse("https://mcp.example.com/mcp?query=param").unwrap(),
             &Url::parse("https://mcp.example.com/mcp?query=param").unwrap()
         ));
+        assert!(AuthorizationManager::is_resource_identifier_valid(
+            &Url::parse("https://mcp.example.com/mcp?oauth=initialize").unwrap(),
+            &Url::parse("https://mcp.example.com/mcp").unwrap()
+        ));
+        assert!(AuthorizationManager::is_resource_identifier_valid(
+            &Url::parse("https://mcp.example.com/mcp").unwrap(),
+            &Url::parse("https://mcp.example.com/mcp?query=value1").unwrap()
+        ));
+        assert!(AuthorizationManager::is_resource_identifier_valid(
+            &Url::parse("https://mcp.example.com/mcp?query=value1").unwrap(),
+            &Url::parse("https://mcp.example.com/mcp?query=value2").unwrap()
+        ));
+        assert!(AuthorizationManager::is_resource_identifier_valid(
+            &Url::parse("https://mcp.example.com/mcp/tools?oauth=initialize").unwrap(),
+            &Url::parse("https://mcp.example.com/mcp?query=value1").unwrap()
+        ));
 
         assert!(!AuthorizationManager::is_resource_identifier_valid(
             &Url::parse("https://mcp.example.com/mcp").unwrap(),
@@ -5571,12 +5611,12 @@ mod tests {
             &Url::parse("https://real.example.com/mcp").unwrap()
         ));
         assert!(!AuthorizationManager::is_resource_identifier_valid(
-            &Url::parse("https://mcp.example.com/mcp").unwrap(),
+            &Url::parse("https://mcp.example.com/mcp-tools?oauth=initialize").unwrap(),
             &Url::parse("https://mcp.example.com/mcp?query=value1").unwrap()
         ));
         assert!(!AuthorizationManager::is_resource_identifier_valid(
-            &Url::parse("https://mcp.example.com/mcp?query=value1").unwrap(),
-            &Url::parse("https://mcp.example.com/mcp?query=value2").unwrap()
+            &Url::parse("https://mcp.example.com/mcp?oauth=initialize").unwrap(),
+            &Url::parse("https://real.example.com/mcp?oauth=initialize").unwrap()
         ));
     }
 


### PR DESCRIPTION
## Why

The [AWS MCP Server](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/getting-started-aws-mcp-server.html) exposes both public documentation tools and authenticated AWS API tools. Requiring OAuth during every initialization would block public tools, but some clients only start OAuth after an initialization-time `401`. AWS therefore uses `?oauth=initialize` to request an early `WWW-Authenticate` challenge without changing the token audience:

```text
MCP endpoint: https://mcp.example.com/mcp?oauth=initialize
Metadata resource: https://mcp.example.com/mcp
```

MCP permits [authorization-dependent tool visibility](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#capabilities) and documents [401 discovery](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/authorization-server-discovery#protected-resource-metadata-discovery-requirements) and [step-up authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#step-up-authorization-flow), but does not prescribe first-time OAuth negotiation for endpoints mixing public and protected tools.

## Standards and compatibility

[RFC 8707 §2](https://datatracker.ietf.org/doc/html/rfc8707#section-2) says resource URIs SHOULD NOT contain queries, but explicitly permits them; it prohibits fragments and does not define query equivalence. [RFC 9728 §3.3](https://datatracker.ietf.org/doc/html/rfc9728#section-3.3) requires exact metadata matching, which literally rejects this AWS pattern. The [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/core-internal/src/shared/authUtils.ts#L17-L56) resolves that interoperability tension by comparing origin and path while ignoring queries.

This PR adopts the same policy: preserve scheme, host, port, path-boundary, and fragment checks; ignore queries for equal or permitted parent paths; and use the metadata's canonical resource in OAuth requests. Consequently, queries no longer distinguish same-origin, path-compatible resources.

## Validation

```bash
cargo +1.97.1 test -p rmcp --features auth,transport-io
cargo +nightly-2025-09-01 fmt --all -- --check
git diff --check
```

554 tests pass, including 369 library tests. Coverage includes the AWS-style OAuth flow, absent/differing queries, parent paths, deceptive path prefixes, and cross-origin resources; the new regression fails before the fix.