### PR TITLE
fix(macros): accept const paths and concat! in tool/prompt descriptions

### DIFF
--- a/crates/rmcp-macros/src/prompt.rs
+++ b/crates/rmcp-macros/src/prompt.rs
@@ -1,5 +1,5 @@
 use darling::{FromMeta, ast::NestedMeta};
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Expr, Ident, ImplItemFn, ReturnType};
 
@@ -12,8 +12,10 @@ pub struct PromptAttribute {
     pub name: Option<String>,
     /// Human readable title of prompt
     pub title: Option<String>,
-    /// Optional description of what the prompt does
-    pub description: Option<String>,
+    /// Optional description of what the prompt does. A string literal, an
+    /// expression that evaluates to a `&'static str` (such as a `const` path
+    /// or `concat!`), or a `#[doc]` attribute on the function.
+    pub description: Option<darling::util::PreservedStrExpr>,
     /// Arguments that can be passed to the prompt
     pub arguments: Option<Expr>,
     /// Optional icons for the prompt
@@ -104,11 +106,8 @@ pub fn prompt(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream>
     };
 
     let name = attribute.name.unwrap_or_else(|| fn_ident.to_string());
-    let description = if let Some(s) = attribute.description {
-        Some(Expr::Lit(syn::ExprLit {
-            attrs: Vec::new(),
-            lit: syn::Lit::Str(syn::LitStr::new(&s, Span::call_site())),
-        }))
+    let description = if let Some(description) = attribute.description {
+        Some(description.into())
     } else {
         fn_item.attrs.iter().try_fold(None, extract_doc_line)?
     };

--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -1,7 +1,7 @@
 use darling::{FromMeta, ast::NestedMeta};
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{ToTokens, format_ident, quote};
-use syn::{Expr, Ident, ImplItemFn, LitStr, ReturnType, parse_quote};
+use syn::{Expr, Ident, ImplItemFn, ReturnType, parse_quote};
 
 use crate::common::extract_doc_line;
 
@@ -65,7 +65,10 @@ pub struct ToolAttribute {
     pub name: Option<String>,
     /// Human readable title of tool
     pub title: Option<String>,
-    pub description: Option<String>,
+    /// The description of the tool. A string literal, an expression that
+    /// evaluates to a `&'static str` (such as a `const` path or `concat!`),
+    /// or a `#[doc]` attribute on the function.
+    pub description: Option<darling::util::PreservedStrExpr>,
     /// A JSON Schema object defining the expected parameters for the tool
     pub input_schema: Option<Expr>,
     /// An optional JSON Schema object defining the structure of the tool's output
@@ -255,13 +258,9 @@ pub fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
         }
     });
 
-    let description_expr = if let Some(s) = attribute.description {
-        Some(Expr::Lit(syn::ExprLit {
-            attrs: Vec::new(),
-            lit: syn::Lit::Str(LitStr::new(&s, Span::call_site())),
-        }))
-    } else {
-        fn_item.attrs.iter().try_fold(None, extract_doc_line)?
+    let description_expr = match attribute.description {
+        Some(description) => Some(description.into()),
+        None => fn_item.attrs.iter().try_fold(None, extract_doc_line)?,
     };
     let resolved_tool_attr = ResolvedToolAttribute {
         name: attribute.name.unwrap_or_else(|| fn_ident.to_string()),

--- a/crates/rmcp/tests/test_prompt_macros.rs
+++ b/crates/rmcp/tests/test_prompt_macros.rs
@@ -73,7 +73,14 @@ impl Server {
             "This is a prompt with no parameters.".to_string(),
         )]
     }
+
+    #[prompt(description = CONST_PROMPT_DESCRIPTION)]
+    async fn const_description_prompt(&self) -> Vec<PromptMessage> {
+        vec![]
+    }
 }
+
+const CONST_PROMPT_DESCRIPTION: &str = "Prompt description from a const";
 
 // define generic service trait
 pub trait DataService: Send + Sync + 'static {
@@ -152,6 +159,16 @@ async fn test_prompt_macros_with_empty_param() {
     assert!(
         _attr.arguments.is_none(),
         "Empty param prompt should have no arguments"
+    );
+}
+
+#[test]
+fn test_prompt_description_accepts_const_expr() {
+    // tests https://github.com/modelcontextprotocol/rust-sdk/issues/1175
+    let prompt = Server::const_description_prompt_prompt_attr();
+    assert_eq!(
+        prompt.description.as_deref(),
+        Some(CONST_PROMPT_DESCRIPTION)
     );
 }
 

--- a/crates/rmcp/tests/test_tool_macros.rs
+++ b/crates/rmcp/tests/test_tool_macros.rs
@@ -61,6 +61,24 @@ impl Server {
 
     #[tool]
     async fn empty_param(&self) {}
+
+    #[tool(description = CONST_TOOL_DESCRIPTION)]
+    async fn const_description_tool(&self) {}
+
+    #[tool(description = concat!("part-a-", "part-b"))]
+    async fn concat_description_tool(&self) {}
+}
+
+const CONST_TOOL_DESCRIPTION: &str = "Description from a const";
+
+#[test]
+fn test_description_accepts_const_and_concat_exprs() {
+    // tests https://github.com/modelcontextprotocol/rust-sdk/issues/1175
+    let tool = Server::const_description_tool_tool_attr();
+    assert_eq!(tool.description.as_deref(), Some(CONST_TOOL_DESCRIPTION));
+
+    let tool = Server::concat_description_tool_tool_attr();
+    assert_eq!(tool.description.as_deref(), Some("part-a-part-b"));
 }
 
 /// Generic service trait.


### PR DESCRIPTION
Fixes #1175

## Motivation and Context

`description` in `#[tool]` and `#[prompt]` only accepted a bare string literal, while neighbouring attributes on the very same items are more permissive: `#[doc]` on the function accepts `include_str!` and that value reaches the published description, and `#[schemars(extend(...))]` on the argument struct accepts const paths.

So the published text could already be sourced from outside the attribute, just not through the field that names it. On a server with many tools, keeping the short broadcast description next to the longer fetchable one is much easier when both can be declared together and the short one referenced from the attribute:

```rust
const GET_PROJECT_DESCRIPTION: &str = "...";

#[tool(description = GET_PROJECT_DESCRIPTION)]
```

## How Has This Been Tested?

- before, on current `main`: a small crate with `#[tool(description = SOME_CONST)]` fails with `error: Unexpected type `path``, and `#[tool(description = concat!("a", "b"))]` fails with `error: Unexpected type `macro``
- after: both compile, and the generated `<fn>_tool_attr().description` equals the const value / `"ab"`; a bare string literal, `#[doc]`-derived and `include_str!` descriptions keep working; `description = 42` is still rejected with a normal type error at the attribute
- added regression tests in `test_tool_macros.rs` (const path, `concat!`) and `test_prompt_macros.rs` (const path); `cargo test -p rmcp-macros`, the focused integration tests, and the full `cargo test -p rmcp --features "client server transport-io which-command"` suite pass locally, plus `cargo clippy --all-targets --all-features -- -D warnings` and `cargo +nightly fmt --all -- --check`

Implementation notes: the field is parsed through darling's `PreservedStrExpr`, whose `FromMeta` keeps a string literal a literal instead of parsing its contents as code, so existing `description = "..."` usage is unchanged; the generated code stores a `&'static str` either way, exactly as before.

## Breaking Changes

None. Existing string-literal descriptions compile to the same code; only inputs that previously failed to compile are now accepted.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
