### PR TITLE
fix: keep initialize on legacy protocol versions

### DIFF
--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -322,12 +322,15 @@ macro_rules! server_handler_methods {
         ) -> impl Future<Output = Result<InitializeResult, McpError>> + MaybeSendFuture + '_ {
             context.peer.set_peer_info(request.clone());
             let mut info = self.get_info();
-            info.protocol_version = negotiate_protocol_version(
+            let negotiated = negotiate_protocol_version(
                 &request.protocol_version,
-                info.protocol_version,
+                std::mem::take(&mut info.protocol_version),
                 &self.supported_protocol_versions(),
             );
-            std::future::ready(Ok(info))
+            std::future::ready(negotiated.map(|version| {
+                info.protocol_version = version;
+                info
+            }))
         }
         /// Return the protocol versions supported by this server.
         ///

--- a/crates/rmcp/src/service.rs
+++ b/crates/rmcp/src/service.rs
@@ -193,12 +193,17 @@ pub enum PeerRequestAssociation {
     Unknown { has_pending_outbound_request: bool },
 }
 
+/// Whether `version` predates `2026-07-28`, the revision that replaced the
+/// `initialize` handshake with per-request metadata.
+pub(crate) fn is_legacy_version(version: &ProtocolVersion) -> bool {
+    version.as_str() < ProtocolVersion::V_2026_07_28.as_str()
+}
+
 pub(crate) fn uses_legacy_lifecycle(
     protocol_version: Option<&ProtocolVersion>,
     uses_discover_lifecycle: bool,
 ) -> bool {
-    !uses_discover_lifecycle
-        && protocol_version.is_none_or(|version| version < &ProtocolVersion::V_2026_07_28)
+    !uses_discover_lifecycle && protocol_version.is_none_or(is_legacy_version)
 }
 
 pub(crate) fn peer_request_association<Req: crate::model::GetExtensions, V>(

--- a/crates/rmcp/src/service/server.rs
+++ b/crates/rmcp/src/service/server.rs
@@ -460,27 +460,60 @@ where
     }
 }
 
-/// Echoes the client-requested version if the server supports it; otherwise
-/// returns `server_fallback`.
+/// Echoes the client-requested version if the server can serve it over the
+/// `initialize` handshake; otherwise returns a legacy version the server does
+/// support.
 ///
 /// `server_supported` comes from [`Service::supported_protocol_versions`], so a
 /// server that narrows that list is never made to answer `initialize` with a
-/// version it cannot serve.
+/// version it cannot serve. `2026-07-28` replaced the handshake with
+/// per-request metadata, so a client naming that revision or later is answered
+/// with the server's newest legacy version instead.
+///
+/// # Errors
+///
+/// Returns [`ErrorCode::UNSUPPORTED_PROTOCOL_VERSION`] when the server supports
+/// no version that still has an `initialize` handshake.
+///
+/// [`ErrorCode::UNSUPPORTED_PROTOCOL_VERSION`]: crate::model::ErrorCode::UNSUPPORTED_PROTOCOL_VERSION
 pub(crate) fn negotiate_protocol_version(
     client_requested: &ProtocolVersion,
     server_fallback: ProtocolVersion,
     server_supported: &[ProtocolVersion],
-) -> ProtocolVersion {
-    if server_supported.contains(client_requested) {
-        client_requested.clone()
+) -> Result<ProtocolVersion, ErrorData> {
+    if is_legacy_version(client_requested) && server_supported.contains(client_requested) {
+        return Ok(client_requested.clone());
+    }
+    let legacy_fallback = if is_legacy_version(&server_fallback) {
+        Some(server_fallback)
     } else {
+        newest_legacy_version(server_supported)
+    };
+    let Some(legacy_fallback) = legacy_fallback else {
         tracing::warn!(
             client_requested = %client_requested,
-            server_fallback = %server_fallback,
-            "client requested unsupported protocol version; falling back to server default"
+            "server supports no protocol version with an initialize handshake; rejecting"
         );
-        server_fallback
-    }
+        return Err(ErrorData::unsupported_protocol_version(
+            client_requested.clone(),
+            server_supported,
+        ));
+    };
+    tracing::warn!(
+        client_requested = %client_requested,
+        server_fallback = %legacy_fallback,
+        "client requested a protocol version unavailable over initialize; falling back to server default"
+    );
+    Ok(legacy_fallback)
+}
+
+/// The newest of `versions` that still has an `initialize` handshake.
+fn newest_legacy_version(versions: &[ProtocolVersion]) -> Option<ProtocolVersion> {
+    versions
+        .iter()
+        .filter(|version| is_legacy_version(version))
+        .max_by(|left, right| left.as_str().cmp(right.as_str()))
+        .cloned()
 }
 
 fn missing_request_metadata_error(missing: &[&str]) -> ErrorData {
@@ -491,6 +524,27 @@ fn missing_request_metadata_error(missing: &[&str]) -> ErrorData {
         ),
         None,
     )
