### PR TITLE
fix(transport): fall back after sessionless HTTP discover rejections

### DIFF
--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -293,6 +293,9 @@ impl StreamableHttpClient for reqwest::Client {
                     ),
                 }
             }
+            if let Some(response) = legacy_discover_response(&message, status, &body) {
+                return Ok(response);
+            }
             return Err(StreamableHttpError::UnexpectedServerResponse(Cow::Owned(
                 format!("HTTP {status}: {body}"),
             )));

--- a/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/common/reqwest/streamable_http_client.rs
@@ -293,7 +293,9 @@ impl StreamableHttpClient for reqwest::Client {
                     ),
                 }
             }
-            if let Some(response) = legacy_discover_response(&message, status, &body) {
+            if let Some(response) =
+                legacy_discover_response(&message, session_was_attached, status, &body)
+            {
                 return Ok(response);
             }
             return Err(StreamableHttpError::UnexpectedServerResponse(Cow::Owned(

--- a/crates/rmcp/src/transport/common/unix_socket.rs
+++ b/crates/rmcp/src/transport/common/unix_socket.rs
@@ -274,6 +274,9 @@ impl StreamableHttpClient for UnixSocketHttpClient {
                 .await
                 .map(|c| String::from_utf8_lossy(&c.to_bytes()).into_owned())
                 .unwrap_or_else(|_| "<failed to read response body>".to_owned());
+            if let Some(response) = legacy_discover_response(&message, status, &body) {
+                return Ok(response);
+            }
             return Err(StreamableHttpError::UnexpectedServerResponse(Cow::Owned(
                 format!("HTTP {status}: {body}"),
             )));

--- a/crates/rmcp/src/transport/common/unix_socket.rs
+++ b/crates/rmcp/src/transport/common/unix_socket.rs
@@ -274,7 +274,9 @@ impl StreamableHttpClient for UnixSocketHttpClient {
                 .await
                 .map(|c| String::from_utf8_lossy(&c.to_bytes()).into_owned())
                 .unwrap_or_else(|_| "<failed to read response body>".to_owned());
-            if let Some(response) = legacy_discover_response(&message, status, &body) {
+            if let Some(response) =
+                legacy_discover_response(&message, session_was_attached, status, &body)
+            {
                 return Ok(response);
             }
             return Err(StreamableHttpError::UnexpectedServerResponse(Cow::Owned(

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -341,10 +341,12 @@ impl StreamableHttpPostResponse {
 /// Keep authentication failures and server errors on their original paths.
 pub(super) fn legacy_discover_response(
     message: &ClientJsonRpcMessage,
+    session_was_attached: bool,
     status: StatusCode,
     body: &str,
 ) -> Option<StreamableHttpPostResponse> {
-    if !status.is_client_error()
+    if session_was_attached
+        || !status.is_client_error()
         || matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN)
     {
         return None;

--- a/crates/rmcp/src/transport/streamable_http_client.rs
+++ b/crates/rmcp/src/transport/streamable_http_client.rs
@@ -10,7 +10,7 @@ use futures::{
     future::BoxFuture,
     stream::{BoxStream, FuturesUnordered},
 };
-use http::{HeaderName, HeaderValue};
+use http::{HeaderName, HeaderValue, StatusCode};
 pub use sse_stream::Error as SseError;
 use sse_stream::Sse;
 use thiserror::Error;
@@ -330,6 +330,41 @@ impl StreamableHttpPostResponse {
             )),
         }
     }
+}
+
+/// Convert a sessionless discovery rejection into a response the lifecycle
+/// layer can classify as a legacy-server signal.
+///
+/// Some legacy streamable-HTTP servers reject `server/discover` in middleware
+/// before it reaches JSON-RPC dispatch. Their response may be an empty or
+/// plain-text 4xx, so there is no JSON-RPC error for the client to forward.
+/// Keep authentication failures and server errors on their original paths.
+pub(super) fn legacy_discover_response(
+    message: &ClientJsonRpcMessage,
+    status: StatusCode,
+    body: &str,
+) -> Option<StreamableHttpPostResponse> {
+    if !status.is_client_error()
+        || matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN)
+    {
+        return None;
+    }
+
+    let ClientJsonRpcMessage::Request(request) = message else {
+        return None;
+    };
+    if !matches!(request.request, ClientRequest::DiscoverRequest(_)) {
+        return None;
+    }
+
+    let error = ErrorData::invalid_request(
+        format!("server/discover rejected with HTTP {status}: {body}"),
+        None,
+    );
+    Some(StreamableHttpPostResponse::Json(
+        ServerJsonRpcMessage::error(error, Some(request.id.clone())),
+        None,
+    ))
 }
 
 /// HTTP backend used by [`StreamableHttpClientTransport`].

--- a/crates/rmcp/tests/test_discover_http_client_startup.rs
+++ b/crates/rmcp/tests/test_discover_http_client_startup.rs
@@ -5,7 +5,17 @@
     feature = "transport-streamable-http-server"
 ))]
 
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
+
+use axum::{
+    Router,
+    body::{Body, Bytes},
+    extract::State,
+    http::{Response, StatusCode},
+    routing::post,
+};
+use serde_json::json;
+use tokio::sync::Mutex;
 
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt, ServerHandler,
@@ -44,6 +54,54 @@ impl ServerHandler for LegacyHttpServer {
             None,
         )))
     }
+}
+
+#[derive(Clone, Default)]
+struct PlainTextLegacyHttpState {
+    methods: Arc<Mutex<Vec<String>>>,
+}
+
+async fn plain_text_legacy_http_handler(
+    State(state): State<PlainTextLegacyHttpState>,
+    body: Bytes,
+) -> Response<Body> {
+    let request: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON-RPC body");
+    let method = request["method"]
+        .as_str()
+        .expect("request method")
+        .to_owned();
+    state.methods.lock().await.push(method.clone());
+
+    if method == "server/discover" {
+        return Response::builder()
+            .status(StatusCode::UNPROCESSABLE_ENTITY)
+            .body(Body::from("Unexpected message, expect initialize request"))
+            .expect("build rejection response");
+    }
+
+    if method == "initialize" {
+        return Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request["id"],
+                    "result": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "serverInfo": {"name": "legacy", "version": "1.0"}
+                    }
+                })
+                .to_string(),
+            ))
+            .expect("build initialize response");
+    }
+
+    Response::builder()
+        .status(StatusCode::ACCEPTED)
+        .body(Body::empty())
+        .expect("build notification response")
 }
 
 #[tokio::test]
