### PR TITLE
rmcp: return forbidden for invalid origin

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -893,13 +893,13 @@ fn validate_origin_header(
         .inspect_err(|_| {
             tracing::warn!(origin = ?origin_header, "rejected request with non-UTF-8 Origin header");
         })
-        .map_err(|_| bad_request_response("Bad Request: Invalid Origin header encoding"))?;
+        .map_err(|_| forbidden_response("Forbidden: Invalid Origin header encoding"))?;
     let origin = parse_origin_value(origin_str).ok_or_else(|| {
         tracing::warn!(
             origin = origin_str,
             "rejected request with malformed Origin header",
         );
-        bad_request_response("Bad Request: Invalid Origin header")
+        forbidden_response("Forbidden: Invalid Origin header")
     })?;
     if !origin_is_allowed(&origin, allowed_origins) {
         tracing::warn!(

--- a/crates/rmcp/tests/test_custom_headers.rs
+++ b/crates/rmcp/tests/test_custom_headers.rs
@@ -1127,7 +1127,10 @@ mod origin_validation {
     use std::sync::Arc;
 
     use bytes::Bytes;
-    use http::{Method, Request, header::CONTENT_TYPE};
+    use http::{
+        Method, Request,
+        header::{CONTENT_TYPE, HeaderValue, ORIGIN},
+    };
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
@@ -1196,6 +1199,24 @@ mod origin_validation {
         let response = service
             .handle(init_request(Some("http://attacker.example")))
             .await;
+        assert_eq!(response.status(), http::StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn malformed_origin_is_forbidden() {
+        let service = service_with_allowed_origins(&["http://localhost:8080"]);
+        let response = service.handle(init_request(Some("not-an-origin"))).await;
+        assert_eq!(response.status(), http::StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn non_utf8_origin_is_forbidden() {
+        let service = service_with_allowed_origins(&["http://localhost:8080"]);
+        let mut request = init_request(None);
+        request
+            .headers_mut()
+            .insert(ORIGIN, HeaderValue::from_bytes(&[0xff]).unwrap());
+        let response = service.handle(request).await;
         assert_eq!(response.status(), http::StatusCode::FORBIDDEN);
     }
 


### PR DESCRIPTION
## Summary

- return `403 Forbidden` for malformed or non-UTF-8 `Origin` headers when Origin validation is enabled
- add regression coverage for both invalid-header cases

Fixes #1188

## Testing

- `cargo test -p rmcp --test test_custom_headers origin_validation --features 'client,server,transport-streamable-http-client-reqwest,transport-streamable-http-server' -- --nocapture`
- `git diff --check`
- targeted `rustfmt` on the two changed files