+}
+
+/// Sends `error` as the response to the `initialize` request and reports it as
+/// the reason the handshake failed.
+async fn report_initialize_failure<T>(
+    transport: &mut T,
+    error: ErrorData,
+    id: RequestId,
+) -> ServerInitializeError
+where
+    T: Transport<RoleServer> + 'static,
+{
+    match transport
+        .send(ServerJsonRpcMessage::error(error.clone(), Some(id)))
+        .await
+    {
+        Ok(()) => ServerInitializeError::InitializeFailed(error),
+        Err(send_error) => {
+            ServerInitializeError::transport::<T>(send_error, "sending error response")
+        }
+    }
 }
 
 async fn serve_server_with_ct_inner<S, T>(
@@ -589,27 +643,21 @@ where
         peer: peer.clone(),
     };
     // Send initialize response
-    let init_response = service.handle_request(request, context).await;
-    let mut init_response = match init_response {
+    let mut init_response = match service.handle_request(request, context).await {
         Ok(ServerResult::InitializeResult(init_response)) => init_response,
         Ok(result) => {
             return Err(ServerInitializeError::UnexpectedInitializeResponse(result));
         }
-        Err(e) => {
-            transport
-                .send(ServerJsonRpcMessage::error(e.clone(), Some(id)))
-                .await
-                .map_err(|error| {
-                    ServerInitializeError::transport::<T>(error, "sending error response")
-                })?;
-            return Err(ServerInitializeError::InitializeFailed(e));
-        }
+        Err(e) => return Err(report_initialize_failure(&mut transport, e, id).await),
     };
-    init_response.protocol_version = negotiate_protocol_version(
+    init_response.protocol_version = match negotiate_protocol_version(
         &requested_protocol_version,
         init_response.protocol_version,
         &service.supported_protocol_versions(),
-    );
+    ) {
+        Ok(version) => version,
+        Err(e) => return Err(report_initialize_failure(&mut transport, e, id).await),
+    };
     // Update peer_info so context.protocol_version() reflects the negotiated
     // version in all subsequent request handlers.
     negotiated_peer_info.protocol_version = init_response.protocol_version.clone();

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -322,7 +322,7 @@ impl<S: Service<RoleServer>> Service<RoleServer> for NegotiatingStatelessHttpSer
                 &requested,
                 result.protocol_version.clone(),
                 &self.0.supported_protocol_versions(),
-            );
+            )?;
             if let Some(peer_info) = peer.peer_info() {
                 let mut peer_info = (*peer_info).clone();
                 peer_info.protocol_version = result.protocol_version.clone();
@@ -375,22 +375,30 @@ fn is_legacy_request(
         validate_request_protocol_version_meta(headers, message)?;
     }
 
+    // An `initialize` request selects legacy semantics whatever version it names:
+    // the handshake exists only in the revisions before 2026-07-28, so the
+    // version in its params never routes it to the stateless path. The
+    // handshake itself answers with a legacy version the server supports.
+    if matches!(
+        message,
+        Some(ClientJsonRpcMessage::Request(req))
+            if matches!(&req.request, ClientRequest::InitializeRequest(_))
+    ) {
+        return Ok(true);
+    }
+
     let uses_discover_lifecycle = matches!(
         message,
         Some(ClientJsonRpcMessage::Request(req))
-            if !matches!(&req.request, ClientRequest::InitializeRequest(_))
-                && req
-                    .request
-                    .get_meta()
-                    .missing_required_keys(&ProtocolVersion::V_2026_07_28)
-                    .is_empty()
+            if req
+                .request
+                .get_meta()
+                .missing_required_keys(&ProtocolVersion::V_2026_07_28)
+                .is_empty()
     );
 
     let from_body = match message {
-        Some(ClientJsonRpcMessage::Request(req)) => match &req.request {
-            ClientRequest::InitializeRequest(init) => Some(init.params.protocol_version.clone()),
-            _ => req.request.get_meta().protocol_version(),
-        },
+        Some(ClientJsonRpcMessage::Request(req)) => req.request.get_meta().protocol_version(),
         _ => None,
     };
     let version = from_body

--- a/crates/rmcp/tests/test_handler_cache_hints.rs
+++ b/crates/rmcp/tests/test_handler_cache_hints.rs
@@ -2,10 +2,14 @@
 #![cfg(feature = "client")]
 
 use rmcp::{
-    ClientHandler, ServerHandler, ServiceExt,
+    ClientHandler, RoleClient, RoleServer, ServerHandler,
     handler::server::router::{prompt::PromptRouter, tool::ToolRouter},
-    model::{CacheScope, ClientInfo, ListPromptsResult, ListToolsResult, ProtocolVersion},
-    prompt_handler, tool_handler,
+    model::{
+        CacheScope, ClientInfo, ListPromptsResult, ListToolsResult, ProtocolVersion, ServerInfo,
+    },
+    prompt_handler,
+    service::serve_directly,
+    tool_handler,
 };
 
 #[derive(Debug, Clone)]
@@ -40,22 +44,33 @@ impl ClientHandler for VersionedClient {
     }
 }
 
