### PR TITLE
fix: treat empty cacheScope as omitted

### DIFF
--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1572,6 +1572,28 @@ where
     Ok(value.map(|ttl_ms| ttl_ms.max(0) as u64))
 }
 
+/// Normalize a `cacheScope` value during deserialization.
+///
+/// SEP-2549 permits `"public"` or `"private"`. Omission is also valid. Some
+/// hosted servers emit an empty string; treat that exact sentinel as omitted
+/// instead of failing the entire list/read result. Unknown or whitespace
+/// values still error.
+fn deserialize_cache_scope<'de, D>(deserializer: D) -> Result<Option<CacheScope>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    match value.as_deref() {
+        None | Some("") => Ok(None),
+        Some("public") => Ok(Some(CacheScope::Public)),
+        Some("private") => Ok(Some(CacheScope::Private)),
+        Some(other) => Err(serde::de::Error::unknown_variant(
+            other,
+            &["public", "private"],
+        )),
+    }
+}
+
 macro_rules! paginated_result {
     ($t:ident {
         $i_item: ident: $t_item: ty
@@ -1609,7 +1631,11 @@ macro_rules! paginated_result {
             /// Scope describing who may cache this result (SEP-2549).
             /// Required by spec version 2026-07-28, but optional here to maintain compatibility
             /// with older spec versions.
-            #[serde(default, skip_serializing_if = "Option::is_none")]
+            #[serde(
+                default,
+                deserialize_with = "deserialize_cache_scope",
+                skip_serializing_if = "Option::is_none"
+            )]
             pub cache_scope: Option<CacheScope>,
             pub $i_item: $t_item,
         }
@@ -1759,7 +1785,11 @@ pub struct ReadResourceResult {
     /// Scope describing who may cache this result (SEP-2549).
     /// Required by spec version 2026-07-28, but optional here to maintain compatibility
     /// with older spec versions.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_cache_scope",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub cache_scope: Option<CacheScope>,
     /// The actual content of the resource
     pub contents: Vec<ResourceContents>,

--- a/crates/rmcp/tests/test_cache_hints.rs
+++ b/crates/rmcp/tests/test_cache_hints.rs
@@ -63,6 +63,45 @@ fn cache_hints_default_to_none_and_negative_ttl_is_normalized_to_zero() {
 }
 
 #[test]
+fn empty_cache_scope_is_treated_as_omitted() {
+    let result: ListToolsResult = serde_json::from_value(json!({
+        "tools": [{ "name": "search", "inputSchema": { "type": "object" } }],
+        "ttlMs": 0,
+        "cacheScope": ""
+    }))
+    .expect("empty cacheScope should deserialize as omitted");
+
+    assert_eq!(result.ttl_ms, Some(0));
+    assert_eq!(result.cache_scope, None);
+    assert_eq!(result.tools.len(), 1);
+    assert_eq!(result.tools[0].name.as_ref(), "search");
+
+    let resources: ReadResourceResult = serde_json::from_value(json!({
+        "contents": [],
+        "cacheScope": ""
+    }))
+    .expect("empty cacheScope should deserialize as omitted on read results");
+    assert_eq!(resources.cache_scope, None);
+}
+
+#[test]
+fn unknown_cache_scope_still_errors() {
+    let err = serde_json::from_value::<ListToolsResult>(json!({
+        "tools": [],
+        "cacheScope": "shared"
+    }))
+    .expect_err("unknown cacheScope values must still fail");
+    assert!(err.to_string().contains("shared"), "{err}");
+
+    let err = serde_json::from_value::<ListToolsResult>(json!({
+        "tools": [],
+        "cacheScope": " "
+    }))
+    .expect_err("whitespace cacheScope values must still fail");
+    assert!(err.to_string().contains("unknown variant"), "{err}");
+}
+
+#[test]
 fn cache_scope_round_trips() {
     assert_eq!(
         serde_json::to_value(CacheScope::Public).unwrap(),

--- a/crates/rmcp/tests/test_deserialization.rs
+++ b/crates/rmcp/tests/test_deserialization.rs
@@ -155,6 +155,20 @@ mod untagged_server_result {
     }
 
     #[test]
+    fn empty_cache_scope_list_tools_result_does_not_fall_through() {
+        let result = parse_result(wrap_response(json!({
+            "tools": [{ "name": "search", "inputSchema": { "type": "object" } }],
+            "ttlMs": 0,
+            "cacheScope": ""
+        })));
+        let ServerResult::ListToolsResult(result) = result else {
+            panic!("expected ListToolsResult, got {result:?}");
+        };
+        assert_eq!(result.cache_scope, None);
+        assert_eq!(result.tools.len(), 1);
+    }
+
+    #[test]
     fn unknown_shape_falls_through_to_custom_result() {
         // A value that doesn't match any known result type should land in
         // CustomResult.


### PR DESCRIPTION
Fixes #1242.

## Motivation and Context

SEP-2549 allows `cacheScope` to be `"public"`, `"private"`, or omitted. Some hosted servers send `""`. The deserializer treats that as an unknown variant, so `tools/list` (and `resources/read`) fail to parse as the typed result.

`ServerResult` is untagged. When `ListToolsResult` rejects the payload, it falls through to `CustomResult`. The tools are on the wire and then disappear.

Negative `ttlMs` is already clamped to `0`. Empty `cacheScope` now maps to `None`. Unknown or whitespace values still error.

## How Has This Been Tested?

- `empty_cache_scope_is_treated_as_omitted` in `crates/rmcp/tests/test_cache_hints.rs`
- `unknown_cache_scope_still_errors` (`"shared"` and `" "` still fail)
- `empty_cache_scope_list_tools_result_does_not_fall_through` in `crates/rmcp/tests/test_deserialization.rs`

## Breaking Changes

None. Empty `cacheScope` previously failed to decode. It is now treated as omitted.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
