### PR TITLE
ci: default workflow tokens to read-only contents

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -3,6 +3,9 @@ on:
   # Runs workflow when activity on a PR in the workflow's repository occurs.
   pull_request_target:
 
+permissions:
+  contents: read
+
 jobs:
   auto-label:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ env:
   CARGO_TERM_COLOR: always
   ARTIFACT_DIR: release-artifacts
 
+permissions:
+  contents: read
+
 jobs:
   commit-lint:
     name: Lint Commit Messages

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 0 * * 1' # Weekly on Monday
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -14,6 +14,9 @@ concurrency:
 env:
   CONFORMANCE_VERSION: "0.2.0-alpha.10"
 
+permissions:
+  contents: read
+
 jobs:
   server:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     name: Clean Up


### PR DESCRIPTION
## Summary

Sets an explicit read-only `contents` permission default on workflows that previously relied on GitHub's repository-level token defaults. This allows checkout—including in the crates.io release job—while preventing implicit write access. Existing job-level grants remain unchanged for jobs that require additional permissions.

Addresses the default token-permission findings tracked in #1215. Release-plz and the coverage job's explicit write permissions are reviewed separately.