+/// Wires the pair up directly on `protocol_version`. `2026-07-28` removed the
+/// `initialize` handshake, so a peer on that revision is reached the way the
+/// discover lifecycle leaves one: with the version already agreed.
 async fn list_results(protocol_version: ProtocolVersion) -> (ListToolsResult, ListPromptsResult) {
     let (server_transport, client_transport) = tokio::io::duplex(4096);
 
+    let client_handler = VersionedClient {
+        protocol_version: protocol_version.clone(),
+    };
+    let mut server_peer_info = ServerInfo::default();
+    server_peer_info.protocol_version = protocol_version;
+
+    let server = serve_directly::<RoleServer, _, _, _, _>(
+        CacheHintServer::new(),
+        server_transport,
+        Some(client_handler.get_info()),
+    );
     let server_handle = tokio::spawn(async move {
-        CacheHintServer::new()
-            .serve(server_transport)
-            .await?
-            .waiting()
-            .await?;
+        server.waiting().await?;
         anyhow::Ok(())
     });
 
-    let client = VersionedClient { protocol_version }
-        .serve(client_transport)
-        .await
-        .expect("client should connect");
+    let client = serve_directly::<RoleClient, _, _, _, _>(
+        client_handler,
+        client_transport,
+        Some(server_peer_info.into()),
+    );
     let tools = client
         .list_tools(None)
         .await

--- a/crates/rmcp/tests/test_protocol_version_negotiation.rs
+++ b/crates/rmcp/tests/test_protocol_version_negotiation.rs
@@ -1,6 +1,7 @@
 //! Tests for protocol version negotiation in the default ServerHandler::initialize impl.
 //!
-//! Known versions are echoed back; unknown versions fall back to LATEST.
+//! Handshake versions are echoed back; every other version falls back to one
+//! the server can serve over `initialize`.
 #![cfg(not(feature = "local"))]
 #![cfg(feature = "client")]
 
@@ -8,8 +9,11 @@ use std::borrow::Cow;
 
 use rmcp::{
     ClientHandler, ErrorData, RoleServer, ServerHandler, ServiceExt,
-    model::{ClientInfo, InitializeRequestParams, InitializeResult, ProtocolVersion, ServerInfo},
-    service::RequestContext,
+    model::{
+        ClientInfo, ErrorCode, InitializeRequestParams, InitializeResult, ProtocolVersion,
+        ServerInfo,
+    },
+    service::{ClientInitializeError, RequestContext},
 };
 
 #[derive(Debug, Clone, Default)]
@@ -21,9 +25,10 @@ impl ServerHandler for EchoServer {
     }
 }
 
