### PR TITLE
fix: map HeaderMismatch to HTTP 400

### DIFF
--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -618,12 +618,13 @@ fn jsonrpc_http_status(message: &ServerJsonRpcMessage) -> http::StatusCode {
     let ServerJsonRpcMessage::Error(error) = message else {
         return http::StatusCode::OK;
     };
-    // Modern per-request HTTP treats invalid params as a malformed request.
+    // Modern per-request HTTP treats protocol validation failures as malformed requests.
     // Legacy requests bypass this mapper and retain HTTP 200 JSON-RPC errors.
     match error.error.code {
         ErrorCode::UNSUPPORTED_PROTOCOL_VERSION
         | ErrorCode::MISSING_REQUIRED_CLIENT_CAPABILITY
-        | ErrorCode::INVALID_PARAMS => http::StatusCode::BAD_REQUEST,
+        | ErrorCode::INVALID_PARAMS
+        | ErrorCode::HEADER_MISMATCH => http::StatusCode::BAD_REQUEST,
         ErrorCode::METHOD_NOT_FOUND => http::StatusCode::NOT_FOUND,
         _ => http::StatusCode::OK,
     }

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -639,12 +639,13 @@ fn jsonrpc_http_status(message: &ServerJsonRpcMessage) -> http::StatusCode {
     let ServerJsonRpcMessage::Error(error) = message else {
         return http::StatusCode::OK;
     };
-    // Modern per-request HTTP treats invalid params as a malformed request.
+    // Modern per-request HTTP treats protocol validation failures as malformed requests.
     // Legacy requests bypass this mapper and retain HTTP 200 JSON-RPC errors.
     match error.error.code {
         ErrorCode::UNSUPPORTED_PROTOCOL_VERSION
         | ErrorCode::MISSING_REQUIRED_CLIENT_CAPABILITY
-        | ErrorCode::INVALID_PARAMS => http::StatusCode::BAD_REQUEST,
+        | ErrorCode::INVALID_PARAMS
+        | ErrorCode::HEADER_MISMATCH => http::StatusCode::BAD_REQUEST,
         ErrorCode::METHOD_NOT_FOUND => http::StatusCode::NOT_FOUND,
         _ => http::StatusCode::OK,
     }

--- a/crates/rmcp/tests/test_streamable_http_json_response.rs
+++ b/crates/rmcp/tests/test_streamable_http_json_response.rs
@@ -34,6 +34,23 @@ const NEGOTIATED_CALL_BODY: &str = r#"{
         }
     }
 }"#;
+const NEGOTIATED_HEADER_MISMATCH_BODY: &str = r#"{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/call",
+    "params": {
+        "name": "header-mismatch",
+        "arguments": {},
+        "_meta": {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": {
+                "name": "test",
+                "version": "1.0"
+            },
+            "io.modelcontextprotocol/clientCapabilities": {}
+        }
+    }
+}"#;
 const NEGOTIATED_CALL_WITH_PROGRESS_BODY: &str = r#"{
     "jsonrpc": "2.0",
     "id": 2,
@@ -66,6 +83,12 @@ impl ServerHandler for ProgressServer {
         request: CallToolRequestParams,
         context: RequestContext<rmcp::RoleServer>,
     ) -> Result<CallToolResponse, ErrorData> {
+        if request.name == "header-mismatch" {
+            return Err(ErrorData::header_mismatch(
+                "header does not match request parameter",
+                None,
+            ));
+        }
         if request.name == "progress" {
             let progress_token = context
                 .meta
@@ -215,6 +238,38 @@ async fn stateless_negotiated_terminal_response_returns_application_json() -> an
     let body: serde_json::Value = response.json().await?;
     assert_eq!(body["id"], 2);
     assert!(body["result"].is_object(), "Expected result object");
+
+    ct.cancel();
+    Ok(())
+}
+
+#[tokio::test]
+async fn stateless_negotiated_header_mismatch_returns_bad_request() -> anyhow::Result<()> {
+    let ct = CancellationToken::new();
+    let (client, url, ct) = spawn_progress_server(
+        StreamableHttpServerConfig::default()
+            .with_legacy_session_mode(false)
+            .with_json_response(true)
+            .with_sse_keep_alive(None)
+            .with_cancellation_token(ct.child_token()),
+    )
+    .await;
+
+    let response = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "tools/call")
+        .header("Mcp-Name", "header-mismatch")
+        .body(NEGOTIATED_HEADER_MISMATCH_BODY)
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), 400);
+    let body: serde_json::Value = response.json().await?;
+    assert_eq!(body["id"], 3);
+    assert_eq!(body["error"]["code"], -32020);
 
     ct.cancel();
     Ok(())

