### PR TITLE
ci: pin commitlint dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,10 @@ jobs:
           node-version: '22'
           
       - name: Install commitlint
-        run: |
-          npm install --save-dev @commitlint/cli @commitlint/config-conventional
-          echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
-          
+        run: npm install --global @commitlint/cli@20.4.3 @commitlint/config-conventional@20.4.3
+
       - name: Lint commit messages
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        run: commitlint --extends @commitlint/config-conventional --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
   fmt:
     name: Code Formatting


### PR DESCRIPTION
## Summary

Pins the commitlint CLI and conventional configuration to exact versions in CI instead of resolving the latest packages at runtime. The configuration is supplied through `--extends`, avoiding the need to introduce an npm project in this Rust repository.

Addresses the npm dependency finding tracked in #1215.
