### PR TITLE
ci: pin release-plz fork revision

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,7 +30,7 @@ jobs:
       # Using fork until semver_check_features support is released upstream.
       # See: https://github.com/release-plz/release-plz/pull/2757
       - name: Install release-plz from fork
-        run: cargo install --locked --git https://github.com/DaleSeo/release-plz --branch feat/semver-check-features release-plz
+        run: cargo install --locked --git https://github.com/DaleSeo/release-plz --rev c2ea743bacf9bbd56e344df68219e60b0ad35d04 release-plz
       - name: Run release-plz release
         run: release-plz release
         env:
@@ -61,7 +61,7 @@ jobs:
       # Using fork until semver_check_features support is released upstream.
       # See: https://github.com/release-plz/release-plz/pull/2757
       - name: Install release-plz from fork
-        run: cargo install --locked --git https://github.com/DaleSeo/release-plz --branch feat/semver-check-features release-plz
+        run: cargo install --locked --git https://github.com/DaleSeo/release-plz --rev c2ea743bacf9bbd56e344df68219e60b0ad35d04 release-plz
       - name: Run release-plz release-pr
         run: release-plz release-pr
         env:


### PR DESCRIPTION
## Summary

Pins the temporary release-plz fork dependency to an exact commit instead of resolving the mutable `feat/semver-check-features` branch at release time.

Pinned revision: `c2ea743bacf9bbd56e344df68219e60b0ad35d04`

Follow-up to the dependency hardening tracked in #1215.