--- a/crates/rmcp/tests/test_streamable_http_json_response.rs
+++ b/crates/rmcp/tests/test_streamable_http_json_response.rs
@@ -243,13 +243,17 @@ async fn stateless_negotiated_terminal_response_returns_application_json() -> an
     Ok(())
 }
 
+#[rstest::rstest]
 #[tokio::test]
-async fn stateless_negotiated_header_mismatch_returns_bad_request() -> anyhow::Result<()> {
+async fn stateless_negotiated_header_mismatch_returns_bad_request(
+    #[values(false, true)] json_response: bool,
+    #[values(false, true)] legacy_session_mode: bool,
+) -> anyhow::Result<()> {
     let ct = CancellationToken::new();
     let (client, url, ct) = spawn_progress_server(
         StreamableHttpServerConfig::default()
-            .with_legacy_session_mode(false)
-            .with_json_response(true)
+            .with_legacy_session_mode(legacy_session_mode)
+            .with_json_response(json_response)
             .with_sse_keep_alive(None)
             .with_cancellation_token(ct.child_token()),
     )
@@ -267,9 +271,14 @@ async fn stateless_negotiated_header_mismatch_returns_bad_request() -> anyhow::R
         .await?;
 
     assert_eq!(response.status(), 400);
+    assert_eq!(response.headers()["content-type"], "application/json");
     let body: serde_json::Value = response.json().await?;
     assert_eq!(body["id"], 3);
     assert_eq!(body["error"]["code"], -32020);
+    assert_eq!(
+        body["error"]["message"],
+        "header does not match request parameter"
+    );
 
     ct.cancel();
     Ok(())


### PR DESCRIPTION
Map handler-generated JSON-RPC `HeaderMismatch` errors (`-32020`) to HTTP 400 on the modern per-request Streamable HTTP path. Add integration coverage for valid `2026-07-28` requests reaching a handler, with JSON responses and legacy session support each enabled and disabled. Verify HTTP status, JSON content type, request ID, error code, and the handler-generated message.

Fixes #1225.

## Motivation and Context

The MCP 2026-07-28 Streamable HTTP server-validation rules require header-validation failures to return HTTP 400 with JSON-RPC error code `-32020`.

RMCP already returns that combination when its transport detects a mismatch before dispatch. However, when application validation returns `ErrorData::header_mismatch(...)` from a `ServerHandler`, the response flows through `jsonrpc_http_status`, where `HEADER_MISMATCH` previously fell through to HTTP 200.

This change adds `HEADER_MISMATCH` to the modern bad-request mapping. Legacy requests continue to bypass this mapper and retain their existing HTTP 200 JSON-RPC behavior.

Specification:

https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http#server-validation

## How Has This Been Tested?

Rebased onto main at `e27c5d1`. All four regression configurations fail with HTTP 200 instead of 400 when the mapping is removed, and pass with the fix restored.

Ran:

```text
cargo test -p rmcp --test test_streamable_http_json_response --test test_streamable_http_standard_headers --test test_streamable_http_protocol_version --test test_stateless_protocol_version --features server,client,transport-streamable-http-server,reqwest
cargo clippy -p rmcp --all-features --all-targets -- -D warnings
cargo fmt --all -- --check
git diff --check
```

Results: 49 focused tests passed. The 10-test JSON response suite also passed again after restoring the mapping. Clippy, formatting, and whitespace checks passed. Stable rustfmt emitted the repository's existing warnings for nightly-only configuration options.

## Breaking Changes

None. This corrects the HTTP status for an existing modern JSON-RPC error response. The JSON-RPC error code and legacy response behavior are unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Related transport-level validation paths already construct HTTP 400 responses directly. The new test specifically covers a `HeaderMismatch` returned after handler dispatch.