-/// Every known version except `2026-07-28`, standing in for a server that has
-/// not implemented that revision.
-const NARROWED_VERSIONS: &[ProtocolVersion] = &[
+/// Every known version whose lifecycle still runs the `initialize` handshake.
+/// `2026-07-28` replaced the handshake with per-request metadata, so this is
+/// also the list a server that has not implemented that revision supports.
+const HANDSHAKE_VERSIONS: &[ProtocolVersion] = &[
     ProtocolVersion::V_2024_11_05,
     ProtocolVersion::V_2025_03_26,
     ProtocolVersion::V_2025_06_18,
@@ -39,7 +44,25 @@ impl ServerHandler for NarrowedServer {
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
-        Cow::Borrowed(NARROWED_VERSIONS)
+        Cow::Borrowed(HANDSHAKE_VERSIONS)
+    }
+}
+
+/// Supports only revisions that have no `initialize` handshake at all.
+#[derive(Debug, Clone, Default)]
+struct ModernOnlyServer;
+
+const MODERN_ONLY_VERSIONS: &[ProtocolVersion] = &[ProtocolVersion::V_2026_07_28];
+
+impl ServerHandler for ModernOnlyServer {
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::default();
+        info.protocol_version = ProtocolVersion::V_2026_07_28;
+        info
+    }
+
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        Cow::Borrowed(MODERN_ONLY_VERSIONS)
     }
 }
 
