### PR TITLE
ci: remove coverage job write permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary

Changes the coverage job's `GITHUB_TOKEN` permission from `contents: write` to `contents: read`. The job checks out code and computes coverage locally; it does not write repository contents.

Addresses the CI write-permission finding tracked in #1215.
