### PR TITLE
ci: scope release token permissions to jobs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,8 +1,6 @@
 name: Release-plz
 
-permissions:
-  pull-requests: write
-  contents: write
+permissions: {}
 
 on:
   push:
@@ -18,6 +16,7 @@ jobs:
     if: ${{ github.repository_owner == 'modelcontextprotocol' }}
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Removes workflow-wide write access from `release-plz.yml` and defaults the workflow token to no permissions. Each job now receives only the permissions documented by release-plz:

- `release-plz release`: `contents: write`, `pull-requests: read`
- `release-plz release-pr`: `contents: write`, `pull-requests: write`

Addresses the release token-permission finding tracked in #1215.
