### PR TITLE
feat(auth): add enterprise refresh-token and ID-JAG exchanges

### DIFF
--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -19,6 +19,7 @@ rmcp = { path = "../crates/rmcp", features = [
     "elicitation",
     "auth",
     "auth-client-credentials-jwt",
+    "auth-enterprise-managed",
     "request-state",
     "transport-streamable-http-server",
     "transport-streamable-http-client-reqwest",
@@ -31,6 +32,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 axum = { version = "0.8", features = ["macros"] }
 anyhow = "1"
+oauth2 = { version = "5.0", default-features = false }
 reqwest = { version = "0.13", features = ["json"] }
 urlencoding = "2"
 url = "2"

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -1,3 +1,5 @@
+use anyhow::Context;
+use oauth2::{ClientSecret, RefreshToken};
 use rmcp::{
     ClientHandler, ClientLifecycleMode, ClientServiceExt, ErrorData, RoleClient, ServiceExt,
     model::*,
@@ -6,7 +8,8 @@ use rmcp::{
         AuthClient, AuthorizationManager, StreamableHttpClientTransport,
         auth::{
             AuthorizationCallback, AuthorizationRequest, ClientCredentialsConfig,
-            InMemoryCredentialStore, JwtSigningAlgorithm, OAuthState,
+            InMemoryCredentialStore, JwtSigningAlgorithm, OAuthState, default_oauth_http_client,
+            enterprise::{EmaAuthorizationServer, EmaClientAuthentication, EmaExchangeRequest},
         },
         streamable_http_client::StreamableHttpClientTransportConfig,
     },
@@ -36,6 +39,17 @@ struct ConformanceContext {
     private_key_pem: Option<String>,
     #[serde(default)]
     signing_algorithm: Option<String>,
+    // enterprise-managed-authorization-refresh-token
+    #[serde(default)]
+    idp_client_id: Option<String>,
+    #[serde(default)]
+    idp_client_secret: Option<String>,
+    #[serde(default)]
+    idp_refresh_token: Option<String>,
+    #[serde(default)]
+    idp_issuer: Option<String>,
+    #[serde(default)]
+    idp_token_endpoint: Option<String>,
 }
 
 fn load_context() -> ConformanceContext {
@@ -760,6 +774,66 @@ async fn run_client_credentials_jwt(
     Ok(())
 }
 
+/// Exchange the fixture's IdP refresh token, then exercise authenticated MCP access.
+async fn run_ema_refresh_token_client(
+    server_url: &str,
+    ctx: &ConformanceContext,
+) -> anyhow::Result<()> {
+    let manager = AuthorizationManager::new(server_url).await?;
+    let metadata = manager.resolve_metadata().await?.metadata;
+    let idp = EmaAuthorizationServer::new(
+        ctx.idp_issuer.as_deref().context("Missing idp_issuer")?,
+        ctx.idp_token_endpoint
+            .as_deref()
+            .context("Missing idp_token_endpoint")?,
+        ctx.idp_client_id
+            .as_deref()
+            .context("Missing idp_client_id")?,
+    )
+    .with_client_authentication(EmaClientAuthentication::ClientSecretBasic(
+        ClientSecret::new(
+            ctx.idp_client_secret
+                .clone()
+                .context("Missing idp_client_secret")?,
+        ),
+    ));
+    let resource_as = EmaAuthorizationServer::new(
+        metadata
+            .issuer
+            .context("Missing authorization server issuer")?,
+        metadata.token_endpoint,
+        ctx.client_id.as_deref().context("Missing client_id")?,
+    )
+    .with_client_authentication(EmaClientAuthentication::ClientSecretBasic(
+        ClientSecret::new(ctx.client_secret.clone().context("Missing client_secret")?),
+    ));
+    let refresh_token = RefreshToken::new(
+        ctx.idp_refresh_token
+            .clone()
+            .context("Missing idp_refresh_token")?,
+    );
+    let http = default_oauth_http_client()?;
+    let token = EmaExchangeRequest::new(idp, resource_as, server_url, &refresh_token)
+        .with_scopes(manager.select_scopes(None, &[]))
+        .exchange(&http, &http)
+        .await?;
+
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(server_url)
+            .auth_header(token.access_token.secret()),
+    );
+    let client = BasicClientHandler
+        .serve_with_lifecycle(transport, conformance_lifecycle())
+        .await?;
+    let tools = client.list_tools(Default::default()).await?;
+    for tool in tools.tools {
+        let args = build_tool_arguments(&tool);
+        client.call_tool(call_tool_params(tool.name, args)).await?;
+    }
+    client.cancel().await?;
+    Ok(())
+}
+
 /// Cross-app access flow (SEP-1046 extension).
 async fn run_cross_app_access_client(
     server_url: &str,
@@ -1109,6 +1183,11 @@ async fn run_scenario(
         // Auth - client credentials
         "auth/client-credentials-basic" => run_client_credentials_basic(server_url, ctx).await?,
         "auth/client-credentials-jwt" => run_client_credentials_jwt(server_url, ctx).await?,
+
+        // Auth - enterprise-managed authorization with a refresh-token subject
+        "auth/enterprise-managed-authorization-refresh-token" => {
+            run_ema_refresh_token_client(server_url, ctx).await?
+        }
 
         // Auth - cross-app access
         "auth/cross-app-access-complete-flow" => {

--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -18,6 +18,7 @@ exhaustive_enums = "warn"
 features = [
   "auth",
   "auth-client-credentials-jwt",
+  "auth-enterprise-managed",
   "base64",
   "client",
   "client-side-sse",
@@ -196,6 +197,7 @@ transport-streamable-http-server-session = [
 tower = ["dep:tower-service"]
 auth = ["dep:async-trait", "dep:oauth2", "__reqwest", "dep:url"]
 auth-client-credentials-jwt = ["auth", "dep:jsonwebtoken", "uuid"]
+auth-enterprise-managed = ["auth", "base64"]
 schemars = ["dep:schemars"]
 
 [dev-dependencies]

--- a/crates/rmcp/Cargo.toml
+++ b/crates/rmcp/Cargo.toml
@@ -201,7 +201,7 @@ auth-enterprise-managed = ["auth", "base64"]
 schemars = ["dep:schemars"]
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full", "test-util"] }
 schemars = { version = "1.1.0", features = ["chrono04"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 hyper = { version = "1", features = ["server", "http1"] }

--- a/crates/rmcp/README.md
+++ b/crates/rmcp/README.md
@@ -24,6 +24,7 @@ For **getting started**, **usage guides**, and **full MCP feature documentation*
 | `macros` | `#[tool]` / `#[prompt]` macros (re-exports [`rmcp-macros`](../rmcp-macros)) | ✅ |
 | `schemars` | JSON Schema generation for tool definitions | |
 | `auth` | OAuth 2.0 authentication support | |
+| `auth-enterprise-managed` | EMA/XAA refresh-token and ID-JAG exchanges for registered public and confidential clients (includes `auth`) | |
 | `elicitation` | Elicitation support | |
 
 ### Transport features
@@ -44,6 +45,10 @@ For **getting started**, **usage guides**, and **full MCP feature documentation*
 | `reqwest` | Uses rustls — pure Rust TLS (recommended default) |
 | `reqwest-native-tls` | Uses platform-native TLS (OpenSSL / Secure Transport / SChannel) |
 | `reqwest-tls-no-provider` | Uses rustls without a default crypto provider (bring your own) |
+
+For enterprise-managed authorization, enable `auth-enterprise-managed` and a TLS
+backend such as `reqwest`. See the [EMA/XAA guide](../../docs/OAUTH_SUPPORT.md#enterprise-managed-authorization-emaxaa)
+for client authentication and an MCP connection example.
 
 ## Transports
 

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -28,6 +28,9 @@ use tracing::{debug, warn};
 
 use crate::transport::common::http_header::HEADER_MCP_PROTOCOL_VERSION;
 
+#[cfg(feature = "auth-enterprise-managed")]
+pub mod enterprise;
+
 const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_OAUTH_HTTP_RESPONSE_BODY_BYTES: usize = 1024 * 1024;
 const MAX_OAUTH_DISCOVERY_REDIRECTS: usize = 10;

--- a/crates/rmcp/src/transport/auth.rs
+++ b/crates/rmcp/src/transport/auth.rs
@@ -102,6 +102,19 @@ pub trait OAuthHttpClient: Send + Sync {
     fn execute(&self, request: OAuthHttpRequest) -> OAuthHttpClientFuture<'_>;
 }
 
+/// Create an OAuth HTTP client with the SDK's default reqwest configuration.
+///
+/// Honors each request's redirect policy, with a 30-second timeout and bounded
+/// response bodies. Enable a TLS feature such as `reqwest` for HTTPS requests.
+/// Implement [`OAuthHttpClient`] instead when custom network policy is required.
+pub fn default_oauth_http_client() -> Result<impl OAuthHttpClient, AuthError> {
+    let client = ReqwestClient::builder()
+        .timeout(DEFAULT_HTTP_TIMEOUT)
+        .build()
+        .map_err(|error| AuthError::InternalError(error.to_string()))?;
+    ReqwestOAuthHttpClient::new(client)
+}
+
 struct ReqwestOAuthHttpClient {
     follow_redirects: ReqwestClient,
     stop_redirects: ReqwestClient,
@@ -1310,13 +1323,9 @@ impl AuthorizationManager {
 
     /// create new auth manager with base url
     pub async fn new<U: IntoUrl>(base_url: U) -> Result<Self, AuthError> {
-        let http_client = ReqwestClient::builder()
-            .timeout(DEFAULT_HTTP_TIMEOUT)
-            .build()
-            .map_err(|e| AuthError::InternalError(e.to_string()))?;
         Self::new_inner(
             base_url,
-            Arc::new(ReqwestOAuthHttpClient::new(http_client)?),
+            Arc::new(default_oauth_http_client()?),
             OAuthHttpRedirectPolicy::Stop,
         )
         .await
@@ -4044,6 +4053,58 @@ mod tests {
             error.to_string(),
             "Metadata error: OAuth metadata discovery failed for https://mcp.example.com/mcp\n  Caused by: request failed\n  Caused by: certificate signed by unknown authority"
         );
+    }
+
+    #[tokio::test]
+    async fn default_oauth_http_client_honors_redirect_policy() {
+        use axum::{Router, routing::post};
+
+        let received = Arc::new(StdMutex::new(Vec::new()));
+        let capture = Arc::clone(&received);
+        let app = Router::new()
+            .route(
+                "/redirect",
+                post(|| async { (StatusCode::TEMPORARY_REDIRECT, [("location", "/token")]) }),
+            )
+            .route(
+                "/token",
+                post(move |body: String| {
+                    let capture = Arc::clone(&capture);
+                    async move {
+                        capture.lock().unwrap().push(body);
+                        StatusCode::OK
+                    }
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}/redirect", listener.local_addr().unwrap());
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = super::default_oauth_http_client().unwrap();
+
+        for (policy, expected) in [
+            (
+                OAuthHttpRedirectPolicy::Stop,
+                StatusCode::TEMPORARY_REDIRECT,
+            ),
+            (OAuthHttpRedirectPolicy::Follow, StatusCode::OK),
+        ] {
+            let request = oauth2::http::Request::builder()
+                .method("POST")
+                .uri(&endpoint)
+                .body(b"credential-sentinel".to_vec())
+                .unwrap();
+            let response = client
+                .execute(OAuthHttpRequest::new(request, policy))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), expected);
+            let expected_bodies = if policy == OAuthHttpRedirectPolicy::Stop {
+                vec![]
+            } else {
+                vec!["credential-sentinel".to_owned()]
+            };
+            assert_eq!(*received.lock().unwrap(), expected_bodies);
+        }
     }
 
     #[tokio::test]

--- a/crates/rmcp/src/transport/auth/enterprise.rs
+++ b/crates/rmcp/src/transport/auth/enterprise.rs
@@ -1,0 +1,584 @@
+//! Non-interactive enterprise-managed authorization (EMA/XAA) token exchange.
+//!
+//! Exchanges an enterprise refresh token for a resource-bound ID-JAG.
+//! Callers must discover and approve both servers and their registrations
+//! before supplying a credential. This module does not discover servers, log in,
+//! persist credentials, or decide when to reauthenticate.
+//!
+//! Configure the IdP client's approved authentication method: HTTP Basic, a client
+//! secret in the request body, or a freshly signed JWT client assertion. Public
+//! clients are supported only where explicitly allowed by the IdP. The helper
+//! requires one MCP resource and does not implement Rich Authorization Requests
+//! or DPoP. It does not automatically retry token requests.
+//!
+//! ID-JAG checks below enforce structure and claim bindings, not cryptographic
+//! signature verification. Assertions come directly from the trusted IdP token
+//! endpoint; the resource authorization server must verify their signatures.
+
+use std::{collections::HashSet, sync::Arc};
+
+use base64::{
+    Engine,
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+};
+use oauth2::{AccessToken, ClientSecret, RefreshToken};
+use serde::{Deserialize, de::DeserializeOwned};
+use thiserror::Error;
+use url::{Host, Url};
+
+use super::{
+    DEFAULT_HTTP_TIMEOUT, MAX_OAUTH_HTTP_RESPONSE_BODY_BYTES, OAuthHttpClient,
+    OAuthHttpRedirectPolicy, OAuthHttpRequest,
+};
+
+const ID_JAG_TOKEN_TYPE: &str = "urn:ietf:params:oauth:token-type:id-jag";
+
+/// Authentication approved for a pre-registered client at one authorization server.
+///
+/// The selected method is used as configured, without negotiation or fallback.
+#[derive(Clone)]
+#[non_exhaustive]
+pub enum EmaClientAuthentication {
+    /// Public client (`token_endpoint_auth_method=none`), only if the server permits it.
+    None,
+    /// `client_secret_basic`, with OAuth form encoding before HTTP Basic encoding.
+    ClientSecretBasic(ClientSecret),
+    /// `client_secret_post`, for servers requiring credentials in the request body.
+    ClientSecretPost(ClientSecret),
+    /// Fresh JWT client assertions, such as `private_key_jwt` or `client_secret_jwt`.
+    /// Signing, key custody, claims, and the registered algorithm belong to the provider.
+    JwtAssertion(Arc<dyn EmaClientAssertionProvider>),
+}
+
+impl std::fmt::Debug for EmaClientAuthentication {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::None => "None",
+            Self::ClientSecretBasic(_) => "ClientSecretBasic { .. }",
+            Self::ClientSecretPost(_) => "ClientSecretPost { .. }",
+            Self::JwtAssertion(_) => "JwtAssertion { .. }",
+        })
+    }
+}
+
+impl EmaClientAuthentication {
+    fn validate(&self) -> Result<(), EmaError> {
+        if let Self::ClientSecretBasic(secret) | Self::ClientSecretPost(secret) = self
+            && secret.secret().trim().is_empty()
+        {
+            return Err(EmaError::InvalidRequest("client secret must not be empty"));
+        }
+        Ok(())
+    }
+}
+
+/// A signed JWT used to authenticate the client, distinct from the ID-JAG grant.
+pub struct EmaClientAssertion(String);
+
+impl EmaClientAssertion {
+    /// Wrap a fresh assertion without exposing it through `Debug`.
+    pub fn new(assertion: String) -> Self {
+        Self(assertion)
+    }
+}
+
+impl std::fmt::Debug for EmaClientAssertion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("EmaClientAssertion { .. }")
+    }
+}
+
+/// Creates client assertions on demand, allowing keys to remain in an external signer.
+///
+/// Called once immediately before each token request.
+/// Set `iss` and `sub` to the registered client identifier and `aud`
+/// to the server's approved audience, with a short expiration and a fresh `jti`.
+/// The SDK does not sign or validate these assertions. Provider failures are
+/// sanitized and the call shares the token request's timeout. Cancellation may
+/// occur when that deadline expires.
+#[async_trait::async_trait]
+pub trait EmaClientAssertionProvider: Send + Sync {
+    async fn create_assertion(
+        &self,
+        server: &EmaAuthorizationServer,
+    ) -> Result<EmaClientAssertion, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+/// A trusted server with a pre-registered client and its approved authentication method.
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct EmaAuthorizationServer {
+    /// Exact issuer identifier from approved metadata.
+    pub issuer: String,
+    /// Token endpoint from that metadata.
+    pub token_endpoint: String,
+    /// Pre-registered client identifier.
+    pub client_id: String,
+    client_authentication: EmaClientAuthentication,
+}
+
+impl EmaAuthorizationServer {
+    /// Use approved metadata and a public-client registration (`token_endpoint_auth_method=none`).
+    /// Set [`Self::with_client_authentication`] for a confidential client.
+    pub fn new(issuer: &str, token_endpoint: &str, client_id: &str) -> Self {
+        Self {
+            issuer: issuer.to_owned(),
+            token_endpoint: token_endpoint.to_owned(),
+            client_id: client_id.to_owned(),
+            client_authentication: EmaClientAuthentication::None,
+        }
+    }
+
+    /// Select the authentication method approved for this server's client registration.
+    pub fn with_client_authentication(mut self, authentication: EmaClientAuthentication) -> Self {
+        self.client_authentication = authentication;
+        self
+    }
+}
+
+/// A refresh-token exchange bound to one MCP resource and two registered clients.
+pub struct EmaExchangeRequest<'a> {
+    idp: EmaAuthorizationServer,
+    resource_as: EmaAuthorizationServer,
+    resource: &'a str,
+    refresh_token: &'a RefreshToken,
+    scopes: &'a [String],
+}
+
+impl<'a> EmaExchangeRequest<'a> {
+    /// No scope parameter is sent until [`Self::scopes`] is used.
+    pub fn new(
+        idp: EmaAuthorizationServer,
+        resource_as: EmaAuthorizationServer,
+        resource: &'a str,
+        refresh_token: &'a RefreshToken,
+    ) -> Self {
+        Self {
+            idp,
+            resource_as,
+            resource,
+            refresh_token,
+            scopes: &[],
+        }
+    }
+
+    /// Request distinct non-empty scope tokens; the IdP may narrow them.
+    /// An empty slice omits `scope`, rather than requesting an empty grant.
+    pub fn scopes(mut self, scopes: &'a [String]) -> Self {
+        self.scopes = scopes;
+        self
+    }
+
+    /// Obtain an ID-JAG without redirects or retries, checking its resource/client bindings.
+    /// The returned assertion does not retain the enterprise refresh token.
+    pub async fn exchange_id_jag(
+        self,
+        idp_http: &dyn OAuthHttpClient,
+    ) -> Result<EmaIdJag, EmaError> {
+        for endpoint in [
+            self.resource,
+            &self.idp.issuer,
+            &self.idp.token_endpoint,
+            &self.resource_as.issuer,
+            &self.resource_as.token_endpoint,
+        ] {
+            validate_endpoint(endpoint)?;
+        }
+        if self.idp.issuer == self.resource_as.issuer {
+            return Err(EmaError::InvalidRequest(
+                "IdP and resource AS issuers must differ",
+            ));
+        }
+        if self.idp.client_id.trim().is_empty()
+            || self.resource_as.client_id.trim().is_empty()
+            || self.refresh_token.secret().trim().is_empty()
+        {
+            return Err(EmaError::InvalidRequest(
+                "client IDs and refresh token must not be empty",
+            ));
+        }
+        self.idp.client_authentication.validate()?;
+        self.resource_as.client_authentication.validate()?;
+        let requested: HashSet<&str> = self.scopes.iter().map(String::as_str).collect();
+        if requested.len() != self.scopes.len() || self.scopes.iter().any(|s| !is_scope_token(s)) {
+            return Err(EmaError::InvalidRequest(
+                "scopes must be distinct non-empty tokens",
+            ));
+        }
+        let mut params = vec![
+            (
+                "grant_type",
+                "urn:ietf:params:oauth:grant-type:token-exchange",
+            ),
+            ("requested_token_type", ID_JAG_TOKEN_TYPE),
+            (
+                "subject_token_type",
+                "urn:ietf:params:oauth:token-type:refresh_token",
+            ),
+            ("subject_token", self.refresh_token.secret()),
+            ("audience", self.resource_as.issuer.as_str()),
+            ("resource", self.resource),
+        ];
+        let scope = self.scopes.join(" ");
+        if !scope.is_empty() {
+            params.push(("scope", &scope));
+        }
+        let jag: IdJagResponse = post_form(
+            idp_http,
+            &self.idp,
+            &params,
+            EmaExchangeStage::IdentityProvider,
+        )
+        .await?;
+        let granted = jag.validate(&self, &requested)?;
+        Ok(EmaIdJag {
+            assertion: AccessToken::new(jag.access_token),
+            scopes: granted,
+        })
+    }
+}
+
+/// An IdP-issued ID-JAG whose structure and bindings have been checked, not its signature.
+pub struct EmaIdJag {
+    assertion: AccessToken,
+    scopes: HashSet<String>,
+}
+
+impl std::fmt::Debug for EmaAuthorizationServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("EmaAuthorizationServer { .. }")
+    }
+}
+
+impl std::fmt::Debug for EmaExchangeRequest<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("EmaExchangeRequest { .. }")
+    }
+}
+
+impl std::fmt::Debug for EmaIdJag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("EmaIdJag { .. }")
+    }
+}
+
+impl EmaIdJag {
+    /// The assertion to present to the approved resource authorization server.
+    pub fn assertion(&self) -> &AccessToken {
+        &self.assertion
+    }
+
+    /// The scope tokens carried by the assertion; an empty set means scope was omitted.
+    pub fn scopes(&self) -> &HashSet<String> {
+        &self.scopes
+    }
+}
+
+/// The endpoint that failed, allowing the caller to apply its own credential lifecycle policy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EmaExchangeStage {
+    IdentityProvider,
+    ResourceAuthorizationServer,
+}
+
+/// Sanitized failures. Raw HTTP adapter errors and provider response bodies are never retained.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EmaError {
+    #[error("invalid EMA exchange request: {0}")]
+    InvalidRequest(&'static str),
+    #[error("invalid EMA response from {stage:?}: {message}")]
+    InvalidResponse {
+        stage: EmaExchangeStage,
+        message: &'static str,
+    },
+    #[error("EMA request to {0:?} failed")]
+    RequestFailed(EmaExchangeStage),
+    #[error("{0:?}: invalid_grant")]
+    InvalidGrant(EmaExchangeStage),
+    #[error("{0:?}: insufficient_user_authentication")]
+    InsufficientUserAuthentication(EmaExchangeStage),
+    #[error("{stage:?} returned HTTP {status}: {code}")]
+    OAuthRejected {
+        stage: EmaExchangeStage,
+        status: u16,
+        code: &'static str,
+    },
+}
+
+async fn post_form<T: DeserializeOwned>(
+    http: &dyn OAuthHttpClient,
+    server: &EmaAuthorizationServer,
+    params: &[(&str, &str)],
+    stage: EmaExchangeStage,
+) -> Result<T, EmaError> {
+    let response = tokio::time::timeout(DEFAULT_HTTP_TIMEOUT, async {
+        // Generate assertions at the request boundary, not when server configuration is built.
+        let client_assertion = match &server.client_authentication {
+            EmaClientAuthentication::JwtAssertion(provider) => {
+                let assertion = provider
+                    .create_assertion(server)
+                    .await
+                    .map_err(|_| EmaError::RequestFailed(stage))?;
+                if assertion.0.trim().is_empty() {
+                    return Err(EmaError::InvalidRequest(
+                        "client assertion must not be empty",
+                    ));
+                }
+                Some(assertion)
+            }
+            _ => None,
+        };
+        let request = {
+            let mut form = url::form_urlencoded::Serializer::new(String::new());
+            form.extend_pairs(params.iter().copied());
+            let mut request = oauth2::http::Request::builder()
+                .method("POST")
+                .uri(&server.token_endpoint)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("accept", "application/json");
+            match &server.client_authentication {
+                EmaClientAuthentication::ClientSecretBasic(secret) => {
+                    let client_id: String =
+                        url::form_urlencoded::byte_serialize(server.client_id.as_bytes()).collect();
+                    let secret: String =
+                        url::form_urlencoded::byte_serialize(secret.secret().as_bytes()).collect();
+                    let encoded = STANDARD.encode(format!("{client_id}:{secret}"));
+                    let mut header =
+                        oauth2::http::HeaderValue::from_str(&format!("Basic {encoded}")).map_err(
+                            |_| EmaError::InvalidRequest("invalid client authentication header"),
+                        )?;
+                    header.set_sensitive(true);
+                    request = request.header(oauth2::http::header::AUTHORIZATION, header);
+                }
+                EmaClientAuthentication::ClientSecretPost(secret) => {
+                    form.append_pair("client_id", &server.client_id)
+                        .append_pair("client_secret", secret.secret());
+                }
+                EmaClientAuthentication::None | EmaClientAuthentication::JwtAssertion(_) => {
+                    form.append_pair("client_id", &server.client_id);
+                }
+            }
+            if let Some(assertion) = client_assertion {
+                form.append_pair(
+                    "client_assertion_type",
+                    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                )
+                .append_pair("client_assertion", &assertion.0);
+            }
+            request
+                .body(form.finish().into_bytes())
+                .map_err(|_| EmaError::InvalidRequest("invalid token endpoint URI"))?
+        };
+        http.execute(OAuthHttpRequest::new(
+            request,
+            OAuthHttpRedirectPolicy::Stop,
+        ))
+        .await
+        .map_err(|_| EmaError::RequestFailed(stage))
+    })
+    .await
+    .map_err(|_| EmaError::RequestFailed(stage))??;
+    let invalid = |message| EmaError::InvalidResponse { stage, message };
+    if response.body().len() > MAX_OAUTH_HTTP_RESPONSE_BODY_BYTES {
+        return Err(invalid("response body too large"));
+    }
+    if !response.status().is_success() {
+        #[derive(Deserialize)]
+        struct OAuthError {
+            error: Option<String>,
+        }
+        let error = serde_json::from_slice::<OAuthError>(response.body()).ok();
+        let code = match error.as_ref().and_then(|e| e.error.as_deref()) {
+            Some("invalid_grant") => return Err(EmaError::InvalidGrant(stage)),
+            Some("insufficient_user_authentication") => {
+                return Err(EmaError::InsufficientUserAuthentication(stage));
+            }
+            Some("invalid_request") => "invalid_request",
+            Some("invalid_client") => "invalid_client",
+            Some("invalid_scope") => "invalid_scope",
+            Some("invalid_target") => "invalid_target",
+            Some("unauthorized_client") => "unauthorized_client",
+            Some("unsupported_grant_type") => "unsupported_grant_type",
+            Some("access_denied") => "access_denied",
+            Some("temporarily_unavailable") => "temporarily_unavailable",
+            Some("server_error") => "server_error",
+            _ => "OAuth token request rejected",
+        };
+        return Err(EmaError::OAuthRejected {
+            stage,
+            status: response.status().as_u16(),
+            code,
+        });
+    }
+    serde_json::from_slice(response.body()).map_err(|_| invalid("malformed token response"))
+}
+
+fn validate_endpoint(value: &str) -> Result<(), EmaError> {
+    let url = Url::parse(value).map_err(|_| EmaError::InvalidRequest("invalid endpoint URL"))?;
+    let loopback = match url.host() {
+        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(Host::Ipv6(ip)) => ip.is_loopback(),
+        None => false,
+    };
+    if (url.scheme() != "https" && !(url.scheme() == "http" && loopback))
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(EmaError::InvalidRequest(
+            "endpoint must use HTTPS or HTTP loopback without userinfo or fragments",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum Resource {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl Resource {
+    fn is_exact(&self, expected: &str) -> bool {
+        match self {
+            Self::Single(value) => value == expected,
+            Self::Multiple(values) => values.as_slice() == [expected],
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct JwtHeader {
+    alg: String,
+    typ: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct IdJagClaims {
+    iss: String,
+    sub: String,
+    aud: Resource,
+    client_id: String,
+    jti: String,
+    exp: u64,
+    iat: u64,
+    resource: Resource,
+    scope: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct IdJagResponse {
+    access_token: String,
+    issued_token_type: String,
+    token_type: String,
+    resource: Option<Resource>,
+    scope: Option<String>,
+    refresh_token: Option<String>,
+}
+
+impl IdJagResponse {
+    fn validate(
+        &self,
+        request: &EmaExchangeRequest<'_>,
+        requested: &HashSet<&str>,
+    ) -> Result<HashSet<String>, EmaError> {
+        let invalid = |message| EmaError::InvalidResponse {
+            stage: EmaExchangeStage::IdentityProvider,
+            message,
+        };
+        if self.issued_token_type != ID_JAG_TOKEN_TYPE
+            || self.token_type != "N_A"
+            || self.refresh_token.is_some()
+        {
+            return Err(invalid("unsupported ID-JAG token type or refresh token"));
+        }
+        let mut parts = self.access_token.split('.');
+        let (Some(header), Some(payload), Some(signature), None) =
+            (parts.next(), parts.next(), parts.next(), parts.next())
+        else {
+            return Err(invalid("ID-JAG must be a compact signed JWT"));
+        };
+        if header.is_empty() || payload.is_empty() || signature.is_empty() {
+            return Err(invalid("ID-JAG contains an empty JWT segment"));
+        }
+        let decode = |value| {
+            URL_SAFE_NO_PAD
+                .decode(value)
+                .map_err(|_| invalid("malformed ID-JAG encoding"))
+        };
+        decode(signature)?;
+        let header: JwtHeader = serde_json::from_slice(&decode(header)?)
+            .map_err(|_| invalid("malformed ID-JAG header"))?;
+        let claims: IdJagClaims = serde_json::from_slice(&decode(payload)?)
+            .map_err(|_| invalid("malformed ID-JAG claims"))?;
+        if header.alg.trim().is_empty()
+            || header.alg.eq_ignore_ascii_case("none")
+            || header.typ.as_deref() != Some("oauth-id-jag+jwt")
+            || claims.iss != request.idp.issuer
+            || !claims.aud.is_exact(&request.resource_as.issuer)
+            || claims.client_id != request.resource_as.client_id
+            || claims.sub.trim().is_empty()
+            || claims.jti.trim().is_empty()
+        {
+            return Err(invalid(
+                "ID-JAG type, issuer, audience, client, subject, or JWT ID mismatch",
+            ));
+        }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| invalid("system clock precedes the Unix epoch"))?
+            .as_secs();
+        if claims.exp <= now || claims.iat > now.saturating_add(60) {
+            return Err(invalid("expired or future-issued ID-JAG"));
+        }
+        if !claims.resource.is_exact(request.resource)
+            || self
+                .resource
+                .as_ref()
+                .is_some_and(|r| !r.is_exact(request.resource))
+        {
+            return Err(invalid("ID-JAG resource mismatch"));
+        }
+        let parse =
+            |scope| parse_scope(scope).ok_or_else(|| invalid("malformed or duplicate scopes"));
+        let granted = match claims.scope.as_deref() {
+            Some(scope) => parse(scope)?,
+            None if requested.is_empty() => HashSet::new(),
+            None => return Err(invalid("ID-JAG is missing requested scope authorization")),
+        };
+        if !requested.is_empty() && !granted.is_subset(requested) {
+            return Err(invalid("ID-JAG scope exceeds the request"));
+        }
+        match self.scope.as_deref() {
+            Some(scope) if parse(scope)? != granted => {
+                return Err(invalid("response scope differs from ID-JAG scope"));
+            }
+            None if !requested.is_empty() && granted != *requested => {
+                return Err(invalid("response omitted narrowed scope"));
+            }
+            _ => {}
+        }
+        Ok(granted.into_iter().map(str::to_owned).collect())
+    }
+}
+
+fn parse_scope(scope: &str) -> Option<HashSet<&str>> {
+    let scopes: HashSet<_> = scope.split(' ').collect();
+    (scopes.iter().all(|s| is_scope_token(s)) && scopes.len() == scope.split(' ').count())
+        .then_some(scopes)
+}
+
+fn is_scope_token(scope: &str) -> bool {
+    !scope.is_empty()
+        && scope
+            .bytes()
+            .all(|b| matches!(b, b'!' | b'#'..=b'[' | b']'..=b'~'))
+}
+
+#[cfg(test)]
+#[path = "enterprise_tests.rs"]
+mod tests;

--- a/crates/rmcp/src/transport/auth/enterprise.rs
+++ b/crates/rmcp/src/transport/auth/enterprise.rs
@@ -1,21 +1,45 @@
-//! Non-interactive enterprise-managed authorization (EMA/XAA) token exchange.
+//! Non-interactive enterprise-managed authorization (EMA/XAA) token exchanges.
 //!
-//! Exchanges an enterprise refresh token for a resource-bound ID-JAG.
-//! Callers must discover and approve both servers and their registrations
+//! Exchanges an enterprise refresh token for an ID-JAG, then for an MCP access
+//! token. Callers must discover and approve both servers and their registrations
 //! before supplying a credential. This module does not discover servers, log in,
 //! persist credentials, or decide when to reauthenticate.
 //!
-//! Configure the IdP client's approved authentication method: HTTP Basic, a client
-//! secret in the request body, or a freshly signed JWT client assertion. Public
-//! clients are supported only where explicitly allowed by the IdP. The helper
-//! requires one MCP resource and does not implement Rich Authorization Requests
-//! or DPoP. It does not automatically retry token requests.
+//! Configure each pre-registered client's approved authentication method separately:
+//! HTTP Basic, a client secret in the request body, or a freshly signed JWT client
+//! assertion. Public-client authentication requires the server's explicit approval.
+//! This helper requires one MCP resource and does not implement Rich
+//! Authorization Requests or DPoP. Redemption consumes the SDK's ID-JAG handle,
+//! without automatic retries; server-side replay policy remains the server's responsibility.
 //!
 //! ID-JAG checks below enforce structure and claim bindings, not cryptographic
 //! signature verification. Assertions come directly from the trusted IdP token
 //! endpoint; the resource authorization server must verify their signatures.
+//!
+//! ```no_run
+//! use oauth2::{ClientSecret, RefreshToken};
+//! use rmcp::transport::auth::{default_oauth_http_client, enterprise::*};
+//!
+//! # async fn authorize(refresh: &RefreshToken, idp_secret: ClientSecret, resource_secret: ClientSecret) -> Result<(), Box<dyn std::error::Error>> {
+//! // Enable `auth-enterprise-managed` and a TLS feature such as `reqwest`.
+//! let http = default_oauth_http_client()?;
+//! let token = EmaExchangeRequest::new(
+//!     EmaAuthorizationServer::new("https://idp.example", "https://idp.example/token", "idp-client")
+//!         .with_client_authentication(EmaClientAuthentication::ClientSecretBasic(idp_secret)),
+//!     EmaAuthorizationServer::new("https://as.example", "https://as.example/token", "mcp-client")
+//!         .with_client_authentication(EmaClientAuthentication::ClientSecretBasic(resource_secret)),
+//!     "https://mcp.example", refresh,
+//! ).with_scopes(["files.read"]).exchange(&http, &http).await?;
+//! // Use token.access_token only for the approved MCP resource; never log it.
+//! // token.scopes contains the final granted scopes, which may be narrower.
+//! # Ok(()) }
+//! ```
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::HashSet,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use base64::{
     Engine,
@@ -90,8 +114,8 @@ impl std::fmt::Debug for EmaClientAssertion {
 
 /// Creates client assertions on demand, allowing keys to remain in an external signer.
 ///
-/// Called once immediately before each token request.
-/// Set `iss` and `sub` to the registered client identifier and `aud`
+/// Called once immediately before each token request, including delayed ID-JAG
+/// redemption. Set `iss` and `sub` to the registered client identifier and `aud`
 /// to the server's approved audience, with a short expiration and a fresh `jti`.
 /// The SDK does not sign or validate these assertions. Provider failures are
 /// sanitized and the call shares the token request's timeout. Cancellation may
@@ -120,11 +144,15 @@ pub struct EmaAuthorizationServer {
 impl EmaAuthorizationServer {
     /// Use approved metadata and a public-client registration (`token_endpoint_auth_method=none`).
     /// Set [`Self::with_client_authentication`] for a confidential client.
-    pub fn new(issuer: &str, token_endpoint: &str, client_id: &str) -> Self {
+    pub fn new(
+        issuer: impl Into<String>,
+        token_endpoint: impl Into<String>,
+        client_id: impl Into<String>,
+    ) -> Self {
         Self {
-            issuer: issuer.to_owned(),
-            token_endpoint: token_endpoint.to_owned(),
-            client_id: client_id.to_owned(),
+            issuer: issuer.into(),
+            token_endpoint: token_endpoint.into(),
+            client_id: client_id.into(),
             client_authentication: EmaClientAuthentication::None,
         }
     }
@@ -142,11 +170,11 @@ pub struct EmaExchangeRequest<'a> {
     resource_as: EmaAuthorizationServer,
     resource: &'a str,
     refresh_token: &'a RefreshToken,
-    scopes: &'a [String],
+    scopes: Vec<String>,
 }
 
 impl<'a> EmaExchangeRequest<'a> {
-    /// No scope parameter is sent until [`Self::scopes`] is used.
+    /// No scope parameter is sent until [`Self::with_scopes`] is used.
     pub fn new(
         idp: EmaAuthorizationServer,
         resource_as: EmaAuthorizationServer,
@@ -158,14 +186,18 @@ impl<'a> EmaExchangeRequest<'a> {
             resource_as,
             resource,
             refresh_token,
-            scopes: &[],
+            scopes: Vec::new(),
         }
     }
 
     /// Request distinct non-empty scope tokens; the IdP may narrow them.
-    /// An empty slice omits `scope`, rather than requesting an empty grant.
-    pub fn scopes(mut self, scopes: &'a [String]) -> Self {
-        self.scopes = scopes;
+    /// An empty iterator omits `scope`, rather than requesting an empty grant.
+    pub fn with_scopes<I, S>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.scopes = scopes.into_iter().map(Into::into).collect();
         self
     }
 
@@ -228,13 +260,30 @@ impl<'a> EmaExchangeRequest<'a> {
             &self.idp,
             &params,
             EmaExchangeStage::IdentityProvider,
+            None,
+            unix_time,
         )
         .await?;
-        let granted = jag.validate(&self, &requested)?;
+        let (granted, expires_at) = jag.validate(&self, &requested)?;
         Ok(EmaIdJag {
             assertion: AccessToken::new(jag.access_token),
             scopes: granted,
+            resource_as: self.resource_as,
+            resource: self.resource.to_owned(),
+            expires_at,
         })
+    }
+
+    /// Perform both exchanges with independently routed HTTP clients and no automatic retries.
+    pub async fn exchange(
+        self,
+        idp_http: &dyn OAuthHttpClient,
+        resource_http: &dyn OAuthHttpClient,
+    ) -> Result<EmaAccessToken, EmaError> {
+        self.exchange_id_jag(idp_http)
+            .await?
+            .exchange(resource_http)
+            .await
     }
 }
 
@@ -242,6 +291,9 @@ impl<'a> EmaExchangeRequest<'a> {
 pub struct EmaIdJag {
     assertion: AccessToken,
     scopes: HashSet<String>,
+    resource_as: EmaAuthorizationServer,
+    resource: String,
+    expires_at: u64,
 }
 
 impl std::fmt::Debug for EmaAuthorizationServer {
@@ -271,6 +323,53 @@ impl EmaIdJag {
     /// The scope tokens carried by the assertion; an empty set means scope was omitted.
     pub fn scopes(&self) -> &HashSet<String> {
         &self.scopes
+    }
+
+    /// Redeem this assertion once, at its approved resource AS, without redirects or retries.
+    /// Consume the grant so this helper cannot accidentally replay it after a failed exchange.
+    pub async fn exchange(self, http: &dyn OAuthHttpClient) -> Result<EmaAccessToken, EmaError> {
+        self.exchange_with_clock(http, unix_time).await
+    }
+
+    async fn exchange_with_clock(
+        self,
+        http: &dyn OAuthHttpClient,
+        now: impl Fn() -> Result<u64, EmaError> + Sync,
+    ) -> Result<EmaAccessToken, EmaError> {
+        if self.expires_at <= now()? {
+            return Err(EmaError::InvalidRequest("ID-JAG expired before redemption"));
+        }
+        // Only the assertion carries authority: repeating resource/scope could undo narrowing.
+        let token: ResourceTokenResponse = post_form(
+            http,
+            &self.resource_as,
+            &[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+                ("assertion", self.assertion.secret()),
+            ],
+            EmaExchangeStage::ResourceAuthorizationServer,
+            Some(self.expires_at),
+            now,
+        )
+        .await?;
+        token.validate(&self.resource, self.scopes)
+    }
+}
+
+/// A resource-bound bearer with secret-safe diagnostics and its optional lifetime.
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct EmaAccessToken {
+    pub access_token: AccessToken,
+    pub expires_in: Option<Duration>,
+    /// Resource-AS scopes, or the ID-JAG scopes when the response omits `scope`.
+    /// Empty when both the ID-JAG and response omit scopes.
+    pub scopes: HashSet<String>,
+}
+
+impl std::fmt::Debug for EmaAccessToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("EmaAccessToken { .. }")
     }
 }
 
@@ -312,6 +411,8 @@ async fn post_form<T: DeserializeOwned>(
     server: &EmaAuthorizationServer,
     params: &[(&str, &str)],
     stage: EmaExchangeStage,
+    grant_expires_at: Option<u64>,
+    now: impl Fn() -> Result<u64, EmaError> + Sync,
 ) -> Result<T, EmaError> {
     let response = tokio::time::timeout(DEFAULT_HTTP_TIMEOUT, async {
         // Generate assertions at the request boundary, not when server configuration is built.
@@ -371,6 +472,12 @@ async fn post_form<T: DeserializeOwned>(
                 .body(form.finish().into_bytes())
                 .map_err(|_| EmaError::InvalidRequest("invalid token endpoint URI"))?
         };
+        // An external signer may outlive the grant even when it meets the request deadline.
+        if let Some(expires_at) = grant_expires_at
+            && expires_at <= now()?
+        {
+            return Err(EmaError::InvalidRequest("ID-JAG expired before redemption"));
+        }
         http.execute(OAuthHttpRequest::new(
             request,
             OAuthHttpRedirectPolicy::Stop,
@@ -468,6 +575,7 @@ struct IdJagClaims {
     iat: u64,
     resource: Resource,
     scope: Option<String>,
+    authorization_details: Option<Vec<serde_json::Value>>,
 }
 
 #[derive(Deserialize)]
@@ -478,6 +586,7 @@ struct IdJagResponse {
     resource: Option<Resource>,
     scope: Option<String>,
     refresh_token: Option<String>,
+    authorization_details: Option<Vec<serde_json::Value>>,
 }
 
 impl IdJagResponse {
@@ -485,7 +594,7 @@ impl IdJagResponse {
         &self,
         request: &EmaExchangeRequest<'_>,
         requested: &HashSet<&str>,
-    ) -> Result<HashSet<String>, EmaError> {
+    ) -> Result<(HashSet<String>, u64), EmaError> {
         let invalid = |message| EmaError::InvalidResponse {
             stage: EmaExchangeStage::IdentityProvider,
             message,
@@ -515,6 +624,12 @@ impl IdJagResponse {
             .map_err(|_| invalid("malformed ID-JAG header"))?;
         let claims: IdJagClaims = serde_json::from_slice(&decode(payload)?)
             .map_err(|_| invalid("malformed ID-JAG claims"))?;
+        if [&self.authorization_details, &claims.authorization_details]
+            .into_iter()
+            .any(|details| details.as_ref().is_some_and(|details| !details.is_empty()))
+        {
+            return Err(invalid("authorization_details is not supported"));
+        }
         if header.alg.trim().is_empty()
             || header.alg.eq_ignore_ascii_case("none")
             || header.typ.as_deref() != Some("oauth-id-jag+jwt")
@@ -528,10 +643,7 @@ impl IdJagResponse {
                 "ID-JAG type, issuer, audience, client, subject, or JWT ID mismatch",
             ));
         }
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|_| invalid("system clock precedes the Unix epoch"))?
-            .as_secs();
+        let now = unix_time()?;
         if claims.exp <= now || claims.iat > now.saturating_add(60) {
             return Err(invalid("expired or future-issued ID-JAG"));
         }
@@ -562,7 +674,7 @@ impl IdJagResponse {
             }
             _ => {}
         }
-        Ok(granted.into_iter().map(str::to_owned).collect())
+        Ok((granted.into_iter().map(str::to_owned).collect(), claims.exp))
     }
 }
 
@@ -577,6 +689,77 @@ fn is_scope_token(scope: &str) -> bool {
         && scope
             .bytes()
             .all(|b| matches!(b, b'!' | b'#'..=b'[' | b']'..=b'~'))
+}
+
+fn unix_time() -> Result<u64, EmaError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|_| EmaError::InvalidRequest("system clock precedes the Unix epoch"))
+}
+
+#[derive(Deserialize)]
+struct ResourceTokenResponse {
+    access_token: String,
+    token_type: String,
+    expires_in: Option<u64>,
+    resource: Option<Resource>,
+    scope: Option<String>,
+    refresh_token: Option<String>,
+    authorization_details: Option<Vec<serde_json::Value>>,
+}
+
+impl ResourceTokenResponse {
+    fn validate(
+        self,
+        resource: &str,
+        granted: HashSet<String>,
+    ) -> Result<EmaAccessToken, EmaError> {
+        let invalid = |message| EmaError::InvalidResponse {
+            stage: EmaExchangeStage::ResourceAuthorizationServer,
+            message,
+        };
+        if self
+            .authorization_details
+            .as_ref()
+            .is_some_and(|details| !details.is_empty())
+        {
+            return Err(invalid("authorization_details is not supported"));
+        }
+        if !self.token_type.eq_ignore_ascii_case("bearer")
+            || self.access_token.trim().is_empty()
+            || self.refresh_token.is_some()
+            || self.expires_in == Some(0)
+        {
+            return Err(invalid(
+                "invalid bearer token, lifetime, or unexpected refresh token",
+            ));
+        }
+        // The resource need not be echoed, but must agree with the ID-JAG if present.
+        if self
+            .resource
+            .as_ref()
+            .is_some_and(|r| !r.is_exact(resource))
+        {
+            return Err(invalid("access token resource mismatch"));
+        }
+        // An omitted scope retains the authority carried by the assertion.
+        let scopes = if let Some(scope) = self.scope.as_deref() {
+            let scopes =
+                parse_scope(scope).ok_or_else(|| invalid("malformed or duplicate scopes"))?;
+            if !scopes.iter().all(|s| granted.contains(*s)) {
+                return Err(invalid("access token scope exceeds ID-JAG scope"));
+            }
+            scopes.into_iter().map(str::to_owned).collect()
+        } else {
+            granted
+        };
+        Ok(EmaAccessToken {
+            access_token: AccessToken::new(self.access_token),
+            expires_in: self.expires_in.map(Duration::from_secs),
+            scopes,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/rmcp/src/transport/auth/enterprise_tests.rs
+++ b/crates/rmcp/src/transport/auth/enterprise_tests.rs
@@ -1,0 +1,645 @@
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+    time::{Duration, SystemTime},
+};
+
+use base64::{
+    Engine,
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+};
+use oauth2::{ClientSecret, HttpResponse, RefreshToken};
+use serde_json::{Value, json};
+
+use super::{
+    EmaExchangeStage::{IdentityProvider as Idp, ResourceAuthorizationServer as ResourceServer},
+    *,
+};
+use crate::transport::auth::{OAuthHttpClientError, OAuthHttpClientFuture, OAuthHttpRequest};
+
+const IDP: &str = "https://idp.example?private-query";
+const AS: &str = "https://as.example?private-query";
+const RESOURCE: &str = "https://mcp.example?private-query";
+const IDP_TOKEN: &str = "https://idp.example/token?private-query";
+const AS_TOKEN: &str = "https://as.example/token?private-query";
+const BAD_SCOPES: &[&str] = &["", "files\tread", "\"", "\\", "\0", "读"];
+
+#[derive(Default)]
+struct MockHttp {
+    requests: Mutex<Vec<OAuthHttpRequest>>,
+    response: Mutex<Option<Result<HttpResponse, OAuthHttpClientError>>>,
+}
+
+impl MockHttp {
+    fn new(status: u16, body: Value) -> Self {
+        Self {
+            response: Mutex::new(Some(Ok(oauth2::http::Response::builder()
+                .status(status)
+                .body(serde_json::to_vec(&body).unwrap())
+                .unwrap()))),
+            ..Self::default()
+        }
+    }
+}
+
+impl OAuthHttpClient for MockHttp {
+    fn execute(&self, request: OAuthHttpRequest) -> OAuthHttpClientFuture<'_> {
+        self.requests.lock().unwrap().push(request);
+        let response = self.response.lock().unwrap().take();
+        let response = response.expect("unexpected HTTP");
+        Box::pin(async move { response })
+    }
+}
+
+fn jwt(header: Value, claims: &Value) -> String {
+    format!(
+        "{}.{}.{}",
+        URL_SAFE_NO_PAD.encode(header.to_string()),
+        URL_SAFE_NO_PAD.encode(claims.to_string()),
+        URL_SAFE_NO_PAD.encode(b"synthetic-signature")
+    )
+}
+
+fn claims() -> Value {
+    let now = SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    json!({"iss":IDP,"aud":AS,"sub":"user","client_id":"mcp",
+        "jti":"jag-id","iat":now,"exp":now + 3600,"resource":RESOURCE,"scope":"files.read"})
+}
+
+fn jag(claims: &Value) -> Value {
+    let mut body = json!({"access_token":jwt(json!({"alg":"ES256","typ":"oauth-id-jag+jwt"}), claims),
+        "issued_token_type":ID_JAG_TOKEN_TYPE,"token_type":"N_A","resource":claims["resource"]});
+    if let Some(scope) = claims.get("scope") {
+        body["scope"] = scope.clone();
+    }
+    body
+}
+
+async fn exchange(idp: &MockHttp, scopes: &str) -> Result<EmaIdJag, EmaError> {
+    let scopes = scopes
+        .split_ascii_whitespace()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let refresh = RefreshToken::new("refresh-token".into());
+    let resource_as = EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp");
+    assert!(!format!("{resource_as:?}").contains("private-query"));
+    let request = EmaExchangeRequest::new(
+        EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp"),
+        resource_as,
+        RESOURCE,
+        &refresh,
+    )
+    .scopes(&scopes);
+    assert!(!format!("{request:?}").contains(refresh.secret()));
+    assert!(!format!("{request:?}").contains("private-query"));
+    let future = request.exchange_id_jag(idp);
+    fn is_send<T: Send>(_: &T) {}
+    is_send(&future);
+    future.await
+}
+
+fn form(request: &OAuthHttpRequest) -> BTreeMap<String, String> {
+    assert!(!request.request.headers().contains_key("authorization"));
+    authenticated_form(request)
+}
+
+fn authenticated_form(request: &OAuthHttpRequest) -> BTreeMap<String, String> {
+    assert_eq!(request.request.method(), "POST");
+    let headers = request.request.headers();
+    assert_eq!(headers["content-type"], "application/x-www-form-urlencoded");
+    assert_eq!(headers["accept"], "application/json");
+    assert_eq!(request.redirect_policy, OAuthHttpRedirectPolicy::Stop);
+    assert_eq!(request.timeout, Some(Duration::from_secs(30)));
+    let pairs = url::form_urlencoded::parse(request.request.body())
+        .into_owned()
+        .collect::<Vec<_>>();
+    let fields = pairs.iter().cloned().collect::<BTreeMap<_, _>>();
+    assert_eq!(pairs.len(), fields.len(), "duplicate form fields");
+    fields
+}
+
+#[tokio::test]
+async fn refresh_exchange_preserves_exact_forms_and_signed_narrowing() {
+    for scopes in ["files.read files.write", ""] {
+        let response = jag(&claims());
+        let idp = MockHttp::new(200, response.clone());
+        let result = exchange(&idp, scopes).await.unwrap();
+        assert_eq!(
+            result.assertion().secret(),
+            response["access_token"].as_str().unwrap()
+        );
+        assert_eq!(result.scopes(), &HashSet::from(["files.read".to_owned()]));
+        assert!(!format!("{result:?}").contains(result.assertion().secret()));
+        assert!(!format!("{result:?}").contains("private-query"));
+        let requests = idp.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].request.uri(), IDP_TOKEN);
+        let mut fields = form(&requests[0]);
+        assert_eq!(
+            fields.remove("scope"),
+            (!scopes.is_empty()).then(|| scopes.to_owned())
+        );
+        assert_eq!(
+            serde_json::to_value(fields).unwrap(),
+            json!({
+                "grant_type":"urn:ietf:params:oauth:grant-type:token-exchange",
+                "requested_token_type":ID_JAG_TOKEN_TYPE,"subject_token":"refresh-token",
+                "subject_token_type":"urn:ietf:params:oauth:token-type:refresh_token",
+                "audience":AS,"resource":RESOURCE,"client_id":"idp"
+            })
+        );
+    }
+}
+
+#[tokio::test]
+async fn scopes_may_be_omitted_but_never_widened() {
+    for (requested, signed, echoed, valid) in [
+        ("", Some("files.read"), None, true),
+        ("", None, None, true),
+        ("files.read", Some("files.read"), None, true),
+        ("files.read files.write", Some("files.read"), None, false),
+        (
+            "files.read",
+            Some("files.read files.write"),
+            Some("files.read files.write"),
+            false,
+        ),
+        ("files.read", None, None, false),
+        ("", Some("files.read"), Some("files.write"), false),
+        ("", Some(" \t"), None, false),
+        ("", Some("files.read files.read"), None, false),
+        ("", Some("files.read"), Some(" \t"), false),
+        ("", Some("files.read"), Some("files.read files.read"), false),
+    ] {
+        let mut claims = claims();
+        claims.as_object_mut().unwrap().remove("scope");
+        if let Some(scope) = signed {
+            claims["scope"] = json!(scope);
+        }
+        let mut response = jag(&claims);
+        response.as_object_mut().unwrap().remove("scope");
+        if let Some(scope) = echoed {
+            response["scope"] = json!(scope);
+        }
+        let result = exchange(&MockHttp::new(200, response), requested).await;
+        assert_eq!(
+            result.is_ok(),
+            valid,
+            "requested={requested:?}, signed={signed:?}, echoed={echoed:?}"
+        );
+        if let Ok(result) = result {
+            let expected = signed.into_iter().map(str::to_owned).collect();
+            assert_eq!(result.scopes(), &expected);
+        }
+    }
+}
+
+#[tokio::test]
+async fn invalid_jags_never_escape_validation() {
+    let original = claims();
+    let mut cases = Vec::new();
+    let invalid = json!({"iss":"https://other.example","aud":[AS,"other"],
+        "client_id":"other","sub":"","jti":" \t","exp":0,"iat":u64::MAX,"resource":[RESOURCE,"other"]});
+    for (key, value) in invalid.as_object().unwrap() {
+        let mut changed = original.clone();
+        changed[key] = value.clone();
+        cases.push(jag(&changed));
+    }
+    for scope in BAD_SCOPES {
+        let mut changed = original.clone();
+        changed["scope"] = json!(scope);
+        cases.push(jag(&changed));
+    }
+    for header in [
+        json!({"alg":"ES256","typ":"JWT"}),
+        json!({"alg":"ES256"}),
+        json!({"alg":"none","typ":"oauth-id-jag+jwt"}),
+    ] {
+        let mut response = jag(&original);
+        response["access_token"] = json!(jwt(header, &original));
+        cases.push(response);
+    }
+    let invalid = json!({"issued_token_type":"Bearer","token_type":"Bearer",
+        "refresh_token":"unsupported","resource":"https://other.example","access_token":"a.b.c.d"});
+    for (key, value) in invalid.as_object().unwrap() {
+        let mut response = jag(&original);
+        response[key] = value.clone();
+        cases.push(response);
+    }
+    for signature in ["", "signature", "not+base64url", "c2ln="] {
+        let mut response = jag(&original);
+        let assertion = response["access_token"].as_str().unwrap();
+        let (signed, _) = assertion.rsplit_once('.').unwrap();
+        response["access_token"] = json!(format!("{signed}.{signature}"));
+        cases.push(response);
+    }
+    for response in cases {
+        let result = exchange(&MockHttp::new(200, response), "files.read").await;
+        assert!(matches!(
+            result,
+            Err(EmaError::InvalidResponse { stage: Idp, .. })
+        ));
+    }
+}
+
+#[tokio::test]
+async fn invalid_inputs_fail_before_http() {
+    // Each server occupies issuer, token endpoint, and client ID slots.
+    let original = [IDP, IDP_TOKEN, "idp", AS, AS_TOKEN, "mcp", RESOURCE, "rt"];
+    let mut cases = Vec::new();
+    for index in [0, 1, 3, 4, 6] {
+        for value in [
+            "invalid",
+            "http://idp.example/token",
+            "https://user:pass@idp.example/token",
+            "https://idp.example/token#fragment",
+        ] {
+            let mut fields = original;
+            fields[index] = value;
+            cases.push((fields, vec![]));
+        }
+    }
+    for (index, value) in [(0, AS), (2, " "), (5, ""), (7, " \t")] {
+        let mut fields = original;
+        fields[index] = value;
+        cases.push((fields, vec![]));
+    }
+    for scope in BAD_SCOPES.iter().copied().chain(["files.read files.write"]) {
+        cases.push((original, vec![scope]));
+    }
+    cases.push((original, vec!["files.read", "files.read"]));
+    for (fields, scopes) in cases {
+        let http = MockHttp::default();
+        let scopes = scopes.into_iter().map(str::to_owned).collect::<Vec<_>>();
+        let result = EmaExchangeRequest::new(
+            EmaAuthorizationServer::new(fields[0], fields[1], fields[2]),
+            EmaAuthorizationServer::new(fields[3], fields[4], fields[5]),
+            fields[6],
+            &RefreshToken::new(fields[7].into()),
+        )
+        .scopes(&scopes)
+        .exchange_id_jag(&http)
+        .await;
+        assert!(matches!(result, Err(EmaError::InvalidRequest(_))));
+        assert!(http.requests.lock().unwrap().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn errors_and_redirects_cannot_reflect_credentials() {
+    const SECRET: &str = "secret-error-sentinel";
+    for (status, code) in [
+        (400, "invalid_grant"),
+        (400, "insufficient_user_authentication"),
+        (400, "invalid_client"),
+        (400, SECRET),
+        (302, SECRET),
+    ] {
+        let failure = json!({"error":code,"error_description":SECRET});
+        let error = exchange(&MockHttp::new(status, failure), "")
+            .await
+            .unwrap_err();
+        match code {
+            "invalid_grant" => assert_eq!(error, EmaError::InvalidGrant(Idp)),
+            "insufficient_user_authentication" => {
+                assert_eq!(error, EmaError::InsufficientUserAuthentication(Idp))
+            }
+            _ => assert!(
+                matches!(error, EmaError::OAuthRejected {stage: Idp, status: actual, ..} if actual == status)
+            ),
+        }
+        assert!(!format!("{error:?} {error}").contains(SECRET));
+    }
+    for adapter_failure in [false, true] {
+        let failure = MockHttp::new(
+            200,
+            json!({"access_token":SECRET,"issued_token_type":SECRET}),
+        );
+        if adapter_failure {
+            *failure.response.lock().unwrap() = Some(Err(SECRET.into()));
+        }
+        let error = exchange(&failure, "").await.unwrap_err();
+        assert!(!format!("{error:?} {error}").contains(SECRET));
+        assert!(std::error::Error::source(&error).is_none());
+        if adapter_failure {
+            assert_eq!(error, EmaError::RequestFailed(Idp));
+        }
+    }
+    let mut oversized = jag(&claims());
+    oversized["ignored"] = json!("x".repeat(1024 * 1024));
+    let error = exchange(&MockHttp::new(200, oversized), "")
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        EmaError::InvalidResponse { stage: Idp, .. }
+    ));
+}
+
+#[derive(Clone, Copy)]
+enum AssertionBehavior {
+    Success,
+    Error,
+    Empty(&'static str),
+}
+
+struct RecordingAssertionProvider {
+    calls: Mutex<Vec<(String, String, String)>>,
+    behavior: AssertionBehavior,
+}
+
+impl RecordingAssertionProvider {
+    fn new(behavior: AssertionBehavior) -> Arc<Self> {
+        Arc::new(Self {
+            calls: Mutex::new(Vec::new()),
+            behavior,
+        })
+    }
+}
+
+fn client_assertion(client_id: &str, issuer: &str, sequence: usize) -> String {
+    jwt(
+        json!({"alg":"ES256","typ":"client-authentication+jwt"}),
+        &json!({"iss":client_id,"sub":client_id,"aud":issuer,
+            "exp":4102444800_u64,"jti":format!("client-assertion-{sequence}")}),
+    )
+}
+
+#[async_trait::async_trait]
+impl EmaClientAssertionProvider for RecordingAssertionProvider {
+    async fn create_assertion(
+        &self,
+        server: &EmaAuthorizationServer,
+    ) -> Result<EmaClientAssertion, Box<dyn std::error::Error + Send + Sync>> {
+        let sequence = {
+            let mut calls = self.calls.lock().unwrap();
+            calls.push((
+                server.issuer.clone(),
+                server.token_endpoint.clone(),
+                server.client_id.clone(),
+            ));
+            calls.len()
+        };
+        match self.behavior {
+            AssertionBehavior::Error => return Err("client-assertion-provider-secret".into()),
+            AssertionBehavior::Empty(value) => return Ok(EmaClientAssertion::new(value.into())),
+            AssertionBehavior::Success => {}
+        }
+        Ok(EmaClientAssertion::new(client_assertion(
+            &server.client_id,
+            &server.issuer,
+            sequence,
+        )))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AuthenticationMethod {
+    Public,
+    Basic,
+    Post,
+    Jwt,
+}
+
+impl AuthenticationMethod {
+    fn configure(
+        self,
+        secret: &str,
+        provider: &Arc<RecordingAssertionProvider>,
+    ) -> EmaClientAuthentication {
+        match self {
+            Self::Public => EmaClientAuthentication::None,
+            Self::Basic => {
+                EmaClientAuthentication::ClientSecretBasic(ClientSecret::new(secret.into()))
+            }
+            Self::Post => {
+                EmaClientAuthentication::ClientSecretPost(ClientSecret::new(secret.into()))
+            }
+            Self::Jwt => EmaClientAuthentication::JwtAssertion(provider.clone()),
+        }
+    }
+}
+
+fn remove_client_authentication(
+    request: &OAuthHttpRequest,
+    method: AuthenticationMethod,
+    client_id: &str,
+    secret: &str,
+    encoded_basic: &str,
+    assertion: &str,
+) -> BTreeMap<String, String> {
+    let mut fields = authenticated_form(request);
+    let authorization = request.request.headers().get("authorization");
+    if method == AuthenticationMethod::Basic {
+        let authorization = authorization.expect("Basic authentication must use a header");
+        assert!(authorization.is_sensitive());
+        let encoded = authorization
+            .to_str()
+            .unwrap()
+            .strip_prefix("Basic ")
+            .unwrap();
+        assert_eq!(STANDARD.decode(encoded).unwrap(), encoded_basic.as_bytes());
+        assert!(!fields.contains_key("client_id"));
+    } else {
+        assert!(authorization.is_none());
+        assert_eq!(fields.remove("client_id").as_deref(), Some(client_id));
+    }
+    assert_eq!(
+        fields.remove("client_secret").as_deref(),
+        (method == AuthenticationMethod::Post).then_some(secret)
+    );
+    assert_eq!(
+        fields.remove("client_assertion_type").as_deref(),
+        (method == AuthenticationMethod::Jwt)
+            .then_some("urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+    );
+    assert_eq!(
+        fields.remove("client_assertion").as_deref(),
+        (method == AuthenticationMethod::Jwt).then_some(assertion)
+    );
+    fields
+}
+
+#[tokio::test]
+async fn idp_client_authentication_is_explicit_and_separate_from_the_grant() {
+    const IDP_CLIENT: &str = "idp:+ %é";
+    const IDP_SECRET: &str = "idp-secret:+ %é";
+    for method in [
+        AuthenticationMethod::Public,
+        AuthenticationMethod::Basic,
+        AuthenticationMethod::Post,
+        AuthenticationMethod::Jwt,
+    ] {
+        let provider = RecordingAssertionProvider::new(AssertionBehavior::Success);
+        let server = EmaAuthorizationServer::new(IDP, IDP_TOKEN, IDP_CLIENT)
+            .with_client_authentication(method.configure(IDP_SECRET, &provider));
+        let refresh = RefreshToken::new("refresh-token".into());
+        assert!(provider.calls.lock().unwrap().is_empty());
+        // Reusing configuration must ask the signer for a fresh assertion.
+        for attempt in 1..=2 {
+            let idp = MockHttp::new(200, jag(&claims()));
+            EmaExchangeRequest::new(
+                server.clone(),
+                EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp"),
+                RESOURCE,
+                &refresh,
+            )
+            .exchange_id_jag(&idp)
+            .await
+            .unwrap();
+            let requests = idp.requests.lock().unwrap();
+            assert_eq!(requests.len(), 1);
+            assert_eq!(requests[0].request.uri(), IDP_TOKEN);
+            let fields = remove_client_authentication(
+                &requests[0],
+                method,
+                IDP_CLIENT,
+                IDP_SECRET,
+                "idp%3A%2B+%25%C3%A9:idp-secret%3A%2B+%25%C3%A9",
+                &client_assertion(IDP_CLIENT, IDP, attempt),
+            );
+            assert_eq!(
+                serde_json::to_value(fields).unwrap(),
+                json!({
+                    "grant_type":"urn:ietf:params:oauth:grant-type:token-exchange",
+                    "requested_token_type":ID_JAG_TOKEN_TYPE,"subject_token":"refresh-token",
+                    "subject_token_type":"urn:ietf:params:oauth:token-type:refresh_token",
+                    "audience":AS,"resource":RESOURCE
+                })
+            );
+            let expected_calls = if method == AuthenticationMethod::Jwt {
+                vec![(IDP.into(), IDP_TOKEN.into(), IDP_CLIENT.into()); attempt]
+            } else {
+                Vec::new()
+            };
+            assert_eq!(*provider.calls.lock().unwrap(), expected_calls);
+        }
+    }
+}
+
+#[tokio::test]
+async fn invalid_static_client_secrets_fail_before_any_http_or_signing() {
+    for stage in [Idp, ResourceServer] {
+        for method in [AuthenticationMethod::Basic, AuthenticationMethod::Post] {
+            for secret in ["", " \t"] {
+                let provider = RecordingAssertionProvider::new(AssertionBehavior::Success);
+                let valid = EmaClientAuthentication::JwtAssertion(provider.clone());
+                let invalid = method.configure(secret, &provider);
+                let (idp_auth, resource_auth) = match stage {
+                    Idp => (invalid, valid),
+                    _ => (valid, invalid),
+                };
+                let idp = MockHttp::default();
+                let error = EmaExchangeRequest::new(
+                    EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp")
+                        .with_client_authentication(idp_auth),
+                    EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp")
+                        .with_client_authentication(resource_auth),
+                    RESOURCE,
+                    &RefreshToken::new("refresh-token".into()),
+                )
+                .exchange_id_jag(&idp)
+                .await
+                .unwrap_err();
+                assert!(matches!(error, EmaError::InvalidRequest(_)));
+                assert!(idp.requests.lock().unwrap().is_empty());
+                assert!(provider.calls.lock().unwrap().is_empty());
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn assertion_provider_failures_and_empty_results_never_reach_http_or_escape_errors() {
+    for behavior in [
+        AssertionBehavior::Error,
+        AssertionBehavior::Empty(""),
+        AssertionBehavior::Empty(" \t"),
+    ] {
+        let provider = RecordingAssertionProvider::new(behavior);
+        let idp = MockHttp::default();
+        let error = EmaExchangeRequest::new(
+            EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp").with_client_authentication(
+                EmaClientAuthentication::JwtAssertion(provider.clone()),
+            ),
+            EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp"),
+            RESOURCE,
+            &RefreshToken::new("refresh-token".into()),
+        )
+        .exchange_id_jag(&idp)
+        .await
+        .unwrap_err();
+        if matches!(behavior, AssertionBehavior::Error) {
+            assert_eq!(error, EmaError::RequestFailed(Idp));
+        } else {
+            assert!(matches!(error, EmaError::InvalidRequest(_)));
+        }
+        assert!(!format!("{error:?} {error}").contains("client-assertion-provider-secret"));
+        assert!(std::error::Error::source(&error).is_none());
+        assert_eq!(provider.calls.lock().unwrap().len(), 1);
+        assert!(idp.requests.lock().unwrap().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn rejected_client_authentication_never_falls_back_or_retries() {
+    for method in [
+        AuthenticationMethod::Basic,
+        AuthenticationMethod::Post,
+        AuthenticationMethod::Jwt,
+    ] {
+        let provider = RecordingAssertionProvider::new(AssertionBehavior::Success);
+        let idp = MockHttp::new(
+            401,
+            json!({"error":"invalid_client","error_description":"client-authentication-secret"}),
+        );
+        let error = EmaExchangeRequest::new(
+            EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp")
+                .with_client_authentication(method.configure("idp-client-secret", &provider)),
+            EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp"),
+            RESOURCE,
+            &RefreshToken::new("refresh-token".into()),
+        )
+        .exchange_id_jag(&idp)
+        .await
+        .unwrap_err();
+        assert_eq!(
+            error,
+            EmaError::OAuthRejected {
+                stage: Idp,
+                status: 401,
+                code: "invalid_client"
+            }
+        );
+        assert!(!format!("{error:?} {error}").contains("client-authentication-secret"));
+        assert_eq!(idp.requests.lock().unwrap().len(), 1);
+        assert_eq!(
+            provider.calls.lock().unwrap().len(),
+            usize::from(method == AuthenticationMethod::Jwt)
+        );
+    }
+}
+
+#[test]
+fn client_authentication_debug_output_redacts_credentials_and_provider_state() {
+    const SECRET: &str = "client-authentication-secret-sentinel";
+    let provider = RecordingAssertionProvider::new(AssertionBehavior::Empty(SECRET));
+    let assertion = EmaClientAssertion::new(SECRET.into());
+    assert!(!format!("{assertion:?}").contains(SECRET));
+    for authentication in [
+        EmaClientAuthentication::ClientSecretBasic(ClientSecret::new(SECRET.into())),
+        EmaClientAuthentication::ClientSecretPost(ClientSecret::new(SECRET.into())),
+        EmaClientAuthentication::JwtAssertion(provider.clone()),
+    ] {
+        assert!(!format!("{authentication:?}").contains(SECRET));
+        let server = EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp")
+            .with_client_authentication(authentication);
+        let refresh = RefreshToken::new("refresh-token".into());
+        let request = EmaExchangeRequest::new(server.clone(), server.clone(), RESOURCE, &refresh);
+        assert!(!format!("{server:?} {request:?}").contains(SECRET));
+        assert!(!format!("{server:?} {request:?}").contains("private-query"));
+    }
+}

--- a/crates/rmcp/src/transport/auth/enterprise_tests.rs
+++ b/crates/rmcp/src/transport/auth/enterprise_tests.rs
@@ -92,7 +92,7 @@ async fn exchange(idp: &MockHttp, scopes: &str) -> Result<EmaIdJag, EmaError> {
         RESOURCE,
         &refresh,
     )
-    .scopes(&scopes);
+    .with_scopes(scopes);
     assert!(!format!("{request:?}").contains(refresh.secret()));
     assert!(!format!("{request:?}").contains("private-query"));
     let future = request.exchange_id_jag(idp);
@@ -198,6 +198,76 @@ async fn scopes_may_be_omitted_but_never_widened() {
 }
 
 #[tokio::test]
+async fn unsupported_authorization_details_are_rejected_at_each_stage() {
+    const SECRET: &str = "authorization-details-secret";
+    for (location, stage) in [
+        ("claims", Idp),
+        ("idp response", Idp),
+        ("resource response", ResourceServer),
+    ] {
+        for (case, details, valid) in [
+            ("absent", None, true),
+            ("null", Some(Value::Null), true),
+            ("empty", Some(json!([])), true),
+            (
+                "additional authority",
+                Some(
+                    json!([{"type":SECRET,"locations":["https://other.example"],"actions":["write"]}]),
+                ),
+                false,
+            ),
+            ("invalid member", Some(json!([null])), false),
+            ("object", Some(json!({"type":SECRET})), false),
+            ("string", Some(json!(SECRET)), false),
+        ] {
+            let mut claims = claims();
+            let mut response = bearer();
+            // Unrelated extension fields remain compatible at every boundary.
+            claims["vendor_extension"] = json!(SECRET);
+            response["vendor_extension"] = json!(SECRET);
+            if location == "claims"
+                && let Some(details) = &details
+            {
+                claims["authorization_details"] = details.clone();
+            }
+            let mut idp_response = jag(&claims);
+            idp_response["vendor_extension"] = json!(SECRET);
+            if let Some(details) = details {
+                match location {
+                    "idp response" => idp_response["authorization_details"] = details,
+                    "resource response" => response["authorization_details"] = details,
+                    _ => {}
+                }
+            }
+            let idp = MockHttp::new(200, idp_response);
+            let resource = MockHttp::new(200, response);
+            let result = EmaExchangeRequest::new(
+                EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp"),
+                EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp"),
+                RESOURCE,
+                &RefreshToken::new("refresh-token".into()),
+            )
+            .with_scopes(["files.read"])
+            .exchange(&idp, &resource)
+            .await;
+            assert_eq!(result.is_ok(), valid, "{location}: {case}");
+            if let Err(error) = result {
+                assert!(
+                    matches!(error, EmaError::InvalidResponse { stage: actual, .. } if actual == stage)
+                );
+                assert!(!format!("{error:?} {error}").contains(SECRET));
+            }
+            assert_eq!(idp.requests.lock().unwrap().len(), 1);
+            assert_eq!(
+                resource.requests.lock().unwrap().len(),
+                usize::from(valid || stage == ResourceServer),
+                "{location}: {case}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
 async fn invalid_jags_never_escape_validation() {
     let original = claims();
     let mut cases = Vec::new();
@@ -273,14 +343,13 @@ async fn invalid_inputs_fail_before_http() {
     cases.push((original, vec!["files.read", "files.read"]));
     for (fields, scopes) in cases {
         let http = MockHttp::default();
-        let scopes = scopes.into_iter().map(str::to_owned).collect::<Vec<_>>();
         let result = EmaExchangeRequest::new(
             EmaAuthorizationServer::new(fields[0], fields[1], fields[2]),
             EmaAuthorizationServer::new(fields[3], fields[4], fields[5]),
             fields[6],
             &RefreshToken::new(fields[7].into()),
         )
-        .scopes(&scopes)
+        .with_scopes(scopes)
         .exchange_id_jag(&http)
         .await;
         assert!(matches!(result, Err(EmaError::InvalidRequest(_))));
@@ -339,11 +408,260 @@ async fn errors_and_redirects_cannot_reflect_credentials() {
     ));
 }
 
+fn bearer() -> Value {
+    json!({"access_token":"resource-token","token_type":"Bearer","expires_in":300})
+}
+
+async fn redeem(http: &MockHttp) -> Result<EmaAccessToken, EmaError> {
+    exchange(
+        &MockHttp::new(200, jag(&claims())),
+        "files.read files.write",
+    )
+    .await?
+    .exchange(http)
+    .await
+}
+
+#[tokio::test]
+async fn full_exchange_uses_separate_clients_and_only_the_narrowed_assertion() {
+    for valid in [true, false] {
+        let mut claims = claims();
+        if !valid {
+            claims["client_id"] = json!("other");
+        }
+        let response = jag(&claims);
+        let idp = MockHttp::new(200, response.clone());
+        let resource_as = MockHttp::new(200, bearer());
+        let refresh = RefreshToken::new("refresh-token".into());
+        let request = EmaExchangeRequest::new(
+            EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp"),
+            EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp"),
+            RESOURCE,
+            &refresh,
+        )
+        .with_scopes(["files.read", "files.write"]);
+        let future = request.exchange(&idp, &resource_as);
+        fn is_send<T: Send>(_: &T) {}
+        is_send(&future);
+        let result = future.await;
+        assert_eq!(idp.requests.lock().unwrap().len(), 1);
+        let requests = resource_as.requests.lock().unwrap();
+        assert_eq!(requests.len(), usize::from(valid));
+        if !valid {
+            assert!(matches!(
+                result,
+                Err(EmaError::InvalidResponse { stage: Idp, .. })
+            ));
+            continue;
+        }
+        let token = result.unwrap();
+        assert_eq!(token.access_token.secret(), "resource-token");
+        assert_eq!(token.expires_in, Some(Duration::from_secs(300)));
+        assert_eq!(token.scopes, HashSet::from(["files.read".to_owned()]));
+        assert!(!format!("{token:?}").contains(token.access_token.secret()));
+        assert_eq!(requests[0].request.uri(), AS_TOKEN);
+        assert_eq!(
+            serde_json::to_value(form(&requests[0])).unwrap(),
+            json!({
+                "grant_type":"urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "assertion":response["access_token"],"client_id":"mcp"
+            })
+        );
+    }
+}
+
+#[tokio::test]
+async fn expired_grants_are_not_redeemed() {
+    let mut grant = exchange(&MockHttp::new(200, jag(&claims())), "")
+        .await
+        .unwrap();
+    grant.expires_at = 0;
+    let resource_as = MockHttp::default();
+    assert!(matches!(
+        grant.exchange(&resource_as).await,
+        Err(EmaError::InvalidRequest(_))
+    ));
+    assert!(resource_as.requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn bearer_responses_cannot_change_resource_or_widen_scope() {
+    let mut cases = vec![
+        ("scope", json!("files.read"), true),
+        ("scope", json!("files.admin"), false),
+        ("scope", json!("files.read files.write"), false),
+        ("scope", json!("files.read files.read"), false),
+        ("resource", json!(RESOURCE), true),
+        ("resource", json!([RESOURCE]), true),
+        ("resource", json!([RESOURCE, "other"]), false),
+        ("resource", json!("https://mcp.example"), false),
+        ("expires_in", json!(0), false),
+        ("expires_in", Value::Null, true),
+        ("refresh_token", json!("unsupported"), false),
+        ("token_type", json!("N_A"), false),
+        ("token_type", json!("bearer"), true),
+        ("access_token", json!(" \t"), false),
+    ];
+    cases.extend(
+        BAD_SCOPES
+            .iter()
+            .map(|scope| ("scope", json!(scope), false)),
+    );
+    for (key, value, valid) in cases {
+        let mut token = bearer();
+        if value.is_null() {
+            token.as_object_mut().unwrap().remove(key);
+        } else {
+            token[key] = value;
+        }
+        let result = redeem(&MockHttp::new(200, token)).await;
+        assert_eq!(result.is_ok(), valid, "{key}");
+        if key == "expires_in" && valid {
+            assert_eq!(result.unwrap().expires_in, None);
+        } else if !valid {
+            assert!(matches!(
+                result,
+                Err(EmaError::InvalidResponse {
+                    stage: ResourceServer,
+                    ..
+                })
+            ));
+        }
+    }
+}
+
+#[tokio::test]
+async fn resource_scope_narrowing_is_reported_without_logging_scope_values() {
+    for read in ["files.read", "private-scope-sentinel"] {
+        let requested = format!("{read} files.write");
+        let mut claims = claims();
+        claims["scope"] = json!(requested);
+        let grant = exchange(&MockHttp::new(200, jag(&claims)), &requested)
+            .await
+            .unwrap();
+        let mut response = bearer();
+        response["scope"] = json!(read);
+        let token = grant.exchange(&MockHttp::new(200, response)).await.unwrap();
+        assert_eq!(token.scopes, HashSet::from([read.to_owned()]));
+        assert!(!format!("{token:?}").contains(read));
+    }
+}
+
+#[tokio::test]
+async fn bearer_scope_may_be_omitted_but_not_added_to_an_unscoped_grant() {
+    for scope in [None, Some("files.read")] {
+        let mut claims = claims();
+        claims.as_object_mut().unwrap().remove("scope");
+        let grant = exchange(&MockHttp::new(200, jag(&claims)), "")
+            .await
+            .unwrap();
+        let mut token = bearer();
+        if let Some(scope) = scope {
+            token["scope"] = json!(scope);
+        }
+        let result = grant.exchange(&MockHttp::new(200, token)).await;
+        assert_eq!(result.is_ok(), scope.is_none());
+        if let Ok(token) = result {
+            assert!(token.scopes.is_empty());
+        }
+    }
+}
+
+#[tokio::test]
+async fn resource_errors_are_staged_and_never_reflect_credentials() {
+    const SECRET: &str = "secret-resource-error-sentinel";
+    for (status, code) in [
+        (400, "invalid_grant"),
+        (400, "insufficient_user_authentication"),
+        (400, "invalid_client"),
+        (302, SECRET),
+        (500, SECRET),
+    ] {
+        let http = MockHttp::new(status, json!({"error":code,"error_description":SECRET}));
+        let error = redeem(&http).await.unwrap_err();
+        match code {
+            "invalid_grant" => assert_eq!(error, EmaError::InvalidGrant(ResourceServer)),
+            "insufficient_user_authentication" => assert_eq!(
+                error,
+                EmaError::InsufficientUserAuthentication(ResourceServer)
+            ),
+            _ => assert!(
+                matches!(error, EmaError::OAuthRejected {stage: ResourceServer, status: actual, ..} if actual == status)
+            ),
+        }
+        assert!(!format!("{error:?} {error}").contains(SECRET));
+        assert!(std::error::Error::source(&error).is_none());
+        assert_eq!(http.requests.lock().unwrap().len(), 1);
+    }
+    let mut oversized = bearer();
+    oversized["ignored"] = json!("x".repeat(1024 * 1024));
+    for (body, adapter_failure) in [
+        (json!({"access_token":SECRET,"expires_in":SECRET}), false),
+        (oversized, false),
+        (Value::Null, true),
+    ] {
+        let http = MockHttp::new(200, body);
+        if adapter_failure {
+            *http.response.lock().unwrap() = Some(Err(SECRET.into()));
+        }
+        let error = redeem(&http).await.unwrap_err();
+        assert!(!format!("{error:?} {error}").contains(SECRET));
+        assert!(std::error::Error::source(&error).is_none());
+        if adapter_failure {
+            assert_eq!(error, EmaError::RequestFailed(ResourceServer));
+        } else {
+            assert!(matches!(
+                error,
+                EmaError::InvalidResponse {
+                    stage: ResourceServer,
+                    ..
+                }
+            ));
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn both_exchanges_enforce_the_timeout_when_the_adapter_does_not() {
+    struct PendingHttp;
+    impl OAuthHttpClient for PendingHttp {
+        fn execute(&self, _: OAuthHttpRequest) -> OAuthHttpClientFuture<'_> {
+            Box::pin(std::future::pending())
+        }
+    }
+    for stage in [Idp, ResourceServer] {
+        let ready = MockHttp::new(200, jag(&claims()));
+        let (idp, resource): (&dyn OAuthHttpClient, &dyn OAuthHttpClient) = match stage {
+            Idp => (&PendingHttp, &ready),
+            _ => (&ready, &PendingHttp),
+        };
+        let refresh = RefreshToken::new("refresh-token".into());
+        let request = EmaExchangeRequest::new(
+            EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp"),
+            EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp"),
+            RESOURCE,
+            &refresh,
+        );
+        let start = tokio::time::Instant::now();
+        let result = tokio::time::timeout(Duration::from_secs(31), request.exchange(idp, resource))
+            .await
+            .expect("the SDK must enforce its own deadline");
+        assert_eq!(result.unwrap_err(), EmaError::RequestFailed(stage));
+        assert_eq!(start.elapsed(), Duration::from_secs(30));
+        assert_eq!(
+            ready.requests.lock().unwrap().len(),
+            usize::from(stage == ResourceServer)
+        );
+    }
+}
+
 #[derive(Clone, Copy)]
 enum AssertionBehavior {
     Success,
     Error,
     Empty(&'static str),
+    Delay(Duration),
+    Pending,
 }
 
 struct RecordingAssertionProvider {
@@ -386,6 +704,8 @@ impl EmaClientAssertionProvider for RecordingAssertionProvider {
         match self.behavior {
             AssertionBehavior::Error => return Err("client-assertion-provider-secret".into()),
             AssertionBehavior::Empty(value) => return Ok(EmaClientAssertion::new(value.into())),
+            AssertionBehavior::Delay(delay) => tokio::time::sleep(delay).await,
+            AssertionBehavior::Pending => std::future::pending::<()>().await,
             AssertionBehavior::Success => {}
         }
         Ok(EmaClientAssertion::new(client_assertion(
@@ -464,45 +784,56 @@ fn remove_client_authentication(
 }
 
 #[tokio::test]
-async fn idp_client_authentication_is_explicit_and_separate_from_the_grant() {
-    const IDP_CLIENT: &str = "idp:+ %é";
-    const IDP_SECRET: &str = "idp-secret:+ %é";
-    for method in [
+async fn client_authentication_is_endpoint_specific_and_never_mixed_with_grants() {
+    const METHODS: [AuthenticationMethod; 4] = [
         AuthenticationMethod::Public,
         AuthenticationMethod::Basic,
         AuthenticationMethod::Post,
         AuthenticationMethod::Jwt,
-    ] {
-        let provider = RecordingAssertionProvider::new(AssertionBehavior::Success);
-        let server = EmaAuthorizationServer::new(IDP, IDP_TOKEN, IDP_CLIENT)
-            .with_client_authentication(method.configure(IDP_SECRET, &provider));
-        let refresh = RefreshToken::new("refresh-token".into());
-        assert!(provider.calls.lock().unwrap().is_empty());
-        // Reusing configuration must ask the signer for a fresh assertion.
-        for attempt in 1..=2 {
-            let idp = MockHttp::new(200, jag(&claims()));
-            EmaExchangeRequest::new(
-                server.clone(),
-                EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp"),
+    ];
+    // Colons, plus signs, spaces, percent signs, and non-ASCII bytes must be
+    // form-encoded individually before the HTTP Basic username/password join.
+    const IDP_CLIENT: &str = "idp:+ %é";
+    const AS_CLIENT: &str = "mcp:+ %é";
+    const IDP_SECRET: &str = "idp-secret:+ %é";
+    const AS_SECRET: &str = "as-secret:+ %é";
+    for idp_method in METHODS {
+        for resource_method in METHODS {
+            let provider = RecordingAssertionProvider::new(AssertionBehavior::Success);
+            let mut claims = claims();
+            claims["client_id"] = json!(AS_CLIENT);
+            let response = jag(&claims);
+            let idp = MockHttp::new(200, response.clone());
+            let resource = MockHttp::new(200, bearer());
+            let refresh = RefreshToken::new("refresh-token".into());
+            let token = EmaExchangeRequest::new(
+                EmaAuthorizationServer::new(IDP, IDP_TOKEN, IDP_CLIENT)
+                    .with_client_authentication(idp_method.configure(IDP_SECRET, &provider)),
+                EmaAuthorizationServer::new(AS, AS_TOKEN, AS_CLIENT)
+                    .with_client_authentication(resource_method.configure(AS_SECRET, &provider)),
                 RESOURCE,
                 &refresh,
             )
-            .exchange_id_jag(&idp)
+            .exchange(&idp, &resource)
             .await
             .unwrap();
-            let requests = idp.requests.lock().unwrap();
-            assert_eq!(requests.len(), 1);
-            assert_eq!(requests[0].request.uri(), IDP_TOKEN);
-            let fields = remove_client_authentication(
-                &requests[0],
-                method,
+            assert_eq!(token.access_token.secret(), "resource-token");
+            let idp_requests = idp.requests.lock().unwrap();
+            let resource_requests = resource.requests.lock().unwrap();
+            assert_eq!(idp_requests.len(), 1);
+            assert_eq!(resource_requests.len(), 1);
+            assert_eq!(idp_requests[0].request.uri(), IDP_TOKEN);
+            assert_eq!(resource_requests[0].request.uri(), AS_TOKEN);
+            let idp_fields = remove_client_authentication(
+                &idp_requests[0],
+                idp_method,
                 IDP_CLIENT,
                 IDP_SECRET,
                 "idp%3A%2B+%25%C3%A9:idp-secret%3A%2B+%25%C3%A9",
-                &client_assertion(IDP_CLIENT, IDP, attempt),
+                &client_assertion(IDP_CLIENT, IDP, 1),
             );
             assert_eq!(
-                serde_json::to_value(fields).unwrap(),
+                serde_json::to_value(idp_fields).unwrap(),
                 json!({
                     "grant_type":"urn:ietf:params:oauth:grant-type:token-exchange",
                     "requested_token_type":ID_JAG_TOKEN_TYPE,"subject_token":"refresh-token",
@@ -510,14 +841,70 @@ async fn idp_client_authentication_is_explicit_and_separate_from_the_grant() {
                     "audience":AS,"resource":RESOURCE
                 })
             );
-            let expected_calls = if method == AuthenticationMethod::Jwt {
-                vec![(IDP.into(), IDP_TOKEN.into(), IDP_CLIENT.into()); attempt]
-            } else {
-                Vec::new()
-            };
+            let resource_fields = remove_client_authentication(
+                &resource_requests[0],
+                resource_method,
+                AS_CLIENT,
+                AS_SECRET,
+                "mcp%3A%2B+%25%C3%A9:as-secret%3A%2B+%25%C3%A9",
+                &client_assertion(
+                    AS_CLIENT,
+                    AS,
+                    1 + usize::from(idp_method == AuthenticationMethod::Jwt),
+                ),
+            );
+            assert_eq!(
+                serde_json::to_value(resource_fields).unwrap(),
+                json!({
+                    "grant_type":"urn:ietf:params:oauth:grant-type:jwt-bearer",
+                    "assertion":response["access_token"]
+                })
+            );
+            let mut expected_calls = Vec::new();
+            if idp_method == AuthenticationMethod::Jwt {
+                expected_calls.push((IDP.into(), IDP_TOKEN.into(), IDP_CLIENT.into()));
+            }
+            if resource_method == AuthenticationMethod::Jwt {
+                expected_calls.push((AS.into(), AS_TOKEN.into(), AS_CLIENT.into()));
+            }
             assert_eq!(*provider.calls.lock().unwrap(), expected_calls);
         }
     }
+}
+
+#[tokio::test(start_paused = true)]
+async fn client_assertions_are_fresh_for_every_request_and_delayed_redemption() {
+    let provider = RecordingAssertionProvider::new(AssertionBehavior::Success);
+    let idp_server = EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp")
+        .with_client_authentication(EmaClientAuthentication::JwtAssertion(provider.clone()));
+    let resource_server = EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp")
+        .with_client_authentication(EmaClientAuthentication::JwtAssertion(provider.clone()));
+    let refresh = RefreshToken::new("refresh-token".into());
+    let mut assertions = HashSet::new();
+    for attempt in 0..2 {
+        let idp = MockHttp::new(200, jag(&claims()));
+        let resource = MockHttp::new(200, bearer());
+        let grant = EmaExchangeRequest::new(
+            idp_server.clone(),
+            resource_server.clone(),
+            RESOURCE,
+            &refresh,
+        )
+        .exchange_id_jag(&idp)
+        .await
+        .unwrap();
+        assert_eq!(provider.calls.lock().unwrap().len(), attempt * 2 + 1);
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        assert_eq!(provider.calls.lock().unwrap().len(), attempt * 2 + 1);
+        grant.exchange(&resource).await.unwrap();
+        assert_eq!(provider.calls.lock().unwrap().len(), attempt * 2 + 2);
+        for http in [&idp, &resource] {
+            let requests = http.requests.lock().unwrap();
+            let mut fields = form(&requests[0]);
+            assert!(assertions.insert(fields.remove("client_assertion").unwrap()));
+        }
+    }
+    assert_eq!(assertions.len(), 4);
 }
 
 #[tokio::test]
@@ -533,6 +920,7 @@ async fn invalid_static_client_secrets_fail_before_any_http_or_signing() {
                     _ => (valid, invalid),
                 };
                 let idp = MockHttp::default();
+                let resource = MockHttp::default();
                 let error = EmaExchangeRequest::new(
                     EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp")
                         .with_client_authentication(idp_auth),
@@ -541,11 +929,12 @@ async fn invalid_static_client_secrets_fail_before_any_http_or_signing() {
                     RESOURCE,
                     &RefreshToken::new("refresh-token".into()),
                 )
-                .exchange_id_jag(&idp)
+                .exchange(&idp, &resource)
                 .await
                 .unwrap_err();
                 assert!(matches!(error, EmaError::InvalidRequest(_)));
                 assert!(idp.requests.lock().unwrap().is_empty());
+                assert!(resource.requests.lock().unwrap().is_empty());
                 assert!(provider.calls.lock().unwrap().is_empty());
             }
         }
@@ -553,73 +942,184 @@ async fn invalid_static_client_secrets_fail_before_any_http_or_signing() {
 }
 
 #[tokio::test]
-async fn assertion_provider_failures_and_empty_results_never_reach_http_or_escape_errors() {
-    for behavior in [
-        AssertionBehavior::Error,
-        AssertionBehavior::Empty(""),
-        AssertionBehavior::Empty(" \t"),
-    ] {
-        let provider = RecordingAssertionProvider::new(behavior);
-        let idp = MockHttp::default();
-        let error = EmaExchangeRequest::new(
-            EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp").with_client_authentication(
-                EmaClientAuthentication::JwtAssertion(provider.clone()),
-            ),
-            EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp"),
-            RESOURCE,
-            &RefreshToken::new("refresh-token".into()),
-        )
-        .exchange_id_jag(&idp)
+async fn a_grant_that_expires_while_signing_is_never_sent_to_the_resource_server() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    let provider = RecordingAssertionProvider::new(AssertionBehavior::Success);
+    let idp = MockHttp::new(200, jag(&claims()));
+    let resource = MockHttp::default();
+    let mut grant = EmaExchangeRequest::new(
+        EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp"),
+        EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp")
+            .with_client_authentication(EmaClientAuthentication::JwtAssertion(provider.clone())),
+        RESOURCE,
+        &RefreshToken::new("refresh-token".into()),
+    )
+    .exchange_id_jag(&idp)
+    .await
+    .unwrap();
+    grant.expires_at = 100;
+    // The clock crosses expiration between the checks before and after signing.
+    let now = AtomicU64::new(99);
+    let error = grant
+        .exchange_with_clock(&resource, || Ok(now.fetch_add(1, Ordering::Relaxed)))
         .await
         .unwrap_err();
-        if matches!(behavior, AssertionBehavior::Error) {
-            assert_eq!(error, EmaError::RequestFailed(Idp));
-        } else {
-            assert!(matches!(error, EmaError::InvalidRequest(_)));
+    assert!(matches!(error, EmaError::InvalidRequest(_)));
+    assert_eq!(provider.calls.lock().unwrap().len(), 1);
+    assert!(resource.requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn assertion_provider_failures_and_empty_results_never_reach_http_or_escape_errors() {
+    for stage in [Idp, ResourceServer] {
+        for behavior in [
+            AssertionBehavior::Error,
+            AssertionBehavior::Empty(""),
+            AssertionBehavior::Empty(" \t"),
+        ] {
+            let provider = RecordingAssertionProvider::new(behavior);
+            let auth = EmaClientAuthentication::JwtAssertion(provider.clone());
+            let (idp_auth, resource_auth) = match stage {
+                Idp => (auth, EmaClientAuthentication::None),
+                _ => (EmaClientAuthentication::None, auth),
+            };
+            let idp = MockHttp::new(200, jag(&claims()));
+            let resource = MockHttp::default();
+            let error = EmaExchangeRequest::new(
+                EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp")
+                    .with_client_authentication(idp_auth),
+                EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp")
+                    .with_client_authentication(resource_auth),
+                RESOURCE,
+                &RefreshToken::new("refresh-token".into()),
+            )
+            .exchange(&idp, &resource)
+            .await
+            .unwrap_err();
+            if matches!(behavior, AssertionBehavior::Error) {
+                assert_eq!(error, EmaError::RequestFailed(stage));
+            } else {
+                assert!(matches!(error, EmaError::InvalidRequest(_)));
+            }
+            assert!(!format!("{error:?} {error}").contains("client-assertion-provider-secret"));
+            assert!(std::error::Error::source(&error).is_none());
+            assert_eq!(provider.calls.lock().unwrap().len(), 1);
+            assert_eq!(
+                idp.requests.lock().unwrap().len(),
+                usize::from(stage == ResourceServer)
+            );
+            assert!(resource.requests.lock().unwrap().is_empty());
         }
-        assert!(!format!("{error:?} {error}").contains("client-assertion-provider-secret"));
-        assert!(std::error::Error::source(&error).is_none());
-        assert_eq!(provider.calls.lock().unwrap().len(), 1);
-        assert!(idp.requests.lock().unwrap().is_empty());
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn signing_and_http_share_one_deadline_at_both_endpoints() {
+    struct DelayedHttp(Mutex<Vec<OAuthHttpRequest>>);
+    impl OAuthHttpClient for DelayedHttp {
+        fn execute(&self, request: OAuthHttpRequest) -> OAuthHttpClientFuture<'_> {
+            self.0.lock().unwrap().push(request);
+            Box::pin(async {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                Err("http-adapter-secret".into())
+            })
+        }
+    }
+    for stage in [Idp, ResourceServer] {
+        for behavior in [
+            AssertionBehavior::Pending,
+            AssertionBehavior::Delay(Duration::from_secs(25)),
+        ] {
+            let provider = RecordingAssertionProvider::new(behavior);
+            let auth = EmaClientAuthentication::JwtAssertion(provider.clone());
+            let (idp_auth, resource_auth) = match stage {
+                Idp => (auth, EmaClientAuthentication::None),
+                _ => (EmaClientAuthentication::None, auth),
+            };
+            let ready = MockHttp::new(200, jag(&claims()));
+            let delayed = DelayedHttp(Mutex::new(Vec::new()));
+            let (idp, resource): (&dyn OAuthHttpClient, &dyn OAuthHttpClient) = match stage {
+                Idp => (&delayed, &ready),
+                _ => (&ready, &delayed),
+            };
+            let refresh = RefreshToken::new("refresh-token".into());
+            let request = EmaExchangeRequest::new(
+                EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp")
+                    .with_client_authentication(idp_auth),
+                EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp")
+                    .with_client_authentication(resource_auth),
+                RESOURCE,
+                &refresh,
+            );
+            let start = tokio::time::Instant::now();
+            let result =
+                tokio::time::timeout(Duration::from_secs(31), request.exchange(idp, resource))
+                    .await
+                    .expect("signing must share the SDK's token request deadline");
+            assert_eq!(result.unwrap_err(), EmaError::RequestFailed(stage));
+            assert_eq!(start.elapsed(), Duration::from_secs(30));
+            assert_eq!(provider.calls.lock().unwrap().len(), 1);
+            assert_eq!(
+                delayed.0.lock().unwrap().len(),
+                usize::from(matches!(behavior, AssertionBehavior::Delay(_)))
+            );
+            assert_eq!(
+                ready.requests.lock().unwrap().len(),
+                usize::from(stage == ResourceServer)
+            );
+        }
     }
 }
 
 #[tokio::test]
 async fn rejected_client_authentication_never_falls_back_or_retries() {
-    for method in [
-        AuthenticationMethod::Basic,
-        AuthenticationMethod::Post,
-        AuthenticationMethod::Jwt,
-    ] {
-        let provider = RecordingAssertionProvider::new(AssertionBehavior::Success);
-        let idp = MockHttp::new(
-            401,
-            json!({"error":"invalid_client","error_description":"client-authentication-secret"}),
-        );
-        let error = EmaExchangeRequest::new(
-            EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp")
-                .with_client_authentication(method.configure("idp-client-secret", &provider)),
-            EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp"),
-            RESOURCE,
-            &RefreshToken::new("refresh-token".into()),
-        )
-        .exchange_id_jag(&idp)
-        .await
-        .unwrap_err();
-        assert_eq!(
-            error,
-            EmaError::OAuthRejected {
-                stage: Idp,
-                status: 401,
-                code: "invalid_client"
-            }
-        );
-        assert!(!format!("{error:?} {error}").contains("client-authentication-secret"));
-        assert_eq!(idp.requests.lock().unwrap().len(), 1);
-        assert_eq!(
-            provider.calls.lock().unwrap().len(),
-            usize::from(method == AuthenticationMethod::Jwt)
-        );
+    for stage in [Idp, ResourceServer] {
+        for method in [
+            AuthenticationMethod::Basic,
+            AuthenticationMethod::Post,
+            AuthenticationMethod::Jwt,
+        ] {
+            let provider = RecordingAssertionProvider::new(AssertionBehavior::Success);
+            let failure = json!({"error":"invalid_client","error_description":"client-authentication-secret"});
+            let idp = if stage == Idp {
+                MockHttp::new(401, failure.clone())
+            } else {
+                MockHttp::new(200, jag(&claims()))
+            };
+            let resource = MockHttp::new(401, failure);
+            let error = EmaExchangeRequest::new(
+                EmaAuthorizationServer::new(IDP, IDP_TOKEN, "idp")
+                    .with_client_authentication(method.configure("idp-client-secret", &provider)),
+                EmaAuthorizationServer::new(AS, AS_TOKEN, "mcp")
+                    .with_client_authentication(method.configure("as-client-secret", &provider)),
+                RESOURCE,
+                &RefreshToken::new("refresh-token".into()),
+            )
+            .exchange(&idp, &resource)
+            .await
+            .unwrap_err();
+            assert_eq!(
+                error,
+                EmaError::OAuthRejected {
+                    stage,
+                    status: 401,
+                    code: "invalid_client"
+                }
+            );
+            assert!(!format!("{error:?} {error}").contains("client-authentication-secret"));
+            assert_eq!(idp.requests.lock().unwrap().len(), 1);
+            assert_eq!(
+                resource.requests.lock().unwrap().len(),
+                usize::from(stage == ResourceServer)
+            );
+            let expected_calls = if method == AuthenticationMethod::Jwt {
+                1 + usize::from(stage == ResourceServer)
+            } else {
+                0
+            };
+            assert_eq!(provider.calls.lock().unwrap().len(), expected_calls);
+        }
     }
 }
 

--- a/docs/OAUTH_SUPPORT.md
+++ b/docs/OAUTH_SUPPORT.md
@@ -15,6 +15,7 @@ This document describes the OAuth 2.1 authorization implementation for Model Con
 - Automatic token refresh
 - Authorized HTTP Client implementation
 - Injectable OAuth HTTP client for custom network environments
+- Opt-in EMA/XAA refresh-token and ID-JAG exchanges for registered public and confidential clients
 
 ## Usage Guide
 
@@ -293,6 +294,130 @@ match oauth_state.request_scope_upgrade("admin:write", MCP_REDIRECT_URI).await {
     }
 }
 ```
+
+## Enterprise-managed authorization (EMA/XAA)
+
+The example requires the `rmcp` features `auth-enterprise-managed`, `client`,
+`reqwest` (TLS), and `transport-streamable-http-client-reqwest`, plus `oauth2`
+version 5. Call the async function from a Tokio runtime.
+
+The exchange profile has these requirements and limits:
+
+- Each authorization server has its own approved client registration and explicit
+  `EmaClientAuthentication`: `None`, `ClientSecretBasic`, `ClientSecretPost`, or
+  `JwtAssertion`. The SDK does not select methods from metadata or fall back to a
+  different method after a failure.
+- Input is an enterprise IdP refresh token. The requested MCP resource must match
+  the ID-JAG's sole `resource` claim; scope may be omitted or narrowed.
+- RAR (`authorization_details`) and DPoP are not supported. Nonempty authorization
+  details are rejected at both exchange stages.
+- Redemption consumes the SDK's ID-JAG handle and does not retry automatically.
+  This is an SDK safety choice, not a protocol requirement that ID-JAGs be single-use.
+
+The [ID-JAG draft recommends confidential clients](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-identity-assertion-authz-grant-04#section-9.1).
+The example below uses confidential clients with `client_secret_basic` at both
+servers. Use `None` only where that server permits a public client registration.
+Discovery, server approval, SSO, credential storage, and reauthentication remain
+the application's responsibility. Client-side ID-JAG checks validate structure and
+bindings, not signatures; the resource authorization server verifies signatures.
+
+```rust no_run
+use oauth2::{ClientSecret, RefreshToken};
+use rmcp::{
+    ServiceExt,
+    model::ClientInfo,
+    transport::{
+        StreamableHttpClientTransport,
+        auth::{
+            default_oauth_http_client,
+            enterprise::{EmaAuthorizationServer, EmaClientAuthentication, EmaExchangeRequest},
+        },
+        streamable_http_client::StreamableHttpClientTransportConfig,
+    },
+};
+
+async fn connect(
+    refresh: &RefreshToken,
+    idp_client_secret: ClientSecret,
+    resource_client_secret: ClientSecret,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let resource = "https://mcp.example/mcp";
+    let http = default_oauth_http_client()?;
+    let idp = EmaAuthorizationServer::new(
+        "https://idp.example", "https://idp.example/token", "idp-client",
+    )
+    .with_client_authentication(EmaClientAuthentication::ClientSecretBasic(idp_client_secret));
+    let resource_as = EmaAuthorizationServer::new(
+        "https://as.example", "https://as.example/token", "mcp-client",
+    )
+    .with_client_authentication(EmaClientAuthentication::ClientSecretBasic(resource_client_secret));
+    let token = EmaExchangeRequest::new(idp, resource_as, resource, refresh)
+        .with_scopes(["files.read"])
+        .exchange(&http, &http)
+        .await?;
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(resource)
+            .auth_header(token.access_token.secret()),
+    );
+    let client = ClientInfo::default().serve(transport).await?;
+    client.list_tools(Default::default()).await?;
+    client.cancel().await?;
+    Ok(())
+}
+```
+
+`auth_header` takes the token without a `Bearer ` prefix. Use it only with the
+approved resource and never log it. This transport uses a fixed token; obtain a
+new token and reconnect when it expires or is rejected.
+
+For a registration using JWT client authentication, implement
+`EmaClientAssertionProvider` with your application's signer and configure
+`JwtAssertion` on that server. The provider example below also uses `async-trait`
+version 0.1; `AppSigner` represents your application's existing signing service.
+
+```rust ignore
+use std::sync::Arc;
+use rmcp::transport::auth::enterprise::{
+    EmaAuthorizationServer, EmaClientAssertion, EmaClientAssertionProvider,
+    EmaClientAuthentication,
+};
+
+struct AppAssertionProvider {
+    signer: AppSigner,
+}
+
+#[async_trait::async_trait]
+impl EmaClientAssertionProvider for AppAssertionProvider {
+    async fn create_assertion(
+        &self,
+        server: &EmaAuthorizationServer,
+    ) -> Result<EmaClientAssertion, Box<dyn std::error::Error + Send + Sync>> {
+        // Sign a new assertion for this registration and approved server.
+        let jwt = self.signer.sign_client_assertion(
+            &server.client_id, &server.issuer, &server.token_endpoint,
+        ).await?;
+        Ok(EmaClientAssertion::new(jwt))
+    }
+}
+
+let resource_as = EmaAuthorizationServer::new(
+    "https://as.example", "https://as.example/token", "mcp-client",
+)
+.with_client_authentication(EmaClientAuthentication::JwtAssertion(Arc::new(
+    AppAssertionProvider { signer },
+)));
+```
+
+The SDK calls the provider before each token request, including delayed
+`EmaIdJag::exchange` redemption. Sign a fresh, short-lived assertion with a unique
+`jti`, the registered client ID in `iss` and `sub`, and the server's approved
+audience in `aud`. Your signer owns the keys and algorithm; the client assertion
+is separate from the ID-JAG grant. Signing and HTTP share a 30-second deadline.
+
+The factory honors per-request redirect policy with the SDK's default reqwest
+settings. For custom proxy, CA, or remote-execution policy, implement
+`OAuthHttpClient`; use separate adapters for the IdP and resource AS when their
+network policies differ.
 
 ## Complete Examples
 


### PR DESCRIPTION
This PR adds the EMA/XAA token exchange flow behind `auth-enterprise-managed`: enterprise refresh token → ID-JAG → MCP access token. It covers the refresh-token portion of the request for support in #531.

Each authorization server has its own client authentication configuration. Clients can use a secret or a fresh JWT assertion from an application-provided signer. Public clients remain supported where explicitly allowed.

## Scope

The exchange targets one MCP resource and preserves scope narrowing. The SDK checks ID-JAG structure and claim bindings. The resource authorization server verifies the signature.

Applications may supply approved server metadata and client registrations. Discovery, login, credential storage, automatic refresh, and reauth remain application responsibilities. JWT signing stays with the application. RAR and DPoP remain unsupported; nonempty `authorization_details` are rejected.

## Testing

Local validation passed for revision `dc26f27a8228`:

- 211 OAuth tests with all features on Rust 1.96.
- 50 doctests passed; 10 ignored.
- Rust 1.88 minimal-feature check passed (`--no-default-features --features auth-enterprise-managed`).
- Formatting, strict rmcp Clippy (`--all-targets --all-features`), and commitlint passed.
- The MCP connection example compiles with its documented features.

Tests use mocked responses and local HTTP fixtures.

## Breaking Changes

None intended and existing OAuth behavior is unchanged.

## Breaking Changes
I've added [a PR](https://github.com/modelcontextprotocol/conformance/pull/484) to extend conformance test coverage for EMA. 

[Conformance Test Results](https://gist.github.com/nicksteele-oai/0552465af948e4c0361979b8f02e4afd) against [rust-sdk#1234](https://github.com/modelcontextprotocol/rust-sdk/pull/1234)
