### PR TITLE
fix(auth): ignore non-metadata JSON when probing for protected resource metadata

### DIFF
--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2606,9 +2606,7 @@ impl AuthorizationManager {
     }
 
     async fn discover_resource_metadata_url(&self) -> Result<Option<Url>, AuthError> {
-        if let Some(resource_metadata_url) =
-            self.probe_resource_metadata_url(&self.base_url).await?
-        {
+        if let Some(resource_metadata_url) = self.probe_resource_endpoint_for_challenge().await? {
             return Ok(Some(resource_metadata_url));
         }
 
@@ -2631,10 +2629,37 @@ impl AuthorizationManager {
         Ok(None)
     }
 
-    /// Probe `url` with a GET, extracting the resource metadata url from a
-    /// 200 (the url itself is the metadata document) or from a 401's
-    /// WWW-Authenticate header value.
+    /// Probe the resource itself, looking only for a `WWW-Authenticate` challenge
+    /// that carries a `resource_metadata` pointer.
+    ///
+    /// A 200 here says nothing about metadata. RFC 9728 publishes the document at
+    /// the well-known URI and advertises it through the challenge parameter, so the
+    /// resource answering its own GET is not the document and must not end
+    /// discovery before the well-known candidates are tried.
     /// https://www.rfc-editor.org/rfc/rfc9728.html#name-use-of-www-authenticate-for
+    async fn probe_resource_endpoint_for_challenge(&self) -> Result<Option<Url>, AuthError> {
+        let response = self
+            .discovery_get(&self.base_url)
+            .await
+            .map_err(|error| Self::discovery_failed(&self.base_url, error))?;
+
+        if response.status() == StatusCode::UNAUTHORIZED {
+            return Ok(self
+                .extract_resource_metadata_url_from_www_authenticate(&response)
+                .await);
+        }
+
+        debug!(
+            "resource endpoint probe returned {}, no WWW-Authenticate pointer to follow",
+            response.status()
+        );
+        Ok(None)
+    }
+
+    /// Probe a `.well-known` candidate with a GET, extracting the resource metadata
+    /// url from a 200 (the url itself is the metadata document) or from a 401's
+    /// WWW-Authenticate header value.
+    /// https://www.rfc-editor.org/rfc/rfc9728.html#name-obtaining-protected-resourc
     async fn probe_resource_metadata_url(&self, url: &Url) -> Result<Option<Url>, AuthError> {
         let response = self
             .discovery_get(url)
@@ -4871,7 +4896,65 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_metadata_ignores_non_metadata_json_at_the_base_url() {
+    async fn resolve_metadata_reaches_the_well_known_document_past_a_non_metadata_base_url() {
+        let document = || {
+            http_response(
+                200,
+                serde_json::json!({
+                    "resource": "https://mcp.example.com/",
+                    "authorization_servers": ["https://auth.example.com"]
+                }),
+            )
+        };
+        let client = RecordingOAuthHttpClient::with_responses(vec![
+            // the MCP endpoint answers GET with a health payload, not metadata
+            http_response(
+                200,
+                serde_json::json!({"status": "healthy", "message": "MCP server is running"}),
+            ),
+            // the well-known candidate carries the real document: probed, then fetched
+            document(),
+            document(),
+            http_response(
+                200,
+                serde_json::json!({
+                    "issuer": "https://auth.example.com",
+                    "authorization_endpoint": "https://auth.example.com/authorize",
+                    "token_endpoint": "https://auth.example.com/token"
+                }),
+            ),
+        ]);
+        let recorder = client.clone();
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/",
+            Arc::new(client),
+        )
+        .await
+        .unwrap();
+
+        let resolution = manager.resolve_metadata().await.unwrap();
+
+        assert_eq!(
+            (
+                resolution.source,
+                resolution.metadata.token_endpoint.as_str(),
+            ),
+            (
+                AuthorizationMetadataSource::ProtectedResourceMetadata,
+                "https://auth.example.com/token",
+            )
+        );
+        assert!(
+            recorder.requests().iter().any(|request| {
+                request.uri == "https://mcp.example.com/.well-known/oauth-protected-resource"
+            }),
+            "the well-known candidate was never probed: {:?}",
+            recorder.requests()
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_ignores_a_well_known_url_that_is_not_a_metadata_document() {
         let health = || {
             http_response(
                 200,
@@ -4879,8 +4962,9 @@ mod tests {
             )
         };
         let client = RecordingOAuthHttpClient::with_responses(vec![
-            // the MCP endpoint answers GET with a health payload, not metadata.
-            // The same URL is hit twice: once to probe, once to fetch the document.
+            // the MCP endpoint answers GET with a health payload, not metadata
+            health(),
+            // so does the well-known candidate: probed, then fetched
             health(),
             health(),
             http_response(

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2508,13 +2508,14 @@ impl AuthorizationManager {
 
     /// Walk the authorization servers a protected resource metadata document
     /// names, keeping the first one that answers with usable metadata.
+    ///
+    /// The document arrives here through `read_resource_metadata`, which is where
+    /// it is decided to be this resource's metadata at all.
     async fn authorization_metadata_from_resource_metadata(
         &self,
         resource_metadata_url: &Url,
         resource_metadata: ResourceServerMetadata,
     ) -> Result<Option<AuthorizationMetadata>, AuthError> {
-        self.validate_resource_metadata_resource(&resource_metadata)?;
-
         self.discovered_resource
             .write()
             .await
@@ -2673,7 +2674,7 @@ impl AuthorizationManager {
                 // The candidate url is the document itself, so read the body here
                 // instead of requesting the same url again.
                 StatusCode::OK => {
-                    if let Some(metadata) = Self::parse_resource_metadata(
+                    if let Some(metadata) = self.read_resource_metadata(
                         &candidate_url,
                         response.body(),
                         ResourceMetadataUrlOrigin::WellKnownGuess,
@@ -2771,10 +2772,15 @@ impl AuthorizationManager {
             return Ok(None);
         }
 
-        Self::parse_resource_metadata(resource_metadata_url, response.body(), origin)
+        self.read_resource_metadata(resource_metadata_url, response.body(), origin)
     }
 
-    fn parse_resource_metadata(
+    /// Read a response body as this resource's protected resource metadata.
+    ///
+    /// A body that is not that document rules out the url it came from, and where
+    /// that url came from decides whether ruling it out leaves anything to try.
+    fn read_resource_metadata(
+        &self,
         resource_metadata_url: &Url,
         body: &[u8],
         origin: ResourceMetadataUrlOrigin,
@@ -2808,6 +2814,21 @@ impl AuthorizationManager {
                 ResourceMetadataUrlOrigin::WellKnownGuess => {
                     debug!(
                         "response at {resource_metadata_url} is not a protected resource metadata document"
+                    );
+                    Ok(None)
+                }
+            };
+        }
+
+        // Carrying those fields only makes the body a metadata document; validation
+        // is what makes it this resource's. Both answers rule out the url the same
+        // way, so both are read the same way.
+        if let Err(error) = self.validate_resource_metadata_resource(&metadata) {
+            return match origin {
+                ResourceMetadataUrlOrigin::Advertised => Err(error),
+                ResourceMetadataUrlOrigin::WellKnownGuess => {
+                    debug!(
+                        "document at {resource_metadata_url} is not this resource's metadata: {error}"
                     );
                     Ok(None)
                 }
@@ -5137,6 +5158,69 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "Metadata error: the server advertised https://mcp.example.com/.well-known/oauth-protected-resource as protected resource metadata, but the document carries neither `resource` nor an authorization server reference"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_tries_the_next_well_known_candidate_past_an_unusable_document() {
+        let client = RecordingOAuthHttpClient::with_responses(vec![
+            // the MCP endpoint answers GET with a health payload, not metadata
+            http_response(
+                200,
+                serde_json::json!({"status": "healthy", "message": "MCP server is running"}),
+            ),
+            // a catch-all handler answers the first candidate with its own error
+            // shape, which carries a `resource` that only validation rejects
+            http_response(
+                200,
+                serde_json::json!({
+                    "error": "not_found",
+                    "resource": "/.well-known/oauth-protected-resource"
+                }),
+            ),
+            // the second candidate carries the real document
+            http_response(
+                200,
+                serde_json::json!({
+                    "resource": "https://mcp.example.com/mcp",
+                    "authorization_servers": ["https://auth.example.com"]
+                }),
+            ),
+            http_response(
+                200,
+                serde_json::json!({
+                    "issuer": "https://auth.example.com",
+                    "authorization_endpoint": "https://auth.example.com/authorize",
+                    "token_endpoint": "https://auth.example.com/token"
+                }),
+            ),
+        ]);
+        let recorder = client.clone();
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/mcp",
+            Arc::new(client),
+        )
+        .await
+        .unwrap();
+
+        let resolution = manager.resolve_metadata().await.unwrap();
+
+        assert_eq!(
+            (
+                resolution.source,
+                resolution.metadata.token_endpoint.as_str(),
+            ),
+            (
+                AuthorizationMetadataSource::ProtectedResourceMetadata,
+                "https://auth.example.com/token",
+            )
+        );
+        assert!(
+            recorder.requests().iter().any(|request| {
+                request.uri == "https://mcp.example.com/mcp/.well-known/oauth-protected-resource"
+            }),
+            "the candidate after the rejected one was never probed: {:?}",
+            recorder.requests()
         );
     }
 

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2528,24 +2528,28 @@ impl AuthorizationManager {
             *self.resource_scopes.write().await = scopes;
         }
 
-        let mut candidates = Vec::new();
+        // A server naming the same authorization server in both the singular draft
+        // field and the list would otherwise have each of that server's well-known
+        // forms requested twice.
+        let mut candidates: Vec<String> = Vec::new();
+        let mut push_candidate = |candidate: String| {
+            let candidate = candidate.trim();
+            if !candidate.is_empty() && !candidates.iter().any(|kept| kept == candidate) {
+                candidates.push(candidate.to_string());
+            }
+        };
 
         if let Some(single) = resource_metadata.authorization_server {
-            candidates.push(single);
+            push_candidate(single);
         }
-        if let Some(list) = resource_metadata.authorization_servers {
-            candidates.extend(list);
+        for candidate in resource_metadata.authorization_servers.unwrap_or_default() {
+            push_candidate(candidate);
         }
 
         for candidate in candidates {
-            let candidate = candidate.trim();
-            if candidate.is_empty() {
-                continue;
-            }
-
-            let candidate_url = match Url::parse(candidate) {
+            let candidate_url = match Url::parse(&candidate) {
                 Ok(url) => url,
-                Err(_) => match resource_metadata_url.join(candidate) {
+                Err(_) => match resource_metadata_url.join(&candidate) {
                     Ok(url) => url,
                     Err(e) => {
                         debug!("Failed to resolve authorization server URL `{candidate}`: {e}");
@@ -5352,6 +5356,58 @@ mod tests {
             advertised_requests,
             1,
             "the url the challenge named was requested again as a candidate: {:?}",
+            recorder.requests()
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_requests_an_authorization_server_named_twice_once() {
+        let mut responses = vec![
+            // the MCP endpoint answers GET with a health payload, not metadata
+            http_response(
+                200,
+                serde_json::json!({"status": "healthy", "message": "MCP server is running"}),
+            ),
+            // the document names the same authorization server in both the singular
+            // draft field and the list
+            http_response(
+                200,
+                serde_json::json!({
+                    "resource": "https://mcp.example.com/",
+                    "authorization_server": "https://auth.example.com",
+                    "authorization_servers": ["https://auth.example.com"]
+                }),
+            ),
+        ];
+        // the authorization server publishes no metadata, so every form of its
+        // discovery url is tried before the run settles on the legacy endpoints
+        responses.extend(std::iter::repeat_with(|| empty_response(404)).take(10));
+        let client = RecordingOAuthHttpClient::with_responses(responses);
+        let recorder = client.clone();
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/",
+            Arc::new(client),
+        )
+        .await
+        .unwrap();
+
+        let resolution = manager.resolve_metadata().await.unwrap();
+
+        assert_eq!(
+            resolution.source,
+            AuthorizationMetadataSource::LegacyEndpointFallback
+        );
+        let discovery_requests = recorder
+            .requests()
+            .iter()
+            .filter(|request| {
+                request.uri == "https://auth.example.com/.well-known/oauth-authorization-server"
+            })
+            .count();
+        assert_eq!(
+            discovery_requests,
+            1,
+            "the authorization server was walked once per field naming it: {:?}",
             recorder.requests()
         );
     }

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2462,13 +2462,20 @@ impl AuthorizationManager {
     async fn discover_oauth_server_via_resource_metadata(
         &self,
     ) -> Result<Option<AuthorizationMetadata>, AuthError> {
-        let Some(resource_metadata_url) = self.discover_resource_metadata_url().await? else {
+        let Some((resource_metadata_url, resource_metadata)) =
+            self.discover_resource_metadata().await?
+        else {
             return Ok(None);
         };
-        self.discover_oauth_server_from_resource_metadata_url(&resource_metadata_url)
-            .await
+        self.authorization_metadata_from_resource_metadata(
+            &resource_metadata_url,
+            resource_metadata,
+        )
+        .await
     }
 
+    /// Read protected resource metadata from the url a `WWW-Authenticate`
+    /// challenge advertised.
     async fn discover_oauth_server_from_resource_metadata_url(
         &self,
         resource_metadata_url: &Url,
@@ -2480,6 +2487,17 @@ impl AuthorizationManager {
             return Ok(None);
         };
 
+        self.authorization_metadata_from_resource_metadata(resource_metadata_url, resource_metadata)
+            .await
+    }
+
+    /// Walk the authorization servers a protected resource metadata document
+    /// names, keeping the first one that answers with usable metadata.
+    async fn authorization_metadata_from_resource_metadata(
+        &self,
+        resource_metadata_url: &Url,
+        resource_metadata: ResourceServerMetadata,
+    ) -> Result<Option<AuthorizationMetadata>, AuthError> {
         self.validate_resource_metadata_resource(&resource_metadata)?;
 
         self.discovered_resource
@@ -2605,9 +2623,17 @@ impl AuthorizationManager {
                 || expected_path.as_bytes().get(actual_path.len()) == Some(&b'/'))
     }
 
-    async fn discover_resource_metadata_url(&self) -> Result<Option<Url>, AuthError> {
+    /// Look for the protected resource metadata document, reading it where it is
+    /// found so that a candidate answering with something else only costs that
+    /// candidate.
+    async fn discover_resource_metadata(
+        &self,
+    ) -> Result<Option<(Url, ResourceServerMetadata)>, AuthError> {
         if let Some(resource_metadata_url) = self.probe_resource_endpoint_for_challenge().await? {
-            return Ok(Some(resource_metadata_url));
+            return Ok(self
+                .fetch_resource_metadata_from_url(&resource_metadata_url)
+                .await?
+                .map(|metadata| (resource_metadata_url, metadata)));
         }
 
         // If the primary URL doesn't use WWW-Authenticate, try oauth-protected-resource discovery.
@@ -2615,14 +2641,38 @@ impl AuthorizationManager {
         for candidate_path in
             Self::well_known_paths(self.base_url.path(), "oauth-protected-resource")
         {
-            let mut discovery_url = self.base_url.clone();
-            discovery_url.set_query(None);
-            discovery_url.set_fragment(None);
-            discovery_url.set_path(&candidate_path);
-            if let Some(resource_metadata_url) =
-                self.probe_resource_metadata_url(&discovery_url).await?
-            {
-                return Ok(Some(resource_metadata_url));
+            let mut candidate_url = self.base_url.clone();
+            candidate_url.set_query(None);
+            candidate_url.set_fragment(None);
+            candidate_url.set_path(&candidate_path);
+
+            let response = self
+                .discovery_get(&candidate_url)
+                .await
+                .map_err(|error| Self::discovery_failed(&candidate_url, error))?;
+
+            match response.status() {
+                // The candidate url is the document itself, so read the body here
+                // instead of requesting the same url again.
+                StatusCode::OK => {
+                    if let Some(metadata) =
+                        Self::parse_resource_metadata(&candidate_url, response.body())
+                    {
+                        return Ok(Some((candidate_url, metadata)));
+                    }
+                }
+                StatusCode::UNAUTHORIZED => {
+                    if let Some(advertised_url) = self
+                        .extract_resource_metadata_url_from_www_authenticate(&response)
+                        .await
+                        && let Some(metadata) = self
+                            .fetch_resource_metadata_from_url(&advertised_url)
+                            .await?
+                    {
+                        return Ok(Some((advertised_url, metadata)));
+                    }
+                }
+                status => debug!("resource metadata probe returned unexpected status: {status}"),
             }
         }
 
@@ -2654,28 +2704,6 @@ impl AuthorizationManager {
             response.status()
         );
         Ok(None)
-    }
-
-    /// Probe a `.well-known` candidate with a GET, extracting the resource metadata
-    /// url from a 200 (the url itself is the metadata document) or from a 401's
-    /// WWW-Authenticate header value.
-    /// https://www.rfc-editor.org/rfc/rfc9728.html#name-obtaining-protected-resourc
-    async fn probe_resource_metadata_url(&self, url: &Url) -> Result<Option<Url>, AuthError> {
-        let response = self
-            .discovery_get(url)
-            .await
-            .map_err(|error| Self::discovery_failed(url, error))?;
-
-        match response.status() {
-            StatusCode::OK => Ok(Some(url.clone())),
-            StatusCode::UNAUTHORIZED => Ok(self
-                .extract_resource_metadata_url_from_www_authenticate(&response)
-                .await),
-            status => {
-                debug!("resource metadata probe returned unexpected status: {status}");
-                Ok(None)
-            }
-        }
     }
 
     async fn extract_resource_metadata_url_from_www_authenticate(
@@ -2719,11 +2747,21 @@ impl AuthorizationManager {
             return Ok(None);
         }
 
-        let metadata = match serde_json::from_slice::<ResourceServerMetadata>(response.body()) {
+        Ok(Self::parse_resource_metadata(
+            resource_metadata_url,
+            response.body(),
+        ))
+    }
+
+    fn parse_resource_metadata(
+        resource_metadata_url: &Url,
+        body: &[u8],
+    ) -> Option<ResourceServerMetadata> {
+        let metadata = match serde_json::from_slice::<ResourceServerMetadata>(body) {
             Ok(metadata) => metadata,
             Err(e) => {
                 debug!("failed to parse resource metadata as JSON: {}", e);
-                return Ok(None);
+                return None;
             }
         };
 
@@ -2731,8 +2769,8 @@ impl AuthorizationManager {
         // object deserializes into an all-`None` value and then fails validation
         // fatally. RFC 9728 requires `resource`, and MCP requires an authorization
         // server reference, so a document carrying neither is not a protected
-        // resource metadata document. Treat it as a soft failure, the same way this
-        // function already treats a non-200 status and a body that is not JSON.
+        // resource metadata document. Treat it as a soft failure, the same way a
+        // non-200 status and a body that is not JSON are treated.
         if metadata.resource.is_none()
             && metadata.authorization_server.is_none()
             && metadata.authorization_servers.is_none()
@@ -2740,10 +2778,10 @@ impl AuthorizationManager {
             debug!(
                 "response at {resource_metadata_url} is not a protected resource metadata document"
             );
-            return Ok(None);
+            return None;
         }
 
-        Ok(Some(metadata))
+        Some(metadata)
     }
 
     fn discovery_failed(url: &Url, error: OAuthHttpClientError) -> AuthError {
@@ -4369,13 +4407,6 @@ mod tests {
             http_response(
                 200,
                 serde_json::json!({
-                    "resource": "https://mcp.example.com/",
-                    "authorization_servers": ["https://auth.example.com/tenant1"]
-                }),
-            ),
-            http_response(
-                200,
-                serde_json::json!({
                     "issuer": "https://auth.example.com/tenant1",
                     "authorization_endpoint": "https://auth.example.com/tenant1/authorize",
                     "token_endpoint": "https://auth.example.com/tenant1/token"
@@ -4407,7 +4438,6 @@ mod tests {
                 vec![
                     "https://mcp.example.com/",
                     "https://mcp.example.com/.well-known/oauth-protected-resource",
-                    "https://mcp.example.com/.well-known/oauth-protected-resource",
                     "https://auth.example.com/.well-known/oauth-authorization-server/tenant1",
                 ],
             )
@@ -4418,13 +4448,6 @@ mod tests {
     async fn protected_resource_metadata_preserves_non_root_issuer_trailing_slash() {
         let client = RecordingOAuthHttpClient::with_responses(vec![
             empty_response(401),
-            http_response(
-                200,
-                serde_json::json!({
-                    "resource": "https://mcp.example.com/",
-                    "authorization_servers": ["https://auth.example.com/tenant1/"]
-                }),
-            ),
             http_response(
                 200,
                 serde_json::json!({
@@ -4897,24 +4920,20 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_metadata_reaches_the_well_known_document_past_a_non_metadata_base_url() {
-        let document = || {
-            http_response(
-                200,
-                serde_json::json!({
-                    "resource": "https://mcp.example.com/",
-                    "authorization_servers": ["https://auth.example.com"]
-                }),
-            )
-        };
         let client = RecordingOAuthHttpClient::with_responses(vec![
             // the MCP endpoint answers GET with a health payload, not metadata
             http_response(
                 200,
                 serde_json::json!({"status": "healthy", "message": "MCP server is running"}),
             ),
-            // the well-known candidate carries the real document: probed, then fetched
-            document(),
-            document(),
+            // the well-known candidate carries the real document
+            http_response(
+                200,
+                serde_json::json!({
+                    "resource": "https://mcp.example.com/",
+                    "authorization_servers": ["https://auth.example.com"]
+                }),
+            ),
             http_response(
                 200,
                 serde_json::json!({
@@ -4964,8 +4983,7 @@ mod tests {
         let client = RecordingOAuthHttpClient::with_responses(vec![
             // the MCP endpoint answers GET with a health payload, not metadata
             health(),
-            // so does the well-known candidate: probed, then fetched
-            health(),
+            // so does the well-known candidate
             health(),
             http_response(
                 200,
@@ -4994,6 +5012,71 @@ mod tests {
                 AuthorizationMetadataSource::AuthorizationServerMetadata,
                 "https://mcp.example.com/oauth/token",
             )
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_tries_the_next_well_known_candidate_past_a_non_metadata_document() {
+        let client = RecordingOAuthHttpClient::with_responses(vec![
+            // the MCP endpoint answers GET with a health payload, not metadata
+            http_response(
+                200,
+                serde_json::json!({"status": "healthy", "message": "MCP server is running"}),
+            ),
+            // so does the first well-known candidate
+            http_response(
+                200,
+                serde_json::json!({"status": "healthy", "message": "MCP server is running"}),
+            ),
+            // the second candidate carries the real document
+            http_response(
+                200,
+                serde_json::json!({
+                    "resource": "https://mcp.example.com/mcp",
+                    "authorization_servers": ["https://auth.example.com"]
+                }),
+            ),
+            http_response(
+                200,
+                serde_json::json!({
+                    "issuer": "https://auth.example.com",
+                    "authorization_endpoint": "https://auth.example.com/authorize",
+                    "token_endpoint": "https://auth.example.com/token"
+                }),
+            ),
+        ]);
+        let recorder = client.clone();
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/mcp",
+            Arc::new(client),
+        )
+        .await
+        .unwrap();
+
+        let resolution = manager.resolve_metadata().await.unwrap();
+
+        assert_eq!(
+            (
+                resolution.source,
+                resolution.metadata.token_endpoint.as_str(),
+            ),
+            (
+                AuthorizationMetadataSource::ProtectedResourceMetadata,
+                "https://auth.example.com/token",
+            )
+        );
+        let document_requests = recorder
+            .requests()
+            .iter()
+            .filter(|request| {
+                request.uri == "https://mcp.example.com/mcp/.well-known/oauth-protected-resource"
+            })
+            .count();
+        assert_eq!(
+            document_requests,
+            1,
+            "the candidate holding the document should be requested exactly once: {:?}",
+            recorder.requests()
         );
     }
 

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     future::Future,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     pin::Pin,
@@ -2645,17 +2645,25 @@ impl AuthorizationManager {
     async fn discover_resource_metadata(
         &self,
     ) -> Result<Option<(Url, ResourceServerMetadata)>, AuthError> {
-        if let Some(resource_metadata_url) = self.probe_resource_endpoint_for_challenge().await? {
-            return Ok(self
+        // A url the resource points at can also be one of the candidates below.
+        let mut requested = HashSet::new();
+
+        if let Some(advertised_url) = self.probe_resource_endpoint_for_challenge().await? {
+            requested.insert(advertised_url.clone());
+            if let Some(metadata) = self
                 .fetch_resource_metadata_from_url(
-                    &resource_metadata_url,
+                    &advertised_url,
                     ResourceMetadataUrlOrigin::Advertised,
                 )
                 .await?
-                .map(|metadata| (resource_metadata_url, metadata)));
+            {
+                return Ok(Some((advertised_url, metadata)));
+            }
+            // Nothing was published there. The candidates below are reached from the
+            // base url rather than from that pointer, so they are still worth trying.
         }
 
-        // If the primary URL doesn't use WWW-Authenticate, try oauth-protected-resource discovery.
+        // The other place the document can be is the well-known location.
         // https://www.rfc-editor.org/rfc/rfc9728.html#name-obtaining-protected-resourc
         for candidate_path in
             Self::well_known_paths(self.base_url.path(), "oauth-protected-resource")
@@ -2664,6 +2672,10 @@ impl AuthorizationManager {
             candidate_url.set_query(None);
             candidate_url.set_fragment(None);
             candidate_url.set_path(&candidate_path);
+
+            if !requested.insert(candidate_url.clone()) {
+                continue;
+            }
 
             let response = self
                 .discovery_get(&candidate_url)
@@ -2683,15 +2695,21 @@ impl AuthorizationManager {
                     }
                 }
                 StatusCode::UNAUTHORIZED => {
-                    if let Some(advertised_url) = self
+                    let Some(advertised_url) = self
                         .extract_resource_metadata_url_from_www_authenticate(&response)
                         .await
-                        && let Some(metadata) = self
-                            .fetch_resource_metadata_from_url(
-                                &advertised_url,
-                                ResourceMetadataUrlOrigin::Advertised,
-                            )
-                            .await?
+                    else {
+                        continue;
+                    };
+                    if !requested.insert(advertised_url.clone()) {
+                        continue;
+                    }
+                    if let Some(metadata) = self
+                        .fetch_resource_metadata_from_url(
+                            &advertised_url,
+                            ResourceMetadataUrlOrigin::Advertised,
+                        )
+                        .await?
                     {
                         return Ok(Some((advertised_url, metadata)));
                     }
@@ -5220,6 +5238,120 @@ mod tests {
                 request.uri == "https://mcp.example.com/mcp/.well-known/oauth-protected-resource"
             }),
             "the candidate after the rejected one was never probed: {:?}",
+            recorder.requests()
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_probes_the_candidates_past_an_advertised_url_that_is_not_served() {
+        let challenge = oauth2::http::Response::builder()
+            .status(401)
+            .header(
+                "www-authenticate",
+                r#"Bearer resource_metadata="https://mcp.example.com/prm""#,
+            )
+            .body(Vec::new())
+            .unwrap();
+        let client = RecordingOAuthHttpClient::with_responses(vec![
+            challenge,
+            // the advertised url is not where the document is served
+            empty_response(404),
+            // neither is the first candidate
+            empty_response(404),
+            // the second candidate carries the document
+            http_response(
+                200,
+                serde_json::json!({
+                    "resource": "https://mcp.example.com/mcp",
+                    "authorization_servers": ["https://auth.example.com"]
+                }),
+            ),
+            http_response(
+                200,
+                serde_json::json!({
+                    "issuer": "https://auth.example.com",
+                    "authorization_endpoint": "https://auth.example.com/authorize",
+                    "token_endpoint": "https://auth.example.com/token"
+                }),
+            ),
+        ]);
+        let recorder = client.clone();
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/mcp",
+            Arc::new(client),
+        )
+        .await
+        .unwrap();
+
+        let resolution = manager.resolve_metadata().await.unwrap();
+
+        assert_eq!(
+            (
+                resolution.source,
+                resolution.metadata.token_endpoint.as_str(),
+            ),
+            (
+                AuthorizationMetadataSource::ProtectedResourceMetadata,
+                "https://auth.example.com/token",
+            )
+        );
+        assert!(
+            recorder.requests().iter().any(|request| {
+                request.uri == "https://mcp.example.com/mcp/.well-known/oauth-protected-resource"
+            }),
+            "the candidates were skipped after the advertised url answered 404: {:?}",
+            recorder.requests()
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_requests_an_advertised_url_that_is_also_a_candidate_once() {
+        let challenge = oauth2::http::Response::builder()
+            .status(401)
+            .header(
+                "www-authenticate",
+                r#"Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource""#,
+            )
+            .body(Vec::new())
+            .unwrap();
+        let mut responses = vec![
+            // the MCP endpoint answers GET with a health payload, not metadata
+            http_response(
+                200,
+                serde_json::json!({"status": "healthy", "message": "MCP server is running"}),
+            ),
+            // the first candidate points at the last candidate of the same run
+            challenge,
+        ];
+        // the document is served nowhere, so the run walks every candidate and
+        // settles on the legacy endpoints
+        responses.extend(std::iter::repeat_with(|| empty_response(404)).take(10));
+        let client = RecordingOAuthHttpClient::with_responses(responses);
+        let recorder = client.clone();
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/mcp",
+            Arc::new(client),
+        )
+        .await
+        .unwrap();
+
+        let resolution = manager.resolve_metadata().await.unwrap();
+
+        assert_eq!(
+            resolution.source,
+            AuthorizationMetadataSource::LegacyEndpointFallback
+        );
+        let advertised_requests = recorder
+            .requests()
+            .iter()
+            .filter(|request| {
+                request.uri == "https://mcp.example.com/.well-known/oauth-protected-resource"
+            })
+            .count();
+        assert_eq!(
+            advertised_requests,
+            1,
+            "the url the challenge named was requested again as a candidate: {:?}",
             recorder.requests()
         );
     }

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -2701,6 +2701,23 @@ impl AuthorizationManager {
                 return Ok(None);
             }
         };
+
+        // Every field of `ResourceServerMetadata` is optional, so an unrelated JSON
+        // object deserializes into an all-`None` value and then fails validation
+        // fatally. RFC 9728 requires `resource`, and MCP requires an authorization
+        // server reference, so a document carrying neither is not a protected
+        // resource metadata document. Treat it as a soft failure, the same way this
+        // function already treats a non-200 status and a body that is not JSON.
+        if metadata.resource.is_none()
+            && metadata.authorization_server.is_none()
+            && metadata.authorization_servers.is_none()
+        {
+            debug!(
+                "response at {resource_metadata_url} is not a protected resource metadata document"
+            );
+            return Ok(None);
+        }
+
         Ok(Some(metadata))
     }
 
@@ -4823,6 +4840,49 @@ mod tests {
             empty_response(404),
             empty_response(404),
             empty_response(404),
+            http_response(
+                200,
+                serde_json::json!({
+                    "issuer": "https://mcp.example.com",
+                    "authorization_endpoint": "https://mcp.example.com/oauth/authorize",
+                    "token_endpoint": "https://mcp.example.com/oauth/token"
+                }),
+            ),
+        ]);
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/",
+            Arc::new(client),
+        )
+        .await
+        .unwrap();
+
+        let resolution = manager.resolve_metadata().await.unwrap();
+
+        assert_eq!(
+            (
+                resolution.source,
+                resolution.metadata.token_endpoint.as_str(),
+            ),
+            (
+                AuthorizationMetadataSource::AuthorizationServerMetadata,
+                "https://mcp.example.com/oauth/token",
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_ignores_non_metadata_json_at_the_base_url() {
+        let health = || {
+            http_response(
+                200,
+                serde_json::json!({"status": "healthy", "message": "MCP server is running"}),
+            )
+        };
+        let client = RecordingOAuthHttpClient::with_responses(vec![
+            // the MCP endpoint answers GET with a health payload, not metadata.
+            // The same URL is hit twice: once to probe, once to fetch the document.
+            health(),
+            health(),
             http_response(
                 200,
                 serde_json::json!({

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -635,6 +635,18 @@ struct ResourceServerMetadata {
     scopes_supported: Option<Vec<String>>,
 }
 
+/// How a url that may hold protected resource metadata was arrived at, which
+/// decides what a document that is not metadata means there.
+#[derive(Debug, Clone, Copy)]
+enum ResourceMetadataUrlOrigin {
+    /// The server named this url in the `resource_metadata` parameter of a
+    /// `WWW-Authenticate` challenge.
+    Advertised,
+    /// The url was derived from the base url, on the chance that the document is
+    /// published there.
+    WellKnownGuess,
+}
+
 /// Parameters extracted from WWW-Authenticate header
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
@@ -2481,7 +2493,10 @@ impl AuthorizationManager {
         resource_metadata_url: &Url,
     ) -> Result<Option<AuthorizationMetadata>, AuthError> {
         let Some(resource_metadata) = self
-            .fetch_resource_metadata_from_url(resource_metadata_url)
+            .fetch_resource_metadata_from_url(
+                resource_metadata_url,
+                ResourceMetadataUrlOrigin::Advertised,
+            )
             .await?
         else {
             return Ok(None);
@@ -2631,7 +2646,10 @@ impl AuthorizationManager {
     ) -> Result<Option<(Url, ResourceServerMetadata)>, AuthError> {
         if let Some(resource_metadata_url) = self.probe_resource_endpoint_for_challenge().await? {
             return Ok(self
-                .fetch_resource_metadata_from_url(&resource_metadata_url)
+                .fetch_resource_metadata_from_url(
+                    &resource_metadata_url,
+                    ResourceMetadataUrlOrigin::Advertised,
+                )
                 .await?
                 .map(|metadata| (resource_metadata_url, metadata)));
         }
@@ -2655,9 +2673,11 @@ impl AuthorizationManager {
                 // The candidate url is the document itself, so read the body here
                 // instead of requesting the same url again.
                 StatusCode::OK => {
-                    if let Some(metadata) =
-                        Self::parse_resource_metadata(&candidate_url, response.body())
-                    {
+                    if let Some(metadata) = Self::parse_resource_metadata(
+                        &candidate_url,
+                        response.body(),
+                        ResourceMetadataUrlOrigin::WellKnownGuess,
+                    )? {
                         return Ok(Some((candidate_url, metadata)));
                     }
                 }
@@ -2666,7 +2686,10 @@ impl AuthorizationManager {
                         .extract_resource_metadata_url_from_www_authenticate(&response)
                         .await
                         && let Some(metadata) = self
-                            .fetch_resource_metadata_from_url(&advertised_url)
+                            .fetch_resource_metadata_from_url(
+                                &advertised_url,
+                                ResourceMetadataUrlOrigin::Advertised,
+                            )
                             .await?
                     {
                         return Ok(Some((advertised_url, metadata)));
@@ -2729,6 +2752,7 @@ impl AuthorizationManager {
     async fn fetch_resource_metadata_from_url(
         &self,
         resource_metadata_url: &Url,
+        origin: ResourceMetadataUrlOrigin,
     ) -> Result<Option<ResourceServerMetadata>, AuthError> {
         debug!(
             "resource metadata discovery url: {:?}",
@@ -2747,21 +2771,19 @@ impl AuthorizationManager {
             return Ok(None);
         }
 
-        Ok(Self::parse_resource_metadata(
-            resource_metadata_url,
-            response.body(),
-        ))
+        Self::parse_resource_metadata(resource_metadata_url, response.body(), origin)
     }
 
     fn parse_resource_metadata(
         resource_metadata_url: &Url,
         body: &[u8],
-    ) -> Option<ResourceServerMetadata> {
+        origin: ResourceMetadataUrlOrigin,
+    ) -> Result<Option<ResourceServerMetadata>, AuthError> {
         let metadata = match serde_json::from_slice::<ResourceServerMetadata>(body) {
             Ok(metadata) => metadata,
             Err(e) => {
                 debug!("failed to parse resource metadata as JSON: {}", e);
-                return None;
+                return Ok(None);
             }
         };
 
@@ -2769,19 +2791,30 @@ impl AuthorizationManager {
         // object deserializes into an all-`None` value and then fails validation
         // fatally. RFC 9728 requires `resource`, and MCP requires an authorization
         // server reference, so a document carrying neither is not a protected
-        // resource metadata document. Treat it as a soft failure, the same way a
-        // non-200 status and a body that is not JSON are treated.
+        // resource metadata document.
         if metadata.resource.is_none()
             && metadata.authorization_server.is_none()
             && metadata.authorization_servers.is_none()
         {
-            debug!(
-                "response at {resource_metadata_url} is not a protected resource metadata document"
-            );
-            return None;
+            return match origin {
+                // The server named this url, so there is nothing better to move on
+                // to: the alternatives all drop the resource binding the document
+                // was supposed to carry. Report it instead.
+                ResourceMetadataUrlOrigin::Advertised => Err(AuthError::MetadataError(format!(
+                    "the server advertised {resource_metadata_url} as protected resource metadata, but the document carries neither `resource` nor an authorization server reference"
+                ))),
+                // Nothing advertised this url, so its answer only rules out this
+                // candidate.
+                ResourceMetadataUrlOrigin::WellKnownGuess => {
+                    debug!(
+                        "response at {resource_metadata_url} is not a protected resource metadata document"
+                    );
+                    Ok(None)
+                }
+            };
         }
 
-        Some(metadata)
+        Ok(Some(metadata))
     }
 
     fn discovery_failed(url: &Url, error: OAuthHttpClientError) -> AuthError {
@@ -5077,6 +5110,33 @@ mod tests {
             1,
             "the candidate holding the document should be requested exactly once: {:?}",
             recorder.requests()
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_from_challenge_reports_an_advertised_url_without_metadata() {
+        let mut responses = vec![http_response(200, serde_json::json!({}))];
+        // enough responses for the fallback to reach the legacy endpoints, so that
+        // treating the document as a soft failure would resolve rather than error
+        responses.extend(std::iter::repeat_with(|| empty_response(404)).take(8));
+        let client = RecordingOAuthHttpClient::with_responses(responses);
+        let manager = AuthorizationManager::new_with_oauth_http_client(
+            "https://mcp.example.com/mcp",
+            Arc::new(client),
+        )
+        .await
+        .unwrap();
+
+        let error = manager
+            .resolve_metadata_from_challenge(Some(
+                r#"Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource""#,
+            ))
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Metadata error: the server advertised https://mcp.example.com/.well-known/oauth-protected-resource as protected resource metadata, but the document carries neither `resource` nor an authorization server reference"
         );
     }
 


### PR DESCRIPTION
## Why

`AuthorizationManager` probes its base URL first when looking for RFC 9728 protected resource metadata, and `probe_resource_metadata_url` treats any `200` there as "this URL is the metadata document". `ResourceServerMetadata` has only optional fields, so an unrelated JSON object deserializes into an all-`None` value, and `validate_resource_metadata_resource` then fails hard with `Protected resource metadata missing required resource field`. The error propagates out of `resolve_metadata()`, so the `.well-known` fallbacks on the following lines never run.

Servers that answer `GET /` with a JSON health payload hit this. Against `https://mcp.tavily.com` today:

```
GET https://mcp.tavily.com/
200 application/json  {"status":"healthy","message":"MCP server is running"}

GET https://mcp.tavily.com/.well-known/oauth-protected-resource
404

GET https://mcp.tavily.com/.well-known/oauth-protected-resource/mcp
200 {"resource":"https://mcp.tavily.com/mcp",
     "authorization_servers":["https://mcp.tavily.com/"],
     "scopes_supported":["openid","offline_access"],
     "bearer_methods_supported":["header"]}

GET https://mcp.tavily.com/.well-known/oauth-authorization-server
200 {"issuer":"https://mcp.tavily.com/","authorization_endpoint":"https://mcp.tavily.com/authorize",
     "token_endpoint":"https://mcp.tavily.com/token","registration_endpoint":"https://mcp.tavily.com/register"}
```

The server publishes valid metadata at both well-known locations, using the RFC 9728 path-insertion form. `resolve_metadata()` still returns `Metadata error: Protected resource metadata missing required resource field`, because it stops at the health payload and never reaches either. The workaround is to configure the endpoint path rather than the host, which is not always what the caller has.

This is the JSON-object half of #810. That PR made a non-JSON body at the base URL a soft failure so discovery could continue. A JSON body that is not a metadata document still deserializes, so it takes the hard path instead.

Sampling the origin root of 36 reachable public remote MCP servers, 18 answer `200`. All 18 are currently read as "this URL is the protected resource metadata document"; 17 of them escape only because their body is HTML or markdown rather than a JSON object.

## Standards

RFC 9728 [Section 3](https://datatracker.ietf.org/doc/html/rfc9728#section-3) requires the metadata document to live at a URL formed by inserting a well-known URI string into the resource identifier, and [Section 5.1](https://datatracker.ietf.org/doc/html/rfc9728#section-5.1) lets a `401` point at it through `WWW-Authenticate`. The [2026-07-28 authorization server discovery requirements](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/authorization-server-discovery) list the same two mechanisms and no others. The resource URL itself is not a metadata location under either, so a `200` from it carries no metadata claim.

RFC 9728 [Section 3.2](https://datatracker.ietf.org/doc/html/rfc9728#section-3.2) allows additional members in the document, so tightening deserialization is not an option here: real documents carry fields this struct does not model, including the `bearer_methods_supported` in the Tavily document above.

## What this changes

`fetch_resource_metadata_from_url` returns `Ok(None)` when the parsed document has none of `resource`, `authorization_server`, or `authorization_servers`, with a `debug!` line, matching how the same function already handles a non-200 status and a body that is not JSON. Discovery then continues to the well-known paths and to authorization server metadata.

A document carrying any of those fields still goes through `validate_resource_metadata_resource` unchanged, so a server that advertises a metadata URL through `WWW-Authenticate` and serves a malformed document there still gets a hard error. `protected_resource_discovery_rejects_missing_resource` and `protected_resource_discovery_rejects_mismatched_resource` both reach the document through an explicit challenge pointer, and both stay green.

## Alternative

The narrower reading is that the base URL should never be treated as a metadata location at all, only as a source of a `WWW-Authenticate` challenge. That is what the TypeScript SDK does: `discoverOAuthProtectedResourceMetadata` only ever fetches `/.well-known/oauth-protected-resource{path}` or a URL taken from the challenge. Scoping the `StatusCode::OK` arm of `probe_resource_metadata_url` to the well-known probe would have the same effect here, and no existing test covers the base-URL-200 path, so that shape stays green too. I went with the document-shape check because it keeps working for servers that do serve metadata at the endpoint itself. Happy to send the other shape instead if you prefer it.

## Test plan

`resolve_metadata_ignores_non_metadata_json_at_the_base_url` mirrors `resolve_metadata_reports_authorization_server_metadata`, with the base URL answering a health payload twice instead of `404`: once for the probe, once for the fetch, which is what a real server does. Before the change it fails with

```
called `Result::unwrap()` on an `Err` value: MetadataError("Protected resource metadata missing required resource field")
```

and after it passes.

```
cargo +nightly fmt --all
cargo clippy --all-targets --all-features -- -D warnings
cargo test -p rmcp --lib --features auth
```

`cargo test -p rmcp --lib --features auth` reports `373 passed; 1 failed`. The one failure is `default_http_client_preserves_connection_failure_cause`, which asserts on an OS connection-refused string and fails the same way on an unmodified checkout of this branch point on a non-English Windows host.