@@ -132,6 +190,50 @@ async fn auto_http_client_falls_back_to_stateful_legacy_startup() {
     client.list_tools(None).await.expect("list tools");
     client.cancel().await.expect("cancel client");
 
+    ct.cancel();
+    server.await.expect("server task");
+}
+
+#[tokio::test]
+async fn auto_http_client_falls_back_after_plain_text_4xx_rejection() {
+    let ct = CancellationToken::new();
+    let state = PlainTextLegacyHttpState::default();
+    let methods = state.methods.clone();
+    let router = Router::new()
+        .route("/mcp", post(plain_text_legacy_http_handler))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener should bind");
+    let address = listener.local_addr().expect("listener address");
+    let server = tokio::spawn({
+        let ct = ct.clone();
+        async move {
+            let _ = axum::serve(listener, router)
+                .with_graceful_shutdown(async move { ct.cancelled_owned().await })
+                .await;
+        }
+    });
+
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("http://{address}/mcp")),
+    );
+    let client = ClientInfo::default()
+        .serve_with_lifecycle(
+            transport,
+            ClientLifecycleMode::Auto {
+                preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+                legacy_version: Some(ProtocolVersion::V_2025_11_25),
+            },
+        )
+        .await
+        .expect("auto HTTP client should fall back after a transport-level rejection");
+    client.cancel().await.expect("cancel client");
+
+    assert_eq!(
+        methods.lock().await.as_slice(),
+        &["server/discover", "initialize", "notifications/initialized"]
+    );
     ct.cancel();
     server.await.expect("server task");
 }

--- a/crates/rmcp/tests/test_discover_http_client_startup.rs
+++ b/crates/rmcp/tests/test_discover_http_client_startup.rs
@@ -14,9 +14,6 @@ use axum::{
     http::{Response, StatusCode},
     routing::post,
 };