@@ -55,7 +78,7 @@ impl ServerHandler for NarrowedOverridingServer {
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
-        Cow::Borrowed(NARROWED_VERSIONS)
+        Cow::Borrowed(HANDSHAKE_VERSIONS)
     }
 
     async fn initialize(
@@ -88,23 +111,28 @@ async fn negotiated_version_with<S: ServerHandler>(
     server: S,
     client_version: ProtocolVersion,
 ) -> ProtocolVersion {
+    negotiate_with(server, client_version)
+        .await
+        .expect("client should connect")
+}
+
+async fn negotiate_with<S: ServerHandler>(
+    server: S,
+    client_version: ProtocolVersion,
+) -> Result<ProtocolVersion, ClientInitializeError> {
     let (server_transport, client_transport) = tokio::io::duplex(4096);
 
     tokio::spawn(async move {
-        let _ = server
-            .serve(server_transport)
-            .await
-            .expect("server should start")
-            .waiting()
-            .await;
+        if let Ok(running) = server.serve(server_transport).await {
+            let _ = running.waiting().await;
+        }
     });
 
     let client = VersionedClient {
         protocol_version: client_version,
     }
     .serve(client_transport)
-    .await
-    .expect("client should connect");
+    .await?;
 
     let version = client
         .peer_info()
@@ -113,18 +141,53 @@ async fn negotiated_version_with<S: ServerHandler>(
         .clone();
 
     client.cancel().await.expect("client should cancel");
-    version
+    Ok(version)
 }
 
 #[tokio::test]
-async fn known_version_echoed_back() {
-    for version in ProtocolVersion::KNOWN_VERSIONS {
+async fn handshake_version_echoed_back() {
+    for version in HANDSHAKE_VERSIONS {
         let negotiated = negotiated_version(version.clone()).await;
         assert_eq!(
             negotiated, *version,
-            "known version {version} should be echoed back"
+            "handshake version {version} should be echoed back"
         );
     }
+}
+
+/// `initialize` disappeared in `2026-07-28`, so agreeing to it here would leave
+/// the peers speaking a revision that has no handshake at all.
+#[tokio::test]
+async fn handshake_never_agrees_to_a_version_that_dropped_it() {
+    let negotiated = negotiated_version(ProtocolVersion::V_2026_07_28).await;
+    assert_eq!(
+        negotiated,
+        ProtocolVersion::LATEST,
+        "a version that dropped the handshake should fall back to the server's own"
+    );
+}
+
+#[tokio::test]
+async fn modern_only_server_rejects_the_handshake() {
+    let error = negotiate_with(ModernOnlyServer, ProtocolVersion::V_2026_07_28)
+        .await
+        .expect_err("a server with no handshake version cannot answer initialize");
+    let ClientInitializeError::JsonRpcError(error) = error else {
+        panic!("expected a JSON-RPC error, got {error:?}");
+    };
+    assert_eq!(
+        error.code,
+        ErrorCode::UNSUPPORTED_PROTOCOL_VERSION,
+        "a server with no handshake version should reject initialize"
+    );
+    assert_eq!(
+        error.data,
+        Some(serde_json::json!({
+            "requested": "2026-07-28",
+            "supported": ["2026-07-28"],
+        })),
+        "the rejection should name the versions the server does support"
+    );
 }
 
 #[tokio::test]
@@ -140,7 +203,7 @@ async fn unknown_version_falls_back_to_latest() {
 
 #[tokio::test]
 async fn narrowed_server_still_echoes_versions_it_supports() {
-    for version in NARROWED_VERSIONS {
+    for version in HANDSHAKE_VERSIONS {
         let negotiated = negotiated_version_with(NarrowedServer, version.clone()).await;
         assert_eq!(
             negotiated, *version,

--- a/crates/rmcp/tests/test_resource_not_found_version.rs
+++ b/crates/rmcp/tests/test_resource_not_found_version.rs
@@ -6,12 +6,12 @@
 #![cfg(feature = "client")]
 
 use rmcp::{
-    ClientHandler, RoleServer, ServerHandler, ServiceError, ServiceExt,
+    ClientHandler, RoleClient, RoleServer, ServerHandler, ServiceError,
     model::{
         ClientInfo, ErrorCode, ErrorData, ProtocolVersion, ReadResourceRequestParams,
-        ReadResourceResponse,
+        ReadResourceResponse, ServerInfo,
     },
-    service::RequestContext,
+    service::{RequestContext, serve_directly},
 };
 
 #[derive(Debug, Clone, Default)]
@@ -40,24 +40,33 @@ impl ClientHandler for VersionedClient {
     }
 }
 
+/// Wires the pair up directly on `client_version`. `2026-07-28` removed the
+/// `initialize` handshake, so a peer on that revision is reached the way the
+/// discover lifecycle leaves one: with the version already agreed.
 async fn not_found_code(client_version: ProtocolVersion) -> ErrorCode {
     let (server_transport, client_transport) = tokio::io::duplex(4096);
 
+    let client_handler = VersionedClient {
+        protocol_version: client_version.clone(),
+    };
+    let mut server_peer_info = ServerInfo::default();
+    server_peer_info.protocol_version = client_version;
+
+    let server = serve_directly::<RoleServer, _, _, _, _>(
+        ResourceServer,
+        server_transport,
+        Some(client_handler.get_info()),
+    );
     let server_handle = tokio::spawn(async move {
-        ResourceServer
-            .serve(server_transport)
-            .await?
-            .waiting()
-            .await?;
+        server.waiting().await?;
         anyhow::Ok(())
     });
 
-    let client = VersionedClient {
-        protocol_version: client_version,
-    }
-    .serve(client_transport)
-    .await
-    .expect("client should connect");
+    let client = serve_directly::<RoleClient, _, _, _, _>(
+        client_handler,
+        client_transport,
+        Some(server_peer_info.into()),
+    );
 
     let error = client
         .read_resource(ReadResourceRequestParams::new("missing://resource"))

--- a/crates/rmcp/tests/test_result_type_version.rs
+++ b/crates/rmcp/tests/test_result_type_version.rs
@@ -6,12 +6,12 @@
 #![cfg(feature = "client")]
 
 use rmcp::{
-    ClientHandler, RoleServer, ServerHandler, ServiceExt,
+    ClientHandler, RoleClient, RoleServer, ServerHandler,
     model::{
         CallToolRequestParams, CallToolResponse, CallToolResult, ClientInfo, ContentBlock,
-        ErrorData, ProtocolVersion, ResultType,
+        ErrorData, ProtocolVersion, ResultType, ServerInfo,
     },
-    service::RequestContext,
+    service::{RequestContext, serve_directly},
 };
 
 #[derive(Debug, Clone, Default)]
@@ -40,20 +40,33 @@ impl ClientHandler for VersionedClient {
     }
 }
 
+/// Wires the pair up directly on `client_version`. `2026-07-28` removed the
+/// `initialize` handshake, so a peer on that revision is reached the way the
+/// discover lifecycle leaves one: with the version already agreed.
 async fn call_tool_result_type(client_version: ProtocolVersion) -> Option<ResultType> {
     let (server_transport, client_transport) = tokio::io::duplex(4096);
 
+    let client_handler = VersionedClient {
+        protocol_version: client_version.clone(),
+    };
+    let mut server_peer_info = ServerInfo::default();
+    server_peer_info.protocol_version = client_version;
+
+    let server = serve_directly::<RoleServer, _, _, _, _>(
+        ToolServer,
+        server_transport,
+        Some(client_handler.get_info()),
+    );
     let server_handle = tokio::spawn(async move {
-        ToolServer.serve(server_transport).await?.waiting().await?;
+        server.waiting().await?;
         anyhow::Ok(())
     });
 
-    let client = VersionedClient {
-        protocol_version: client_version,
-    }
-    .serve(client_transport)
-    .await
-    .expect("client should connect");
+    let client = serve_directly::<RoleClient, _, _, _, _>(
+        client_handler,
+        client_transport,
+        Some(server_peer_info.into()),
+    );
 
     let result = client
         .call_tool(CallToolRequestParams::new("echo"))

--- a/crates/rmcp/tests/test_sep_2260_request_association.rs
+++ b/crates/rmcp/tests/test_sep_2260_request_association.rs
@@ -10,7 +10,7 @@ use rmcp::{
         CreateMessageRequest, CreateMessageRequestParams, CreateMessageResult, ProtocolVersion,
         SamplingMessage, ServerCapabilities, ServerInfo, ServerRequest,
     },
-    service::RequestContext,
+    service::{RequestContext, RunningService, serve_directly},
 };
 use serde_json::{Value, json};
 use tokio::{
@@ -95,20 +95,43 @@ impl ClientHandler for SamplingClient {
     }
 }
 
+/// Connects the pair on `2026-07-28`. That revision dropped the `initialize`
+/// handshake, so the version is agreed up front the way a discover-lifecycle
+/// startup leaves it.
+fn serve_modern_pair(
+    server: SamplingServer,
+) -> (
+    RunningService<RoleServer, SamplingServer>,
+    RunningService<RoleClient, SamplingClient>,
+) {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+    let mut server_peer_info = server.get_info();
+    server_peer_info.protocol_version = ProtocolVersion::V_2026_07_28;
+
+    let running_server = serve_directly::<RoleServer, _, _, _, _>(
+        server,
+        server_transport,
+        Some(SamplingClient.get_info()),
+    );
+    let client = serve_directly::<RoleClient, _, _, _, _>(
+        SamplingClient,
+        client_transport,
+        Some(server_peer_info.into()),
+    );
+    (running_server, client)
+}
+
 #[tokio::test]
 async fn nested_sampling_allowed_standalone_rejected() -> anyhow::Result<()> {
-    let (server_transport, client_transport) = tokio::io::duplex(4096);
     let (tx, rx) = oneshot::channel();
     let server = SamplingServer {
         outside: Arc::new(Mutex::new(Some(tx))),
     };
+    let (running_server, client) = serve_modern_pair(server);
     let server_handle = tokio::spawn(async move {
-        let running = server.serve(server_transport).await?;
-        running.waiting().await?;
+        running_server.waiting().await?;
         anyhow::Ok(())
     });
-
-    let client = SamplingClient.serve(client_transport).await?;
 
     let result = client
         .peer()
@@ -129,18 +152,15 @@ async fn nested_sampling_allowed_standalone_rejected() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn generic_send_request_bypass_rejected() -> anyhow::Result<()> {
-    let (server_transport, client_transport) = tokio::io::duplex(4096);
     let (tx, rx) = oneshot::channel();
     let server = SamplingServer {
         outside: Arc::new(Mutex::new(Some(tx))),
     };
+    let (running_server, client) = serve_modern_pair(server);
     let server_handle = tokio::spawn(async move {
-        let running = server.serve(server_transport).await?;
-        running.waiting().await?;
+        running_server.waiting().await?;
         anyhow::Ok(())
     });
-
-    let client = SamplingClient.serve(client_transport).await?;
 
     let result = client
         .peer()

--- a/crates/rmcp/tests/test_stateless_protocol_version.rs
+++ b/crates/rmcp/tests/test_stateless_protocol_version.rs
@@ -1,7 +1,8 @@
 //! Tests for protocol version negotiation in stateless HTTP mode.
 //!
-//! Supported versions are echoed back; unknown versions, and versions outside
-//! the server's `supported_protocol_versions`, fall back to the handler's own
+//! Supported handshake versions are echoed back; unknown versions, versions
+//! outside the server's `supported_protocol_versions`, and versions that no
+//! longer have an `initialize` handshake fall back to the handler's own
 //! version.
 #![cfg(not(feature = "local"))]
 
@@ -36,9 +37,10 @@ impl ServerHandler for OverridingInitialize {
     }
 }
 
-/// Every known version except `2026-07-28`, standing in for a server that has
-/// not implemented that revision.
-const NARROWED_VERSIONS: &[ProtocolVersion] = &[
+/// Every known version whose lifecycle still runs the `initialize` handshake.
+/// `2026-07-28` replaced the handshake with per-request metadata, so this is
+/// also the list a server that has not implemented that revision supports.
+const HANDSHAKE_VERSIONS: &[ProtocolVersion] = &[
     ProtocolVersion::V_2024_11_05,
     ProtocolVersion::V_2025_03_26,
     ProtocolVersion::V_2025_06_18,
@@ -56,7 +58,7 @@ impl ServerHandler for NarrowedOverridingInitialize {
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
-        Cow::Borrowed(NARROWED_VERSIONS)
+        Cow::Borrowed(HANDSHAKE_VERSIONS)
     }
 
     async fn initialize(
@@ -148,15 +150,15 @@ async fn post_init(client: &reqwest::Client, url: &str, body_version: &str) -> s
 }
 
 #[tokio::test]
-async fn stateless_json_init_echoes_known_versions_when_handler_overrides_initialize() {
+async fn stateless_json_init_echoes_handshake_versions_when_handler_overrides_initialize() {
     let (client, url, ct) = spawn_server(stateless_json_config()).await;
 
-    for version in ProtocolVersion::KNOWN_VERSIONS {
+    for version in HANDSHAKE_VERSIONS {
         let resp = post_init(&client, &url, version.as_str()).await;
         assert_eq!(
             resp["result"]["protocolVersion"],
             version.as_str(),
-            "known version {version} should be echoed back"
+            "handshake version {version} should be echoed back"
         );
     }
 
@@ -164,15 +166,15 @@ async fn stateless_json_init_echoes_known_versions_when_handler_overrides_initia
 }
 
 #[tokio::test]
-async fn stateless_sse_init_echoes_known_versions_when_handler_overrides_initialize() {
+async fn stateless_sse_init_echoes_handshake_versions_when_handler_overrides_initialize() {
     let (client, url, ct) = spawn_server(stateless_sse_config()).await;
 
-    for version in ProtocolVersion::KNOWN_VERSIONS {
+    for version in HANDSHAKE_VERSIONS {
         let resp = post_init(&client, &url, version.as_str()).await;
         assert_eq!(
             resp["result"]["protocolVersion"],
             version.as_str(),
-            "known version {version} should be echoed back"
+            "handshake version {version} should be echoed back"
         );
     }
 
@@ -198,7 +200,7 @@ async fn stateless_json_init_echoes_versions_the_server_narrowed_to() {
     let (client, url, ct) =
         spawn_server_of::<NarrowedOverridingInitialize>(stateless_json_config()).await;
 
-    for version in NARROWED_VERSIONS {
+    for version in HANDSHAKE_VERSIONS {
         let resp = post_init(&client, &url, version.as_str()).await;
         assert_eq!(
             resp["result"]["protocolVersion"],

--- a/crates/rmcp/tests/test_streamable_http_protocol_version.rs
+++ b/crates/rmcp/tests/test_streamable_http_protocol_version.rs
@@ -87,6 +87,17 @@ async fn post_init(
     req.send().await.expect("send initialize request")
 }
 
+/// First JSON-RPC message of an SSE response, skipping the empty priming event.
+async fn sse_payload(response: reqwest::Response) -> anyhow::Result<Value> {
+    let body = response.text().await?;
+    let data = body
+        .lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .find(|data| !data.is_empty())
+        .expect("response must carry a JSON-RPC payload");
+    Ok(serde_json::from_str(data)?)
+}
+
 async fn post_non_initialize(client: &reqwest::Client, url: &str) -> reqwest::Response {
     client
         .post(url)
@@ -187,6 +198,27 @@ async fn stateless_init_accepts_when_header_absent() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn stateless_init_naming_a_post_handshake_version_negotiates_down() -> anyhow::Result<()> {
+    let (client, url, ct) = spawn_server(stateless_json_config()).await;
+
+    let response = post_init(&client, &url, None, "2026-07-28").await;
+    assert_eq!(
+        response.status(),
+        200,
+        "initialize selects legacy semantics whatever version it names"
+    );
+
+    let body: serde_json::Value = response.json().await?;
+    assert_eq!(
+        body["result"]["protocolVersion"], "2025-11-25",
+        "initialize must settle on a version that still has the handshake"
+    );
+
+    ct.cancel();
+    Ok(())
+}
+
+#[tokio::test]
 async fn stateful_init_rejects_when_header_mismatches_body() -> anyhow::Result<()> {
     let (client, url, ct) = spawn_server(stateful_config()).await;
 
@@ -213,6 +245,37 @@ async fn stateful_rejected_initial_posts_do_not_create_sessions() -> anyhow::Res
     let response = post_init(&client, &url, Some("2024-11-05"), "2025-11-25").await;
     assert_eq!(response.status(), 400);
     assert_eq!(session_manager.sessions.read().await.len(), 0);
+
+    ct.cancel();
+    Ok(())
+}
+
+/// The `initialize` handshake exists only in the revisions before `2026-07-28`,
+/// so naming a later version in it does not make the request a modern one: the
+/// server keeps legacy semantics, opens a session, and answers with a version it
+/// can actually serve over the handshake.
+#[tokio::test]
+async fn stateful_init_naming_a_post_handshake_version_opens_a_legacy_session() -> anyhow::Result<()>
+{
+    let (client, url, ct) = spawn_server(stateful_config()).await;
+
+    let response = post_init(&client, &url, None, "2026-07-28").await;
+    assert_eq!(
+        response.status(),
+        200,
+        "initialize selects legacy semantics whatever version it names"
+    );
+    assert!(
+        response.headers().contains_key("Mcp-Session-Id"),
+        "the handshake must open a session, got headers: {:?}",
+        response.headers()
+    );
+
+    let payload = sse_payload(response).await?;
+    assert_eq!(
+        payload["result"]["protocolVersion"], "2025-11-25",
+        "initialize must settle on a version that still has the handshake"
+    );
 
     ct.cancel();
     Ok(())


### PR DESCRIPTION
Fixes #1209.

## Motivation and Context

The [2026-07-28 versioning spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning#backward-compatibility-with-initialization-based-versions) is very clear about how a server that supports both eras should behave.

> An initialize request selects legacy semantics, scoped to the stdio process (stdio) or the session (HTTP), as specified by the negotiated legacy protocol version.

Two parts of the implementation broke that contract:

1. `negotiate_protocol_version` returned the client's requested version whenever `supported_protocol_versions()` included it. That also applied to `2026-07-28` and later, even though those versions do not use a handshake.

2. In the Streamable HTTP tower service, `is_legacy_request` used the `protocolVersion` from the `initialize` body to decide between session and stateless routing. As a result, a `2026-07-28` handshake took the stateless path and did not create a session. The server then accepted a legacy-lifecycle request but handled it with modern-lifecycle semantics.

The fix makes these two parts consistent. Any `initialize` request is treated as a legacy client, regardless of the version it names. It always uses the session path and negotiates a version that still supports the handshake.

If the server does not support any such version, it now returns `-32022 UnsupportedProtocolVersionError` and identifies the versions it does support. This is also what the same spec page recommends. A server that supports only modern versions should name those supported protocol versions in any error returned for an `initialize` request.

## How Has This Been Tested?

Added tests

## Breaking Changes

There is no public API change and no change to any lifecycle defined by the spec. `initialize` never legitimately produced a 2026-07-28 session, so nothing that followed the spec could have depended on it.

Code that used the handshake to reach a modern peer should switch to `ClientLifecycleMode::Discover` or `Auto`. Alternatively, it can use `serve_directly` with the version that was already agreed on. Seven tests in this repo took that shortcut and have been migrated to `serve_directly`, following the pattern already used in `test_mrtr_behavior.rs`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed