### PR TITLE
fix(transport): cancel pending modern HTTP requests

### DIFF
--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -454,7 +454,9 @@ path = "tests/test_streamable_http_connection_reuse.rs"
 [[test]]
 name = "test_streamable_http_disconnect_cancel"
 required-features = [
+  "client",
   "server",
+  "transport-streamable-http-client-reqwest",
   "transport-streamable-http-server",
   "reqwest",
 ]

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -32,6 +32,14 @@ use crate::{
 
 type BoxedSseStream = BoxStream<'static, Result<Sse, SseError>>;
 type SseTaskResult<E> = (Option<RequestId>, Result<(), StreamableHttpError<E>>);
+
+struct ModernPostTaskResult<E: std::error::Error + Send + Sync + 'static> {
+    request_id: Option<RequestId>,
+    responder: tokio::sync::oneshot::Sender<Result<(), StreamableHttpError<E>>>,
+    response: Option<Result<StreamableHttpPostResponse, StreamableHttpError<E>>>,
+    stream_ct: CancellationToken,
+}
+
 const SESSION_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn build_request_headers(
@@ -949,19 +957,17 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                 ))?;
             let _ = initialized_notification.responder.send(Ok(()));
         }
-        #[expect(
-            clippy::large_enum_variant,
-            reason = "the event is short-lived and boxing would add allocation in the event loop"
-        )]
         enum Event<W: Worker, E: std::error::Error + Send + Sync + 'static> {
             ClientMessage(WorkerSendRequest<W>),
             ServerMessage(ServerJsonRpcMessage),
+            ModernPostResult(ModernPostTaskResult<E>),
             StreamResult {
                 request_id: Option<RequestId>,
                 result: Result<(), StreamableHttpError<E>>,
             },
         }
         let mut streams = tokio::task::JoinSet::new();
+        let mut modern_posts = tokio::task::JoinSet::new();
         let mut pending_stream_response_ids = HashSet::new();
         let mut request_stream_cancellations = HashMap::<RequestId, CancellationToken>::new();
         let mut awaiting_fallback_initialized = false;
@@ -996,6 +1002,13 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                     };
                     Event::ServerMessage(message)
                 },
+                terminated_post = modern_posts.join_next(), if !modern_posts.is_empty() => {
+                    match terminated_post {
+                        Some(Ok(result)) => Event::ModernPostResult(result),
+                        Some(Err(error)) => break 'main_loop Err(WorkerQuitReason::Join(error)),
+                        None => continue,
+                    }
+                }
                 terminated_stream = streams.join_next(), if !streams.is_empty() => {
                     match terminated_stream {
                         Some(result) => {
@@ -1125,9 +1138,6 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                                 ClientNotification::InitializedNotification(_)
                             )
                     );
-                    // Pass a clone to the first attempt so `message` is retained for a
-                    // potential re-init retry. `post_message` takes ownership and the
-                    // trait cannot be changed, so the clone is unavoidable.
                     let (request_version, request_headers) = request_version_headers(
                         &protocol_headers,
                         &message,
@@ -1144,6 +1154,40 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                             cleanup.protocol_headers = protocol_headers.clone();
                         }
                     }
+                    if uses_modern_http {
+                        let stream_ct = transport_task_ct.child_token();
+                        if let Some(request_id) = request_id.as_ref() {
+                            request_stream_cancellations
+                                .insert(request_id.clone(), stream_ct.clone());
+                        }
+                        let client = self.client.clone();
+                        let uri = config.uri.clone();
+                        let auth_header = config.auth_header.clone();
+                        let max_sse_event_size = config.max_sse_event_size;
+                        modern_posts.spawn(async move {
+                            let response = tokio::select! {
+                                response = client.post_message_with_max_sse_event_size(
+                                    uri,
+                                    message,
+                                    None,
+                                    auth_header,
+                                    request_headers,
+                                    max_sse_event_size,
+                                ) => Some(response),
+                                _ = stream_ct.cancelled() => None,
+                            };
+                            ModernPostTaskResult {
+                                request_id,
+                                responder,
+                                response,
+                                stream_ct,
+                            }
+                        });
+                        continue;
+                    }
+                    // Pass a clone to the first attempt so `message` is retained for a
+                    // potential re-init retry. `post_message` takes ownership and the
+                    // trait cannot be changed, so the clone is unavoidable.
                     let response = self
                         .client
                         .post_message_with_max_sse_event_size(
@@ -1391,6 +1435,78 @@ impl<C: StreamableHttpClient> Worker for StreamableHttpClientWorker<C> {
                         }
                         awaiting_fallback_initialized = false;
                     }
+                    let _ = responder.send(send_result);
+                }
+                Event::ModernPostResult(ModernPostTaskResult {
+                    request_id,
+                    responder,
+                    response,
+                    stream_ct,
+                }) => {
+                    let send_result = match (stream_ct.is_cancelled(), response) {
+                        (true, _) | (_, None) => Ok(()),
+                        (false, Some(response)) => match response {
+                            Err(error) => {
+                                if let Some(request_id) = request_id.as_ref() {
+                                    request_stream_cancellations.remove(request_id);
+                                }
+                                Err(error)
+                            }
+                            Ok(StreamableHttpPostResponse::Accepted) => {
+                                if let Some(request_id) = request_id.as_ref() {
+                                    request_stream_cancellations.remove(request_id);
+                                }
+                                Self::mark_stream_response_pending(
+                                    &mut pending_stream_response_ids,
+                                    request_id,
+                                );
+                                tracing::trace!("client message accepted");
+                                Ok(())
+                            }
+                            Ok(StreamableHttpPostResponse::Json(mut message, ..)) => {
+                                if let Some(request_id) = request_id.as_ref() {
+                                    request_stream_cancellations.remove(request_id);
+                                }
+                                cache_tools_from_response(
+                                    &mut tool_header_cache,
+                                    &mut message,
+                                    &negotiated_version,
+                                );
+                                context.send_to_handler(message).await?;
+                                Ok(())
+                            }
+                            Ok(StreamableHttpPostResponse::Sse(stream, ..)) => {
+                                Self::mark_stream_response_pending(
+                                    &mut pending_stream_response_ids,
+                                    request_id.clone(),
+                                );
+                                let sse_stream = Self::response_sse_to_jsonrpc(
+                                    stream,
+                                    None,
+                                    self.client.clone(),
+                                    config.uri.clone(),
+                                    config.auth_header.clone(),
+                                    protocol_headers.clone(),
+                                    config.max_sse_event_size,
+                                    self.config.retry_config.clone(),
+                                );
+                                let stream_tx = sse_worker_tx.clone();
+                                let origin = match &request_id {
+                                    Some(id) => InboundStreamOrigin::OutboundRequest(id.clone()),
+                                    None => InboundStreamOrigin::Unassociated,
+                                };
+                                streams.spawn(async move {
+                                    let result = Self::execute_sse_stream(
+                                        sse_stream, stream_tx, origin, true, stream_ct,
+                                    )
+                                    .await;
+                                    (request_id, result)
+                                });
+                                tracing::trace!("got new sse stream");
+                                Ok(())
+                            }
+                        },
+                    };
                     let _ = responder.send(send_result);
                 }
                 Event::ServerMessage(mut json_rpc_message) => {

--- a/crates/rmcp/tests/test_streamable_http_disconnect_cancel.rs
+++ b/crates/rmcp/tests/test_streamable_http_disconnect_cancel.rs
@@ -1,4 +1,5 @@
 #![cfg(all(
+    feature = "client",
     feature = "server",
     feature = "transport-streamable-http-server",
     feature = "reqwest",
@@ -16,14 +17,18 @@
 use std::{sync::Arc, time::Duration};
 
 use rmcp::{
-    ErrorData as McpError, RoleServer, ServerHandler,
+    ClientLifecycleMode, ClientServiceExt, ErrorData as McpError, RoleServer, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ServerCapabilities,
-        ServerInfo,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ClientInfo, ClientRequest,
+        ContentBlock, ProtocolVersion, Request, ServerCapabilities, ServerInfo,
     },
-    service::RequestContext,
-    transport::streamable_http_server::{
-        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    service::{PeerRequestOptions, RequestContext},
+    transport::{
+        StreamableHttpClientTransport,
+        streamable_http_client::StreamableHttpClientTransportConfig,
+        streamable_http_server::{
+            StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+        },
     },
 };
 use tokio::sync::Notify;
@@ -191,6 +196,50 @@ async fn stateless_json_client_disconnect_cancels_request() -> anyhow::Result<()
         .await
         .expect("RequestContext::ct should fire after client disconnect (JSON)");
 
+    server.server_ct.cancel();
+    Ok(())
+}
+
+/// Modern RMCP clients must be able to cancel while the request POST is still
+/// waiting for its first response event.
+#[tokio::test]
+async fn modern_rmcp_client_cancels_pending_request() -> anyhow::Result<()> {
+    let server = spawn_stateless_server(false).await?;
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(server.url.clone()),
+    );
+    let client = ClientInfo::default()
+        .serve_with_lifecycle(
+            transport,
+            ClientLifecycleMode::Discover {
+                preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+            },
+        )
+        .await?;
+
+    let request = client
+        .send_cancellable_request(
+            ClientRequest::CallToolRequest(Request::new(CallToolRequestParams::new(
+                "wait_for_cancel".to_owned(),
+            ))),
+            PeerRequestOptions::no_options(),
+        )
+        .await?;
+
+    tokio::time::timeout(Duration::from_secs(5), server.started.notified())
+        .await
+        .expect("tool handler should start");
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        request.cancel(Some("test cancellation".to_owned())),
+    )
+    .await
+    .expect("RequestHandle::cancel should not wait for the response stream")?;
+    tokio::time::timeout(Duration::from_secs(10), server.cancelled.notified())
+        .await
+        .expect("RequestContext::ct should fire after RequestHandle::cancel");
+
+    client.cancel().await?;
     server.server_ct.cancel();
     Ok(())
 }


### PR DESCRIPTION
Allow modern Streamable HTTP requests to be cancelled before their POST returns the first response event. The client worker stays responsive while request POSTs are in flight, and the same per-request cancellation token continues to own any returned SSE stream.

## Motivation and Context

Fixes #1193.

`RequestHandle::cancel()` currently waits forever when a `2026-07-28` request POST is still waiting for its response stream. The worker awaits the POST inline, so it cannot process the cancellation that should close that same request.

This is required by the modern MCP transport rules:

- [Transport overview: cancellation](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports#cancellation)
- [Streamable HTTP: cancellation](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http#cancellation)

## How Has This Been Tested?

The new integration test uses an RMCP client and server over a real Axum HTTP listener. Before the fix, it fails after five seconds because `RequestHandle::cancel()` remains pending. With the fix, cancellation returns and the server's `RequestContext::ct` fires.

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 783 passed, 24 ignored
- Full RMCP suite with all non-local features — 1,093 passed, 13 ignored
- Focused disconnect suite — 3 passed

## Breaking Changes

None. This fixes modern Streamable HTTP cancellation behavior without changing the public API. Legacy lifecycle, session, and re-initialization paths are unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The implementation uses RMCP's existing Tokio `JoinSet` and `CancellationToken`; it adds no dependency. A modern request's token is registered before its POST starts. Cancelling the request drops the pending HTTP future, and if the POST returns an SSE stream first, that same token controls the stream as before. Response-versus-cancellation races keep the existing behavior of ignoring a response after cancellation.

Issues #857 and PR #967 added the matching server-side disconnect handling. This change makes RMCP's public client cancellation API trigger that path even before response headers or the first SSE event arrive.