-use serde_json::json;
-use tokio::sync::Mutex;
-
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt, ServerHandler,
     model::{ClientInfo, DiscoverResult, ErrorCode, ErrorData, ProtocolVersion},
@@ -29,6 +26,8 @@ use rmcp::{
         },
     },
 };
+use serde_json::json;
+use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Clone, Default)]

--- a/crates/rmcp/tests/test_streamable_http_4xx_error_body.rs
+++ b/crates/rmcp/tests/test_streamable_http_4xx_error_body.rs
@@ -7,7 +7,10 @@
 use std::{collections::HashMap, sync::Arc};
 
 use rmcp::{
-    model::{ClientJsonRpcMessage, ClientRequest, PingRequest, RequestId},
+    model::{
+        ClientJsonRpcMessage, ClientRequest, DiscoverRequest, DiscoverRequestParams, PingRequest,
+        RequestId,
+    },
     transport::streamable_http_client::{
         StreamableHttpClient, StreamableHttpError, StreamableHttpPostResponse,
     },
@@ -41,6 +44,13 @@ async fn spawn_mock_server(status: u16, content_type: &'static str, body: &'stat
 fn ping_message() -> ClientJsonRpcMessage {
     ClientJsonRpcMessage::request(
         ClientRequest::PingRequest(PingRequest::default()),
+        RequestId::Number(1),
+    )
+}
+
+fn discover_message() -> ClientJsonRpcMessage {
+    ClientJsonRpcMessage::request(
+        ClientRequest::DiscoverRequest(DiscoverRequest::new(DiscoverRequestParams {})),
         RequestId::Number(1),
     )
 }
@@ -109,6 +119,29 @@ async fn http_4xx_malformed_json_body_falls_back_to_unexpected_server_response()
             Arc::from(url.as_str()),
             ping_message(),
             None,
+            None,
+            HashMap::new(),
+        )
+        .await;
+
+    match result {
+        Err(StreamableHttpError::UnexpectedServerResponse(_)) => {}
+        other => panic!("expected UnexpectedServerResponse, got: {other:?}"),
+    }
+}
+
+/// A discovery request attached to an existing session must retain the
+/// transport error path; legacy fallback only applies to sessionless probes.
+#[tokio::test]
+async fn sessionful_discover_4xx_does_not_trigger_legacy_fallback() {
+    let url = spawn_mock_server(422, "text/plain", "Session-bound rejection").await;
+
+    let client = reqwest::Client::new();
+    let result = client
+        .post_message(
+            Arc::from(url.as_str()),
+            discover_message(),
+            Some(Arc::from("session-1")),
             None,
             HashMap::new(),
         )


### PR DESCRIPTION
## Summary

Some legacy streamable-HTTP servers reject `server/discover` in middleware with an empty or plain-text 4xx response before JSON-RPC dispatch. That prevents `ClientLifecycleMode::Auto` from reaching the legacy `initialize` path.

This change:

- Converts only sessionless `server/discover` client-error responses into a correlated `INVALID_REQUEST` response for the existing lifecycle classifier.
- Preserves 401/403 responses, 5xx responses, existing-session failures, and non-discover requests as transport errors.
- Applies the fallback to both the reqwest and Unix socket HTTP clients.
- Adds regressions for plain-text 4xx fallback and the sessionful discovery boundary.

This addresses #1040. It is complementary to #1141, which handles JSON-RPC error responses; this change covers transport-level empty, malformed, and non-JSON 4xx responses.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p rmcp --test test_streamable_http_4xx_error_body --features client,reqwest,transport-streamable-http-client-reqwest,transport-streamable-http-server`
- `cargo test -p rmcp --test test_discover_http_client_startup --features client,reqwest,transport-streamable-http-client-reqwest,transport-streamable-http-server`
- `cargo test -p rmcp --test test_unix_socket_transport --features client,server,transport-streamable-http-client-unix-socket`
- `cargo test -p rmcp --features client,server,reqwest,transport-io,transport-streamable-http-client-reqwest,transport-streamable-http-server` (296 unit tests, all integration tests, and 39 non-ignored doctests)

## Breaking Changes

None.