### PR TITLE
docs: use auto lifecycle in streamable HTTP example

### DIFF
--- a/examples/clients/src/streamable_http.rs
+++ b/examples/clients/src/streamable_http.rs
@@ -1,14 +1,15 @@
 use anyhow::Result;
 use rmcp::{
-    ServiceExt,
-    model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation},
+    ClientLifecycleMode, ClientServiceExt,
+    model::{
+        CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation, ProtocolVersion,
+    },
     transport::StreamableHttpClientTransport,
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize logging
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -19,25 +20,29 @@ async fn main() -> Result<()> {
     let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
     let client_info = ClientInfo::new(
         ClientCapabilities::default(),
-        Implementation::new("test sse client", "0.0.1"),
+        Implementation::new("streamable-http-client", "0.0.1"),
     );
-    let client = client_info.serve(transport).await.inspect_err(|e| {
-        tracing::error!("client error: {:?}", e);
-    })?;
+    let client = client_info
+        .serve_with_lifecycle(
+            transport,
+            ClientLifecycleMode::Auto {
+                preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+                legacy_version: Some(ProtocolVersion::V_2025_11_25),
+            },
+        )
+        .await
+        .inspect_err(|e| {
+            tracing::error!("client error: {:?}", e);
+        })?;
 
-    // Initialize
     let server_info = client.peer_info();
     tracing::info!("Connected to server: {server_info:#?}");
 
-    // List tools
     let tools = client.list_tools(Default::default()).await?;
     tracing::info!("Available tools: {tools:#?}");
 
     let tool_result = client
-        .call_tool(
-            CallToolRequestParams::new("increment")
-                .with_arguments(serde_json::json!({}).as_object().cloned().unwrap()),
-        )
+        .call_tool(CallToolRequestParams::new("increment"))
         .await?;
     tracing::info!("Tool result: {tool_result:#?}");
     client.cancel().await?;


### PR DESCRIPTION
Closes #1164.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This PR updates the example to use `ClientLifecycleMode::Auto`. It prefers the `2026-07-28` protocol and falls back to legacy initialization with `2025-11-25`. It also gives the example the correct identity and calls the argument-free `increment` tool without creating an unnecessary empty JSON object.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed