### PR TITLE
feat(model): add ServerConfig and ClientConfig aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ Use [`ClientServiceExt::serve_with_lifecycle`](crates/rmcp/src/service/client.rs
 select another lifecycle explicitly:
 
 ```rust, ignore
-use rmcp::{ClientLifecycleMode, ClientServiceExt, InitializeRequestParams, ProtocolVersion};
+use rmcp::{ClientLifecycleMode, ClientServiceExt, ProtocolVersion, model::ClientConfig};
 
 // Start directly with server/discover and include client metadata on every request.
-let client = InitializeRequestParams::default()
+let client = ClientConfig::default()
     .serve_with_lifecycle(
         transport,
         ClientLifecycleMode::Discover {
@@ -113,7 +113,7 @@ let client = InitializeRequestParams::default()
 
 // Or probe the discover lifecycle and fall back when a legacy server reports
 // that server/discover is not implemented or does not respond within 10 seconds.
-let client = InitializeRequestParams::default()
+let client = ClientConfig::default()
     .serve_with_lifecycle(
         transport,
         ClientLifecycleMode::Auto {
@@ -369,8 +369,8 @@ use serde_json::json;
 struct MyServer;
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_resources()
                 .build(),
@@ -582,8 +582,8 @@ impl MyServer {
 
 #[prompt_handler]
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_prompts().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_prompts().build())
     }
 }
 ```
@@ -934,8 +934,8 @@ Enable the logging capability, handle level changes from the client, and send lo
 use rmcp::{ServerHandler, model::*, service::RequestContext};
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_logging()
                 .build(),
@@ -1007,8 +1007,8 @@ Enable the completions capability and implement the `complete()` handler. Use `r
 use rmcp::{ErrorData as McpError, ServerHandler, model::*, service::RequestContext, RoleServer};
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_completions()
                 .enable_prompts()
@@ -1253,8 +1253,8 @@ use rmcp::{
 };
 
 impl ServerHandler for MyServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -1584,7 +1584,7 @@ use rmcp::transport::StreamableHttpClientTransport;
 
 // Defaults are stateless-friendly.
 let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
-let client = InitializeRequestParams::default().serve(transport).await?;
+let client = ClientConfig::default().serve(transport).await?;
 ```
 
 **Example:** [`examples/servers/src/counter_streamhttp.rs`](examples/servers/src/counter_streamhttp.rs) (server), [`examples/clients/src/streamable_http.rs`](examples/clients/src/streamable_http.rs) (client)
@@ -1638,7 +1638,7 @@ server example). The client transport connects with a single URI:
 use rmcp::transport::StreamableHttpClientTransport;
 
 let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
-let client = InitializeRequestParams::default().serve(transport).await?;
+let client = ClientConfig::default().serve(transport).await?;
 ```
 
 The client allows up to 16 ordinary http POSTs at once. Configure this with
@@ -1742,10 +1742,10 @@ knows what the other supports. Declare yours with the `ServerCapabilities`
 builder in `get_info()`:
 
 ```rust,ignore
-use rmcp::model::{InitializeResult, ServerCapabilities};
+use rmcp::model::{ServerCapabilities, ServerConfig};
 
-fn get_info(&self) -> InitializeResult {
-    InitializeResult::new(
+fn get_info(&self) -> ServerConfig {
+    ServerConfig::new(
         ServerCapabilities::builder()
             .enable_tools()
             .enable_prompts()

--- a/conformance/src/bin/client.rs
+++ b/conformance/src/bin/client.rs
@@ -74,8 +74,8 @@ impl ClientHandler for BasicClientHandler {}
 struct ElicitationDefaultsClientHandler;
 
 impl ClientHandler for ElicitationDefaultsClientHandler {
-    fn get_info(&self) -> InitializeRequestParams {
-        let mut info = InitializeRequestParams::default();
+    fn get_info(&self) -> ClientConfig {
+        let mut info = ClientConfig::default();
         info.capabilities.elicitation = Some(
             ElicitationCapability::new()
                 .with_form(FormElicitationCapability::new().with_schema_validation(true)),
@@ -163,8 +163,8 @@ impl ClientHandler for ElicitationDefaultsClientHandler {
 struct FullClientHandler;
 
 impl ClientHandler for FullClientHandler {
-    fn get_info(&self) -> InitializeRequestParams {
-        let mut info = InitializeRequestParams::default();
+    fn get_info(&self) -> ClientConfig {
+        let mut info = ClientConfig::default();
         info.capabilities.elicitation = Some(
             ElicitationCapability::new()
                 .with_form(FormElicitationCapability::new().with_schema_validation(true)),

--- a/conformance/src/bin/server.rs
+++ b/conformance/src/bin/server.rs
@@ -704,8 +704,8 @@ impl ServerHandler for ConformanceServer {
         (name == "test_custom_header").then(custom_header_tool)
     }
 
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_prompts()
                 .enable_prompts_list_changed()

--- a/crates/rmcp-macros/src/lib.rs
+++ b/crates/rmcp-macros/src/lib.rs
@@ -217,8 +217,8 @@ pub fn tool_router(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// ```rust,ignore
 /// #[tool_handler]
 /// impl ServerHandler for MyToolHandler {
-///     fn get_info(&self) -> InitializeResult {
-///         InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+///     fn get_info(&self) -> ServerConfig {
+///         ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
 ///     }
 /// }
 /// ```

--- a/crates/rmcp-macros/src/tool_handler.rs
+++ b/crates/rmcp-macros/src/tool_handler.rs
@@ -116,7 +116,7 @@ pub(crate) enum CallerCapability {
     Prompts,
 }
 
-/// Build a `get_info()` method that returns `InitializeResult` with the appropriate capabilities.
+/// Build a `get_info()` method that returns `ServerConfig` with the appropriate capabilities.
 ///
 /// The caller declares its own capability via `caller`. Sibling handler attributes
 /// (`prompt_handler`, `tool_handler`) are detected automatically
@@ -157,8 +157,8 @@ pub(crate) fn build_get_info(
     }
 
     syn::parse2::<ImplItem>(quote! {
-        fn get_info(&self) -> rmcp::model::InitializeResult {
-            rmcp::model::InitializeResult::new(
+        fn get_info(&self) -> rmcp::model::ServerConfig {
+            rmcp::model::ServerConfig::new(
                 rmcp::model::ServerCapabilities::builder()
                     #(#capability_calls)*
                     .build()

--- a/crates/rmcp/src/handler/client.rs
+++ b/crates/rmcp/src/handler/client.rs
@@ -274,8 +274,8 @@ macro_rules! client_handler_methods {
             std::future::ready(())
         }
 
-        fn get_info(&self) -> ClientInfo {
-            InitializeRequestParams::default()
+        fn get_info(&self) -> ClientConfig {
+            ClientConfig::default()
         }
     };
 }
@@ -292,12 +292,12 @@ pub trait ClientHandler: Sized + 'static {
     client_handler_methods!();
 }
 
-/// Do nothing, with default client info.
+/// Do nothing, with the default client config.
 impl ClientHandler for () {}
 
-/// Do nothing, with a specific client info.
-impl ClientHandler for ClientInfo {
-    fn get_info(&self) -> ClientInfo {
+/// Do nothing, with a specific client config.
+impl ClientHandler for ClientConfig {
+    fn get_info(&self) -> ClientConfig {
         self.clone()
     }
 }
@@ -422,7 +422,7 @@ macro_rules! impl_client_handler_for_wrapper {
                 (**self).on_custom_notification(notification, context)
             }
 
-            fn get_info(&self) -> ClientInfo {
+            fn get_info(&self) -> ClientConfig {
                 (**self).get_info()
             }
         }

--- a/crates/rmcp/src/handler/server.rs
+++ b/crates/rmcp/src/handler/server.rs
@@ -334,15 +334,15 @@ macro_rules! server_handler_methods {
         /// ```
         /// use rmcp::{
         ///     ErrorData as McpError, RoleServer, ServerHandler,
-        ///     model::{InitializeRequestParams, InitializeResult, ServerInfo},
+        ///     model::{InitializeRequestParams, InitializeResult, ServerConfig},
         ///     service::RequestContext,
         /// };
         ///
         /// struct MyServer;
         ///
         /// impl ServerHandler for MyServer {
-        ///     fn get_info(&self) -> ServerInfo {
-        ///         ServerInfo::default()
+        ///     fn get_info(&self) -> ServerConfig {
+        ///         ServerConfig::default()
         ///     }
         ///
         ///     async fn initialize(
@@ -600,8 +600,8 @@ macro_rules! server_handler_methods {
             std::future::ready(())
         }
 
-        fn get_info(&self) -> ServerInfo {
-            InitializeResult::default()
+        fn get_info(&self) -> ServerConfig {
+            ServerConfig::default()
         }
 
         /// SEP-2663 `tasks/get`: return the current [`DetailedTask`] state.
@@ -839,7 +839,7 @@ macro_rules! impl_server_handler_for_wrapper {
                 (**self).on_custom_notification(notification, context)
             }
 
-            fn get_info(&self) -> ServerInfo {
+            fn get_info(&self) -> ServerConfig {
                 (**self).get_info()
             }
 

--- a/crates/rmcp/src/model.rs
+++ b/crates/rmcp/src/model.rs
@@ -1119,26 +1119,58 @@ impl InitializeResult {
     }
 }
 
-/// Full server initialize payload (`InitializeResult`).
+/// A server's own configuration: the protocol version, capabilities,
+/// implementation identity, and instructions it advertises to clients.
 ///
-/// Prefer [`InitializeResult`]. The name collides with the protocol's
-/// `serverInfo` field, which is only the [`Implementation`] identity (#1082).
-//
-// The signatures this crate publishes (`ServerHandler::get_info`,
-// `DiscoverResult::from_server_info`, and the `ClientInfo` equivalents below)
-// keep spelling the alias. It resolves to the same type, so the spelling makes
-// no difference to callers, but rustdoc records the name as written and the
-// public API check treats a respelling as a changed item. Moving those
-// signatures onto the canonical names is a documented API change and belongs in
-// the next major release.
-#[deprecated(note = "use `InitializeResult` instead")]
+/// This is what `ServerHandler::get_info` returns. It is an alias for
+/// [`InitializeResult`] because the same value is sent as the `initialize`
+/// response on the wire.
+///
+/// # Examples
+///
+/// ```
+/// use rmcp::model::{ServerCapabilities, ServerConfig};
+///
+/// let config = ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
+///     .with_instructions("Call `add` to sum two numbers.");
+/// assert!(config.capabilities.tools.is_some());
+/// ```
+pub type ServerConfig = InitializeResult;
+
+/// A client's own configuration: the protocol version, capabilities, and
+/// implementation identity it advertises to servers.
+///
+/// This is what `ClientHandler::get_info` returns. It is an alias for
+/// [`InitializeRequestParams`] because the same value is sent as the
+/// `initialize` request on the wire.
+///
+/// # Examples
+///
+/// ```
+/// use rmcp::model::{ClientCapabilities, ClientConfig, Implementation};
+///
+/// let config = ClientConfig::new(
+///     ClientCapabilities::builder().enable_elicitation().build(),
+///     Implementation::new("my-client", "1.0.0"),
+/// );
+/// assert!(config.capabilities.elicitation.is_some());
+/// ```
+pub type ClientConfig = InitializeRequestParams;
+
+/// Deprecated alias for [`ServerConfig`].
+///
+/// The name collides with the protocol's `serverInfo` field, which is only the
+/// [`Implementation`] identity, so `server_info.server_info` was easy to
+/// misread (#1082).
+#[deprecated(note = "use `ServerConfig` instead")]
 pub type ServerInfo = InitializeResult;
 
-/// Full client initialize params (`InitializeRequestParams`).
+/// Deprecated alias for [`ClientConfig`].
 ///
-/// Prefer [`InitializeRequestParams`]. The name collides with the protocol's
-/// `clientInfo` field, which is only the [`Implementation`] identity (#1082).
-#[deprecated(note = "use `InitializeRequestParams` instead")]
+/// The name collides with the protocol's `clientInfo` field, which is only the
+/// [`Implementation`] identity, so `client_info.client_info` was easy to
+/// misread (#1082).
+#[deprecated(note = "use `ClientConfig` instead")]
 pub type ClientInfo = InitializeRequestParams;
 
 /// Information negotiated about a server peer.
@@ -1298,18 +1330,18 @@ impl DiscoverResult {
         self
     }
 
-    /// Create a discovery result from the server's initialization information.
+    /// Create a discovery result from the server's configuration.
     pub fn from_server_info(
         supported_versions: Vec<ProtocolVersion>,
-        server_info: ServerInfo,
+        server_config: ServerConfig,
     ) -> Self {
-        let InitializeResult {
+        let ServerConfig {
             capabilities,
             server_info,
             instructions,
             meta,
             ..
-        } = server_info;
+        } = server_config;
         let mut result = Self {
             result_type: ResultType::COMPLETE,
             supported_versions,

--- a/crates/rmcp/src/service/client.rs
+++ b/crates/rmcp/src/service/client.rs
@@ -13,10 +13,10 @@ use crate::{
     model::{
         ArgumentInfo, CacheScope, CallToolRequest, CallToolRequestParams, CallToolResponse,
         CallToolResult, CancelTaskParams, CancelTaskRequest, CancelledNotification,
-        CancelledNotificationParam, ClientJsonRpcMessage, ClientNotification, ClientRequest,
-        ClientResult, CompleteRequest, CompleteRequestParams, CompleteResult, CompletionContext,
-        CompletionInfo, DEFAULT_MRTR_MAX_ROUNDS, DiscoverRequest, DiscoverRequestParams,
-        DiscoverResult, ErrorData, GetExtensions, GetMeta, GetPromptRequest,
+        CancelledNotificationParam, ClientConfig, ClientJsonRpcMessage, ClientNotification,
+        ClientRequest, ClientResult, CompleteRequest, CompleteRequestParams, CompleteResult,
+        CompletionContext, CompletionInfo, DEFAULT_MRTR_MAX_ROUNDS, DiscoverRequest,
+        DiscoverRequestParams, DiscoverResult, ErrorData, GetExtensions, GetMeta, GetPromptRequest,
         GetPromptRequestParams, GetPromptResponse, GetPromptResult, GetTaskParams, GetTaskRequest,
         GetTaskResult, InitializeRequest, InitializeRequestParams, InitializedNotification,
         InputRequest, InputRequiredResult, InputResponses, JsonRpcResponse, ListPromptsRequest,
@@ -266,7 +266,7 @@ impl ServiceRole for RoleClient {
     type PeerReq = ServerRequest;
     type PeerResp = ServerResult;
     type PeerNot = ServerNotification;
-    type Info = InitializeRequestParams;
+    type Info = ClientConfig;
     type PeerInfo = ServerPeerInfo;
     type InitializeError = ClientInitializeError;
     const IS_CLIENT: bool = true;

--- a/crates/rmcp/src/service/server.rs
+++ b/crates/rmcp/src/service/server.rs
@@ -16,13 +16,13 @@ use crate::{
         CancelledNotification, CancelledNotificationParam, ClientJsonRpcMessage,
         ClientNotification, ClientRequest, ClientResult, CreateMessageRequest,
         CreateMessageRequestParams, CreateMessageResult, EmptyResult, ErrorData,
-        InitializeRequestParams, InitializeResult, ListRootsRequest, ListRootsResult,
-        LoggingMessageNotification, LoggingMessageNotificationParam, ProgressNotification,
-        ProgressNotificationParam, PromptListChangedNotification, ProtocolVersion,
-        ResourceListChangedNotification, ResourceUpdatedNotification,
-        ResourceUpdatedNotificationParam, ServerNotification, ServerRequest, ServerResult,
-        SubscriptionFilter, SubscriptionsAcknowledgedNotification,
-        SubscriptionsAcknowledgedNotificationParams, ToolListChangedNotification,
+        InitializeRequestParams, ListRootsRequest, ListRootsResult, LoggingMessageNotification,
+        LoggingMessageNotificationParam, ProgressNotification, ProgressNotificationParam,
+        PromptListChangedNotification, ProtocolVersion, ResourceListChangedNotification,
+        ResourceUpdatedNotification, ResourceUpdatedNotificationParam, ServerConfig,
+        ServerNotification, ServerRequest, ServerResult, SubscriptionFilter,
+        SubscriptionsAcknowledgedNotification, SubscriptionsAcknowledgedNotificationParams,
+        ToolListChangedNotification,
     },
     transport::DynamicTransportError,
 };
@@ -38,7 +38,7 @@ impl ServiceRole for RoleServer {
     type PeerReq = ClientRequest;
     type PeerResp = ClientResult;
     type PeerNot = ClientNotification;
-    type Info = InitializeResult;
+    type Info = ServerConfig;
     type PeerInfo = InitializeRequestParams;
 
     type InitializeError = ServerInitializeError;

--- a/crates/rmcp/src/transport/streamable_http_server/tower.rs
+++ b/crates/rmcp/src/transport/streamable_http_server/tower.rs
@@ -27,8 +27,8 @@ use crate::{
     model::{
         ClientCapabilities, ClientJsonRpcMessage, ClientNotification, ClientRequest, ErrorCode,
         ErrorData, GetExtensions, GetMeta, Implementation, InitializeRequest,
-        InitializeRequestParams, InitializeResult, InitializedNotification, JsonObject,
-        JsonRpcError, ProtocolVersion, RequestId, ServerJsonRpcMessage, ServerResult,
+        InitializeRequestParams, InitializedNotification, JsonObject, JsonRpcError,
+        ProtocolVersion, RequestId, ServerConfig, ServerJsonRpcMessage, ServerResult,
     },
     serve_server,
     service::{
@@ -367,7 +367,7 @@ impl<S: Service<RoleServer>> Service<RoleServer> for NegotiatingStatelessHttpSer
         self.0.handle_notification(notification, context).await
     }
 
-    fn get_info(&self) -> InitializeResult {
+    fn get_info(&self) -> ServerConfig {
         self.0.get_info()
     }
 

--- a/crates/rmcp/tests/common/calculator.rs
+++ b/crates/rmcp/tests/common/calculator.rs
@@ -2,7 +2,7 @@
 use rmcp::{
     ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{InitializeResult, ServerCapabilities},
+    model::{ServerCapabilities, ServerConfig},
     schemars, tool, tool_router,
 };
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -52,8 +52,8 @@ impl Calculator {
 }
 
 impl ServerHandler for Calculator {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions("A simple calculator")
     }
 }

--- a/crates/rmcp/tests/common/handlers.rs
+++ b/crates/rmcp/tests/common/handlers.rs
@@ -115,8 +115,8 @@ impl TestServer {
 
 impl ServerHandler for TestServer {
     #[allow(deprecated)]
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_logging().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_logging().build())
     }
 
     #[allow(deprecated)]

--- a/crates/rmcp/tests/test_cancelled_response.rs
+++ b/crates/rmcp/tests/test_cancelled_response.rs
@@ -8,8 +8,8 @@ use std::{collections::BTreeSet, process::Stdio, time::Duration};
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler, ServiceExt,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, InitializeResult,
-        ServerCapabilities,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ServerCapabilities,
+        ServerConfig,
     },
     service::RequestContext,
 };
@@ -91,8 +91,8 @@ async fn cancelled_request_receives_no_response() -> anyhow::Result<()> {
 struct WaitForCancelServer;
 
 impl ServerHandler for WaitForCancelServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_custom_headers.rs
+++ b/crates/rmcp/tests/test_custom_headers.rs
@@ -719,7 +719,7 @@ async fn test_server_rejects_unsupported_protocol_version() {
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
-        model::{InitializeResult, ServerCapabilities},
+        model::{ServerCapabilities, ServerConfig},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
@@ -730,8 +730,8 @@ async fn test_server_rejects_unsupported_protocol_version() {
     struct TestHandler;
 
     impl ServerHandler for TestHandler {
-        fn get_info(&self) -> InitializeResult {
-            InitializeResult::new(ServerCapabilities::builder().build())
+        fn get_info(&self) -> ServerConfig {
+            ServerConfig::new(ServerCapabilities::builder().build())
         }
     }
 
@@ -892,7 +892,7 @@ async fn test_server_validates_host_when_origin_validation_is_disabled_by_defaul
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
-        model::{InitializeResult, ServerCapabilities},
+        model::{ServerCapabilities, ServerConfig},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
@@ -903,8 +903,8 @@ async fn test_server_validates_host_when_origin_validation_is_disabled_by_defaul
     struct TestHandler;
 
     impl ServerHandler for TestHandler {
-        fn get_info(&self) -> InitializeResult {
-            InitializeResult::new(ServerCapabilities::builder().build())
+        fn get_info(&self) -> ServerConfig {
+            ServerConfig::new(ServerCapabilities::builder().build())
         }
     }
 
@@ -975,7 +975,7 @@ async fn test_server_validates_host_header_port_for_dns_rebinding_protection() {
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
-        model::{InitializeResult, ServerCapabilities},
+        model::{ServerCapabilities, ServerConfig},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
@@ -986,8 +986,8 @@ async fn test_server_validates_host_header_port_for_dns_rebinding_protection() {
     struct TestHandler;
 
     impl ServerHandler for TestHandler {
-        fn get_info(&self) -> InitializeResult {
-            InitializeResult::new(ServerCapabilities::builder().build())
+        fn get_info(&self) -> ServerConfig {
+            ServerConfig::new(ServerCapabilities::builder().build())
         }
     }
 
@@ -1046,7 +1046,7 @@ async fn test_server_falls_back_to_uri_authority_when_host_header_missing() {
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
-        model::{InitializeResult, ServerCapabilities},
+        model::{ServerCapabilities, ServerConfig},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
@@ -1057,8 +1057,8 @@ async fn test_server_falls_back_to_uri_authority_when_host_header_missing() {
     struct TestHandler;
 
     impl ServerHandler for TestHandler {
-        fn get_info(&self) -> InitializeResult {
-            InitializeResult::new(ServerCapabilities::builder().build())
+        fn get_info(&self) -> ServerConfig {
+            ServerConfig::new(ServerCapabilities::builder().build())
         }
     }
 
@@ -1132,7 +1132,7 @@ mod origin_validation {
     use http_body_util::Full;
     use rmcp::{
         handler::server::ServerHandler,
-        model::{InitializeResult, ServerCapabilities},
+        model::{ServerCapabilities, ServerConfig},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
@@ -1143,8 +1143,8 @@ mod origin_validation {
     struct TestHandler;
 
     impl ServerHandler for TestHandler {
-        fn get_info(&self) -> InitializeResult {
-            InitializeResult::new(ServerCapabilities::builder().build())
+        fn get_info(&self) -> ServerConfig {
+            ServerConfig::new(ServerCapabilities::builder().build())
         }
     }
 

--- a/crates/rmcp/tests/test_discover_http_client_startup.rs
+++ b/crates/rmcp/tests/test_discover_http_client_startup.rs
@@ -16,7 +16,7 @@ use axum::{
 };
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt, ServerHandler,
-    model::{DiscoverResult, ErrorCode, ErrorData, InitializeRequestParams, ProtocolVersion},
+    model::{ClientConfig, DiscoverResult, ErrorCode, ErrorData, ProtocolVersion},
     service::{MaybeSendFuture, RequestContext, RoleServer},
     transport::{
         StreamableHttpClientTransport,
@@ -132,7 +132,7 @@ async fn discover_http_client_bootstraps_headers_without_initialize() {
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!("http://{address}/mcp")),
     );
-    let client = InitializeRequestParams::default()
+    let client = ClientConfig::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {
@@ -176,7 +176,7 @@ async fn auto_http_client_falls_back_to_stateful_legacy_startup() {
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!("http://{address}/mcp")),
     );
-    let client = InitializeRequestParams::default()
+    let client = ClientConfig::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Auto {
@@ -217,7 +217,7 @@ async fn auto_http_client_falls_back_after_plain_text_4xx_rejection() {
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!("http://{address}/mcp")),
     );
-    let client = InitializeRequestParams::default()
+    let client = ClientConfig::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Auto {

--- a/crates/rmcp/tests/test_handler_cache_hints.rs
+++ b/crates/rmcp/tests/test_handler_cache_hints.rs
@@ -5,7 +5,7 @@ use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler,
     handler::server::router::{prompt::PromptRouter, tool::ToolRouter},
     model::{
-        CacheScope, InitializeRequestParams, InitializeResult, ListPromptsResult, ListToolsResult,
+        CacheScope, ClientConfig, InitializeResult, ListPromptsResult, ListToolsResult,
         ProtocolVersion,
     },
     prompt_handler,
@@ -38,8 +38,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> InitializeRequestParams {
-        let mut info = InitializeRequestParams::default();
+    fn get_info(&self) -> ClientConfig {
+        let mut info = ClientConfig::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }

--- a/crates/rmcp/tests/test_inflight_response_drain.rs
+++ b/crates/rmcp/tests/test_inflight_response_drain.rs
@@ -14,7 +14,7 @@ use std::{
 use rmcp::{
     ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolRequestParams, InitializeRequestParams, InitializeResult, ServerCapabilities},
+    model::{CallToolRequestParams, ClientConfig, ServerCapabilities, ServerConfig},
     service::QuitReason,
     tool, tool_handler, tool_router,
 };
@@ -55,8 +55,8 @@ impl SlowToolServer {
 
 #[tool_handler]
 impl ServerHandler for SlowToolServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 }
 
@@ -64,8 +64,8 @@ impl ServerHandler for SlowToolServer {
 struct DummyClientHandler;
 
 impl rmcp::ClientHandler for DummyClientHandler {
-    fn get_info(&self) -> InitializeRequestParams {
-        InitializeRequestParams::default()
+    fn get_info(&self) -> ClientConfig {
+        ClientConfig::default()
     }
 }
 

--- a/crates/rmcp/tests/test_mrtr_behavior.rs
+++ b/crates/rmcp/tests/test_mrtr_behavior.rs
@@ -114,8 +114,8 @@ impl MacroMrtrServer {
 
 #[tool_handler]
 impl ServerHandler for MacroMrtrServer {
-    fn get_info(&self) -> InitializeResult {
-        let mut info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
+    fn get_info(&self) -> ServerConfig {
+        let mut info = ServerConfig::new(ServerCapabilities::builder().enable_tools().build());
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
     }
@@ -221,8 +221,8 @@ impl MrtrServer {
 }
 
 impl ServerHandler for MrtrServer {
-    fn get_info(&self) -> InitializeResult {
-        let mut info = InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        let mut info = ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_prompts()
@@ -609,9 +609,8 @@ async fn request_state_codec_seals_and_verifies_through_the_loop() -> anyhow::Re
     struct SealingServer;
 
     impl ServerHandler for SealingServer {
-        fn get_info(&self) -> InitializeResult {
-            let mut info =
-                InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
+        fn get_info(&self) -> ServerConfig {
+            let mut info = ServerConfig::new(ServerCapabilities::builder().enable_tools().build());
             info.protocol_version = ProtocolVersion::V_2026_07_28;
             info
         }

--- a/crates/rmcp/tests/test_notification.rs
+++ b/crates/rmcp/tests/test_notification.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use rmcp::{
     ClientHandler, ServerHandler, ServiceExt,
     model::{
-        ClientNotification, CustomNotification, InitializeResult, ResourceUpdatedNotificationParam,
-        ServerCapabilities, ServerNotification, SubscribeRequestParams,
+        ClientNotification, CustomNotification, ResourceUpdatedNotificationParam,
+        ServerCapabilities, ServerConfig, ServerNotification, SubscribeRequestParams,
     },
 };
 use serde_json::json;
@@ -16,8 +16,8 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 struct Server {}
 
 impl ServerHandler for Server {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_resources()
                 .enable_resources_subscribe()

--- a/crates/rmcp/tests/test_prompt_macros.rs
+++ b/crates/rmcp/tests/test_prompt_macros.rs
@@ -7,8 +7,7 @@ use rmcp::{
     ClientHandler, ServerHandler, ServiceExt,
     handler::server::{router::prompt::PromptRouter, wrapper::Parameters},
     model::{
-        ContentBlock, GetPromptRequestParams, GetPromptResult, InitializeRequestParams,
-        PromptMessage, Role,
+        ClientConfig, ContentBlock, GetPromptRequestParams, GetPromptResult, PromptMessage, Role,
     },
     prompt, prompt_handler, prompt_router,
 };
@@ -298,8 +297,8 @@ fn test_optional_field_schema_generation_via_macro() {
 struct DummyClientHandler {}
 
 impl ClientHandler for DummyClientHandler {
-    fn get_info(&self) -> InitializeRequestParams {
-        InitializeRequestParams::default()
+    fn get_info(&self) -> ClientConfig {
+        ClientConfig::default()
     }
 }
 

--- a/crates/rmcp/tests/test_protocol_version_negotiation.rs
+++ b/crates/rmcp/tests/test_protocol_version_negotiation.rs
@@ -16,8 +16,8 @@ use std::{
 use rmcp::{
     ClientHandler, ErrorData, RoleServer, ServerHandler, ServiceExt,
     model::{
-        ClientCapabilities, ErrorCode, Implementation, InitializeRequestParams, InitializeResult,
-        ProtocolVersion,
+        ClientCapabilities, ClientConfig, ErrorCode, Implementation, InitializeRequestParams,
+        InitializeResult, ProtocolVersion, ServerConfig,
     },
     service::{ClientInitializeError, RequestContext},
 };
@@ -26,8 +26,8 @@ use rmcp::{
 struct EchoServer;
 
 impl ServerHandler for EchoServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::default()
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::default()
     }
 }
 
@@ -45,8 +45,8 @@ const HANDSHAKE_VERSIONS: &[ProtocolVersion] = &[
 struct NarrowedServer;
 
 impl ServerHandler for NarrowedServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::default()
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::default()
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
@@ -61,8 +61,8 @@ struct ModernOnlyServer;
 const MODERN_ONLY_VERSIONS: &[ProtocolVersion] = &[ProtocolVersion::V_2026_07_28];
 
 impl ServerHandler for ModernOnlyServer {
-    fn get_info(&self) -> InitializeResult {
-        let mut info = InitializeResult::default();
+    fn get_info(&self) -> ServerConfig {
+        let mut info = ServerConfig::default();
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
     }
@@ -79,8 +79,8 @@ impl ServerHandler for ModernOnlyServer {
 struct NarrowedOverridingServer;
 
 impl ServerHandler for NarrowedOverridingServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::default()
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::default()
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
@@ -102,8 +102,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> InitializeRequestParams {
-        let mut info = InitializeRequestParams::default();
+    fn get_info(&self) -> ClientConfig {
+        let mut info = ClientConfig::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }
@@ -247,8 +247,8 @@ struct DelegatingServer {
 }
 
 impl ServerHandler for DelegatingServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::default()
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::default()
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {

--- a/crates/rmcp/tests/test_resource_not_found_version.rs
+++ b/crates/rmcp/tests/test_resource_not_found_version.rs
@@ -8,7 +8,7 @@
 use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler, ServiceError,
     model::{
-        ErrorCode, ErrorData, InitializeRequestParams, InitializeResult, ProtocolVersion,
+        ClientConfig, ErrorCode, ErrorData, InitializeResult, ProtocolVersion,
         ReadResourceRequestParams, ReadResourceResponse,
     },
     service::{RequestContext, serve_directly},
@@ -33,8 +33,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> InitializeRequestParams {
-        let mut info = InitializeRequestParams::default();
+    fn get_info(&self) -> ClientConfig {
+        let mut info = ClientConfig::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }

--- a/crates/rmcp/tests/test_result_type_version.rs
+++ b/crates/rmcp/tests/test_result_type_version.rs
@@ -8,8 +8,8 @@
 use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
-        InitializeRequestParams, InitializeResult, ProtocolVersion, ResultType,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ClientConfig, ContentBlock,
+        ErrorData, InitializeResult, ProtocolVersion, ResultType,
     },
     service::{RequestContext, serve_directly},
 };
@@ -33,8 +33,8 @@ struct VersionedClient {
 }
 
 impl ClientHandler for VersionedClient {
-    fn get_info(&self) -> InitializeRequestParams {
-        let mut info = InitializeRequestParams::default();
+    fn get_info(&self) -> ClientConfig {
+        let mut info = ClientConfig::default();
         info.protocol_version = self.protocol_version.clone();
         info
     }

--- a/crates/rmcp/tests/test_sep_2260_request_association.rs
+++ b/crates/rmcp/tests/test_sep_2260_request_association.rs
@@ -9,10 +9,9 @@ use std::sync::{Arc, Mutex};
 use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler, ServiceError, ServiceExt,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
-        CreateMessageRequest, CreateMessageRequestParams, CreateMessageResult,
-        InitializeRequestParams, InitializeResult, ProtocolVersion, SamplingMessage,
-        ServerCapabilities, ServerRequest,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ClientConfig, ContentBlock,
+        CreateMessageRequest, CreateMessageRequestParams, CreateMessageResult, ProtocolVersion,
+        SamplingMessage, ServerCapabilities, ServerConfig, ServerRequest,
     },
     service::{RequestContext, RunningService, serve_directly},
 };
@@ -30,8 +29,8 @@ struct SamplingServer {
 }
 
 impl ServerHandler for SamplingServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(
@@ -94,8 +93,8 @@ impl ClientHandler for SamplingClient {
         .with_stop_reason(CreateMessageResult::STOP_REASON_END_TURN))
     }
 
-    fn get_info(&self) -> InitializeRequestParams {
-        let mut info = InitializeRequestParams::default();
+    fn get_info(&self) -> ClientConfig {
+        let mut info = ClientConfig::default();
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
     }

--- a/crates/rmcp/tests/test_sep_2260_stream_enforcement.rs
+++ b/crates/rmcp/tests/test_sep_2260_stream_enforcement.rs
@@ -26,9 +26,8 @@ use http::{HeaderName, HeaderValue};
 use rmcp::{
     ClientHandler,
     model::{
-        ClientJsonRpcMessage, CreateMessageRequestParams, CreateMessageResult,
-        InitializeRequestParams, InitializeResult, ProtocolVersion, SamplingMessage,
-        ServerCapabilities, ServerJsonRpcMessage,
+        ClientConfig, ClientJsonRpcMessage, CreateMessageRequestParams, CreateMessageResult,
+        ProtocolVersion, SamplingMessage, ServerCapabilities, ServerConfig, ServerJsonRpcMessage,
     },
     service::{ClientLifecycleMode, RequestContext, RoleClient, serve_client_with_lifecycle},
     transport::streamable_http_client::{
@@ -81,7 +80,7 @@ impl StreamableHttpClient for ScriptedServer {
         // Receiver drop is normal at test teardown; never panic in the transport task.
         let _ = self.posted.send(value.clone());
         if value["method"] == "initialize" {
-            let mut info = InitializeResult::new(ServerCapabilities::default());
+            let mut info = ServerConfig::new(ServerCapabilities::default());
             info.protocol_version = ProtocolVersion::V_2026_07_28;
             let response = ServerJsonRpcMessage::response(
                 rmcp::model::ServerResult::InitializeResult(info),
@@ -153,8 +152,8 @@ impl ClientHandler for SamplingClient {
         ))
     }
 
-    fn get_info(&self) -> InitializeRequestParams {
-        InitializeRequestParams::default()
+    fn get_info(&self) -> ClientConfig {
+        ClientConfig::default()
     }
 }
 

--- a/crates/rmcp/tests/test_sep_2260_stream_routing.rs
+++ b/crates/rmcp/tests/test_sep_2260_stream_routing.rs
@@ -9,7 +9,7 @@ use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     model::{
         CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ElicitRequestParams,
-        ElicitationSchema, InitializeResult, ServerCapabilities,
+        ElicitationSchema, ServerCapabilities, ServerConfig,
     },
     service::RequestContext,
     transport::streamable_http_server::{
@@ -23,8 +23,8 @@ use tokio_util::sync::CancellationToken;
 struct ElicitingServer;
 
 impl ServerHandler for ElicitingServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_server_discover_client.rs
+++ b/crates/rmcp/tests/test_server_discover_client.rs
@@ -3,8 +3,8 @@
 use rmcp::{
     ClientHandler, ServerHandler, ServiceExt,
     model::{
-        ClientCapabilities, Implementation, InitializeResult, ProtocolVersion, RequestMetaObject,
-        ServerCapabilities,
+        ClientCapabilities, Implementation, ProtocolVersion, RequestMetaObject, ServerCapabilities,
+        ServerConfig,
     },
     select_protocol_version,
 };
@@ -13,8 +13,8 @@ use rmcp::{
 struct DiscoveryServer;
 
 impl ServerHandler for DiscoveryServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("discovery-server", "1.0.0"))
     }
 }

--- a/crates/rmcp/tests/test_server_discover_http.rs
+++ b/crates/rmcp/tests/test_server_discover_http.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 
 use rmcp::{
     ServerHandler,
-    model::{Implementation, InitializeResult, ProtocolVersion, ServerCapabilities},
+    model::{Implementation, ProtocolVersion, ServerCapabilities, ServerConfig},
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     },
@@ -20,8 +20,8 @@ use tokio_util::sync::CancellationToken;
 struct DiscoveryServer;
 
 impl ServerHandler for DiscoveryServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("discovery-server", "1.0.0"))
             .with_instructions("Use the tools carefully")
     }

--- a/crates/rmcp/tests/test_server_initialization.rs
+++ b/crates/rmcp/tests/test_server_initialization.rs
@@ -6,7 +6,7 @@ use common::handlers::TestServer;
 use rmcp::{
     ServerHandler, ServiceExt,
     model::{
-        ClientJsonRpcMessage, InitializeResult, ProtocolVersion, ServerCapabilities,
+        ClientJsonRpcMessage, ProtocolVersion, ServerCapabilities, ServerConfig,
         ServerJsonRpcMessage, ServerResult,
     },
     transport::{IntoTransport, Transport},
@@ -281,8 +281,8 @@ async fn server_falls_back_when_client_protocol_version_unknown() {
 struct PinnedServer;
 
 impl ServerHandler for PinnedServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().build())
             .with_protocol_version(ProtocolVersion::V_2025_06_18)
     }
 }

--- a/crates/rmcp/tests/test_sse_concurrent_streams.rs
+++ b/crates/rmcp/tests/test_sse_concurrent_streams.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use rmcp::{
     RoleServer, ServerHandler,
-    model::{Implementation, InitializeResult, ServerCapabilities, ToolsCapability},
+    model::{Implementation, ServerCapabilities, ServerConfig, ToolsCapability},
     service::NotificationContext,
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
@@ -45,8 +45,8 @@ impl TestServer {
 }
 
 impl ServerHandler for TestServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools_with({
                     let mut tools = ToolsCapability::default();

--- a/crates/rmcp/tests/test_stateless_protocol_version.rs
+++ b/crates/rmcp/tests/test_stateless_protocol_version.rs
@@ -10,7 +10,10 @@ use std::borrow::Cow;
 
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
-    model::{InitializeRequestParams, InitializeResult, ProtocolVersion, ServerCapabilities},
+    model::{
+        InitializeRequestParams, InitializeResult, ProtocolVersion, ServerCapabilities,
+        ServerConfig,
+    },
     service::RequestContext,
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
@@ -22,8 +25,8 @@ use tokio_util::sync::CancellationToken;
 struct OverridingInitialize;
 
 impl ServerHandler for OverridingInitialize {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::default())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::default())
     }
 
     async fn initialize(
@@ -51,8 +54,8 @@ const HANDSHAKE_VERSIONS: &[ProtocolVersion] = &[
 struct NarrowedOverridingInitialize;
 
 impl ServerHandler for NarrowedOverridingInitialize {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::default())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::default())
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {

--- a/crates/rmcp/tests/test_stdio_response_concurrency.rs
+++ b/crates/rmcp/tests/test_stdio_response_concurrency.rs
@@ -5,8 +5,8 @@ use std::{collections::BTreeSet, process::Stdio, time::Duration};
 use rmcp::{
     ErrorData as McpError, ServerHandler, ServiceExt,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, InitializeResult,
-        ServerCapabilities,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ServerCapabilities,
+        ServerConfig,
     },
 };
 use serde_json::{Value, json};
@@ -82,8 +82,8 @@ struct LargeResponseServer;
 
 impl ServerHandler for LargeResponseServer {
     #[allow(deprecated)]
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_streamable_http_client_concurrency.rs
+++ b/crates/rmcp/tests/test_streamable_http_client_concurrency.rs
@@ -16,9 +16,9 @@ use futures::{StreamExt, stream::BoxStream};
 use http::{HeaderName, HeaderValue};
 use rmcp::{
     model::{
-        CallToolRequestParams, CancelledNotificationParam, ClientJsonRpcMessage, ClientRequest,
-        DiscoverResult, InitializeRequestParams, ProtocolVersion, Request, RequestId,
-        RequestMetaObject, ServerJsonRpcMessage,
+        CallToolRequestParams, CancelledNotificationParam, ClientConfig, ClientJsonRpcMessage,
+        ClientRequest, DiscoverResult, InitializeRequestParams, ProtocolVersion, Request,
+        RequestId, RequestMetaObject, ServerJsonRpcMessage,
     },
     service::{
         ClientLifecycleMode, PeerRequestOptions, RequestHandle, RoleClient, RunningService,
@@ -345,7 +345,7 @@ impl StreamableHttpClient for ScriptedClient {
 }
 
 struct Harness {
-    client: RunningService<RoleClient, InitializeRequestParams>,
+    client: RunningService<RoleClient, ClientConfig>,
     started: mpsc::UnboundedReceiver<Posted>,
     controls: mpsc::UnboundedReceiver<ControlPost>,
     incoming: mpsc::UnboundedSender<Result<Sse, SseError>>,
@@ -402,8 +402,7 @@ impl Harness {
             config,
         );
         let client =
-            serve_client_with_lifecycle(InitializeRequestParams::default(), transport, lifecycle)
-                .await?;
+            serve_client_with_lifecycle(ClientConfig::default(), transport, lifecycle).await?;
         Ok(Self {
             client,
             started: requests,

--- a/crates/rmcp/tests/test_streamable_http_connection_reuse.rs
+++ b/crates/rmcp/tests/test_streamable_http_connection_reuse.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use rmcp::{
     ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolRequestParams, InitializeRequestParams, InitializeResult, ServerCapabilities},
+    model::{CallToolRequestParams, ClientConfig, ServerCapabilities, ServerConfig},
     schemars, tool, tool_handler, tool_router,
     transport::{
         StreamableHttpClientTransport,
@@ -46,8 +46,8 @@ impl SumServer {
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for SumServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 }
 
@@ -83,7 +83,7 @@ async fn test_subsequent_tool_calls_reuse_connections() -> anyhow::Result<()> {
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
     );
-    let client = InitializeRequestParams::default().serve(transport).await?;
+    let client = ClientConfig::default().serve(transport).await?;
 
     // Warm up: first call may include one-time setup costs.
     let args: serde_json::Map<String, serde_json::Value> =

--- a/crates/rmcp/tests/test_streamable_http_disconnect_cancel.rs
+++ b/crates/rmcp/tests/test_streamable_http_disconnect_cancel.rs
@@ -18,8 +18,8 @@ use std::{sync::Arc, time::Duration};
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, InitializeResult,
-        ServerCapabilities,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ServerCapabilities,
+        ServerConfig,
     },
     service::RequestContext,
     transport::streamable_http_server::{
@@ -37,8 +37,8 @@ struct CancelProbe {
 
 impl ServerHandler for CancelProbe {
     #[allow(deprecated)]
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_streamable_http_event_store.rs
+++ b/crates/rmcp/tests/test_streamable_http_event_store.rs
@@ -18,8 +18,8 @@ use futures::StreamExt;
 use rmcp::{
     ErrorData, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, InitializeResult,
-        ProgressNotificationParam, ServerCapabilities,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
+        ProgressNotificationParam, ServerCapabilities, ServerConfig,
     },
     service::RequestContext,
     transport::streamable_http_server::{
@@ -109,8 +109,8 @@ impl EventStore for InMemoryEventStore {
 struct ProgressServer;
 
 impl ServerHandler for ProgressServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_streamable_http_json_response.rs
+++ b/crates/rmcp/tests/test_streamable_http_json_response.rs
@@ -2,8 +2,8 @@
 use rmcp::{
     ErrorData, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, InitializeResult,
-        ProgressNotificationParam, ServerCapabilities,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
+        ProgressNotificationParam, ServerCapabilities, ServerConfig,
     },
     service::RequestContext,
     transport::streamable_http_server::{
@@ -57,8 +57,8 @@ const NEGOTIATED_CALL_WITH_PROGRESS_BODY: &str = r#"{
 struct ProgressServer;
 
 impl ServerHandler for ProgressServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_streamable_http_protocol_version.rs
+++ b/crates/rmcp/tests/test_streamable_http_protocol_version.rs
@@ -481,8 +481,8 @@ impl CountingServer {
 }
 
 impl ServerHandler for CountingServer {
-    fn get_info(&self) -> rmcp::model::InitializeResult {
-        rmcp::model::InitializeResult::new(
+    fn get_info(&self) -> rmcp::model::ServerConfig {
+        rmcp::model::ServerConfig::new(
             rmcp::model::ServerCapabilities::builder()
                 .enable_tools()
                 .build(),

--- a/crates/rmcp/tests/test_streamable_http_stale_session.rs
+++ b/crates/rmcp/tests/test_streamable_http_stale_session.rs
@@ -15,9 +15,9 @@ use http::{HeaderName, HeaderValue};
 use rmcp::{
     ServiceError, ServiceExt,
     model::{
-        CallToolRequestParams, ClientJsonRpcMessage, ClientRequest, ErrorCode, ErrorData,
-        InitializeRequestParams, InitializeResult, PingRequest, ProtocolVersion, RequestId,
-        ServerCapabilities, ServerJsonRpcMessage, ServerResult,
+        CallToolRequestParams, ClientConfig, ClientJsonRpcMessage, ClientRequest, ErrorCode,
+        ErrorData, InitializeResult, PingRequest, ProtocolVersion, RequestId, ServerCapabilities,
+        ServerJsonRpcMessage, ServerResult,
     },
     transport::{
         StreamableHttpClientTransport,
@@ -205,7 +205,7 @@ async fn test_reinitialization_completes_accepted_sse_request_instead_of_hanging
         mock_client,
         StreamableHttpClientTransportConfig::with_uri("mock://mcp"),
     );
-    let mut client = InitializeRequestParams::default().serve(transport).await?;
+    let mut client = ClientConfig::default().serve(transport).await?;
 
     let peer = client.peer().clone();
     let pending_call = tokio::spawn(async move {

--- a/crates/rmcp/tests/test_streamable_http_standard_headers.rs
+++ b/crates/rmcp/tests/test_streamable_http_standard_headers.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use rmcp::{
     ServerHandler,
-    model::{InitializeResult, ServerCapabilities, Tool},
+    model::{ServerCapabilities, ServerConfig, Tool},
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     },
@@ -18,8 +18,8 @@ const SEP_VERSION: &str = "2026-07-28";
 struct HeaderValidationServer;
 
 impl ServerHandler for HeaderValidationServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     fn get_tool(&self, name: &str) -> Option<Tool> {

--- a/crates/rmcp/tests/test_subscriptions.rs
+++ b/crates/rmcp/tests/test_subscriptions.rs
@@ -18,8 +18,8 @@ use rmcp::{
     ClientHandler, ClientServiceExt, ServerHandler, ServiceExt,
     model::{
         ClientNotification, ClientRequest, DiscoverResult, GetMeta, Implementation,
-        InitializeResult, NotificationMetaObject, PromptListChangedNotification, ProtocolVersion,
-        ServerCapabilities, ServerNotification, ServerResult, SubscriptionFilter,
+        NotificationMetaObject, PromptListChangedNotification, ProtocolVersion, ServerCapabilities,
+        ServerConfig, ServerNotification, ServerResult, SubscriptionFilter,
         SubscriptionsAcknowledgedNotification, SubscriptionsAcknowledgedNotificationParams,
         SubscriptionsListenResult,
     },
@@ -44,8 +44,8 @@ impl ClientHandler for CountingClient {
 }
 
 impl ServerHandler for ToolsOnlyServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -80,8 +80,8 @@ impl ServerHandler for ToolsOnlyServer {
 struct ToolsAndPromptsServer;
 
 impl ServerHandler for ToolsAndPromptsServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -120,8 +120,8 @@ impl ServerHandler for ToolsAndPromptsServer {
 struct ResourceSubscriptionServer;
 
 impl ServerHandler for ResourceSubscriptionServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_resources()
                 .enable_resources_subscribe()
@@ -182,8 +182,8 @@ impl ServerHandler for RemoteCancellationServer {
 struct FloodServer;
 
 impl ServerHandler for FloodServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -217,8 +217,8 @@ struct ClosedSinkServer {
 struct LeakyServer;
 
 impl ServerHandler for LeakyServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -314,14 +314,14 @@ impl rmcp::service::Service<RoleServer> for MalformedAcknowledgmentServer {
         Ok(())
     }
 
-    fn get_info(&self) -> rmcp::model::InitializeResult {
-        InitializeResult::default()
+    fn get_info(&self) -> rmcp::model::ServerConfig {
+        ServerConfig::default()
     }
 }
 
 impl ServerHandler for ClosedSinkServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()

--- a/crates/rmcp/tests/test_subscriptions_streamable_http.rs
+++ b/crates/rmcp/tests/test_subscriptions_streamable_http.rs
@@ -18,8 +18,8 @@ use std::{
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt, ServerHandler,
     model::{
-        ClientRequest, Implementation, InitializeRequestParams, InitializeResult, ListToolsRequest,
-        ProtocolVersion, RequestMetaObject, ServerCapabilities, ServerNotification,
+        ClientConfig, ClientRequest, Implementation, ListToolsRequest, ProtocolVersion,
+        RequestMetaObject, ServerCapabilities, ServerConfig, ServerNotification,
         SubscriptionFilter,
     },
     service::{PeerRequestOptions, SubscriptionContext, SubscriptionEnd},
@@ -53,8 +53,8 @@ impl ServerHandler for HttpSubscriptionServer {
         Cow::Borrowed(&[ProtocolVersion::V_2026_07_28, ProtocolVersion::V_2025_11_25])
     }
 
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
@@ -160,7 +160,7 @@ async fn modern_http_listen_uses_post_stream_and_cancels_by_closing_it() -> anyh
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(url.clone()),
     );
-    let client = InitializeRequestParams::default()
+    let client = ClientConfig::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {
@@ -205,7 +205,7 @@ async fn modern_http_graceful_close_returns_final_listen_result() -> anyhow::Res
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(url),
     );
-    let client = InitializeRequestParams::default()
+    let client = ClientConfig::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {
@@ -241,7 +241,7 @@ async fn modern_http_stream_close_without_result_is_abrupt() -> anyhow::Result<(
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(url),
     );
-    let client = InitializeRequestParams::default()
+    let client = ClientConfig::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {
@@ -274,7 +274,7 @@ async fn modern_http_lifecycle_stays_sessionless_for_older_application_version()
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(url),
     );
-    let client = InitializeRequestParams::default()
+    let client = ClientConfig::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {

--- a/crates/rmcp/tests/test_task.rs
+++ b/crates/rmcp/tests/test_task.rs
@@ -107,8 +107,8 @@ impl ServerHandler for TaskServer {
         self.tasks.cancel_task(&request.task_id)
     }
 
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tasks()
@@ -117,8 +117,8 @@ impl ServerHandler for TaskServer {
     }
 }
 
-fn tasks_client_info() -> InitializeRequestParams {
-    InitializeRequestParams::new(
+fn tasks_client_info() -> ClientConfig {
+    ClientConfig::new(
         ClientCapabilities::builder().enable_tasks().build(),
         Implementation::from_build_env(),
     )
@@ -275,8 +275,8 @@ impl ServerHandler for AlwaysTaskServer {
         Ok(CallToolResponse::Task(CreateTaskResult::new(task)))
     }
 
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tasks()

--- a/crates/rmcp/tests/test_tool_disable_notification.rs
+++ b/crates/rmcp/tests/test_tool_disable_notification.rs
@@ -9,7 +9,7 @@ use std::sync::{
 use rmcp::{
     ClientHandler, RoleClient, RoleServer, ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRoute, tool::ToolCallContext},
-    model::{CallToolResponse, CallToolResult, InitializeResult, ServerCapabilities, Tool},
+    model::{CallToolResponse, CallToolResult, ServerCapabilities, ServerConfig, Tool},
     service::{MaybeSendFuture, NotificationContext},
 };
 use tokio::sync::{Notify, RwLock};
@@ -41,8 +41,8 @@ impl TestToolServer {
 }
 
 impl ServerHandler for TestToolServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
     }
 
     async fn call_tool(

--- a/crates/rmcp/tests/test_tool_macros.rs
+++ b/crates/rmcp/tests/test_tool_macros.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use rmcp::{
     ClientHandler, ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolRequestParams, InitializeRequestParams, InitializeResult, ServerCapabilities},
+    model::{CallToolRequestParams, ClientConfig, ServerCapabilities, ServerConfig},
     tool, tool_handler, tool_router,
 };
 use schemars::JsonSchema;
@@ -287,8 +287,8 @@ fn test_optional_field_schema_generation_via_macro() {
 struct DummyClientHandler {}
 
 impl ClientHandler for DummyClientHandler {
-    fn get_info(&self) -> InitializeRequestParams {
-        InitializeRequestParams::default()
+    fn get_info(&self) -> ClientConfig {
+        ClientConfig::default()
     }
 }
 
@@ -549,8 +549,8 @@ impl ManualInfoServer {
 
 #[tool_handler]
 impl ServerHandler for ManualInfoServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_resources()

--- a/docs/OAUTH_SUPPORT.md
+++ b/docs/OAUTH_SUPPORT.md
@@ -253,7 +253,7 @@ let transport = StreamableHttpClientTransport::with_client(
 );
 
 // create client and connect to MCP server
-let client_service = InitializeRequestParams::default();
+let client_service = ClientConfig::default();
 let client = client_service.serve(transport).await?;
 ```
 
@@ -325,7 +325,7 @@ bindings, not signatures; the resource authorization server verifies signatures.
 use oauth2::{ClientSecret, RefreshToken};
 use rmcp::{
     ServiceExt,
-    model::ClientInfo,
+    model::ClientConfig,
     transport::{
         StreamableHttpClientTransport,
         auth::{
@@ -359,7 +359,7 @@ async fn connect(
         StreamableHttpClientTransportConfig::with_uri(resource)
             .auth_header(token.access_token.secret()),
     );
-    let client = ClientInfo::default().serve(transport).await?;
+    let client = ClientConfig::default().serve(transport).await?;
     client.list_tools(Default::default()).await?;
     client.cancel().await?;
     Ok(())

--- a/examples/clients/src/auth/client_credentials.rs
+++ b/examples/clients/src/auth/client_credentials.rs
@@ -3,7 +3,7 @@ use std::env;
 use anyhow::{Context, Result};
 use rmcp::{
     ServiceExt,
-    model::InitializeRequestParams,
+    model::ClientConfig,
     transport::{
         StreamableHttpClientTransport,
         auth::{AuthClient, ClientCredentialsConfig, OAuthState},
@@ -73,7 +73,7 @@ async fn main() -> Result<()> {
     );
 
     // Connect to MCP server and list tools
-    let client_service = InitializeRequestParams::default();
+    let client_service = ClientConfig::default();
     let client = client_service.serve(transport).await?;
     tracing::info!("Connected to MCP server");
 

--- a/examples/clients/src/auth/oauth_client.rs
+++ b/examples/clients/src/auth/oauth_client.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use rmcp::{
     RoleClient, ServiceExt,
-    model::InitializeRequestParams,
+    model::ClientConfig,
     service::RunningService,
     transport::{
         StreamableHttpClientTransport,
@@ -58,7 +58,7 @@ async fn callback_handler(
 
 enum ConnectOutcome {
     /// The server accepted the unauthenticated connection.
-    Connected(RunningService<RoleClient, InitializeRequestParams>),
+    Connected(RunningService<RoleClient, ClientConfig>),
     /// The server answered 401; authorize with this `WWW-Authenticate`
     /// challenge and reconnect.
     AuthRequired(String),
@@ -72,7 +72,7 @@ async fn try_connect(http_client: reqwest::Client, server_url: &str) -> Result<C
         http_client,
         StreamableHttpClientTransportConfig::with_uri(server_url),
     );
-    match InitializeRequestParams::default().serve(transport).await {
+    match ClientConfig::default().serve(transport).await {
         Ok(client) => Ok(ConnectOutcome::Connected(client)),
         Err(error) => match error.auth_challenge() {
             Some(challenge) => Ok(ConnectOutcome::AuthRequired(challenge.to_string())),
@@ -90,7 +90,7 @@ async fn authorize_and_connect(
     client_metadata_url: &str,
     code_receiver: oneshot::Receiver<CallbackParams>,
     output: &mut BufWriter<tokio::io::Stdout>,
-) -> Result<RunningService<RoleClient, InitializeRequestParams>> {
+) -> Result<RunningService<RoleClient, ClientConfig>> {
     tracing::info!("Server requires authorization: {challenge}");
 
     // initialize oauth state machine
@@ -156,7 +156,7 @@ async fn authorize_and_connect(
         auth_client,
         StreamableHttpClientTransportConfig::with_uri(server_url),
     );
-    Ok(InitializeRequestParams::default().serve(transport).await?)
+    Ok(ClientConfig::default().serve(transport).await?)
 }
 
 #[tokio::main]

--- a/examples/clients/src/progress_client.rs
+++ b/examples/clients/src/progress_client.rs
@@ -8,7 +8,7 @@ use clap::{Parser, ValueEnum};
 use rmcp::{
     ClientHandler, ServiceExt,
     model::{
-        CallToolRequestParams, ClientCapabilities, Implementation, InitializeRequestParams,
+        CallToolRequestParams, ClientCapabilities, ClientConfig, Implementation,
         ProgressNotificationParam,
     },
     service::{NotificationContext, RoleClient},
@@ -121,8 +121,8 @@ impl ClientHandler for ProgressAwareClient {
         }
     }
 
-    fn get_info(&self) -> InitializeRequestParams {
-        InitializeRequestParams::new(
+    fn get_info(&self) -> ClientConfig {
+        ClientConfig::new(
             ClientCapabilities::default(),
             Implementation::new("progress-test-client", "1.0.0"),
         )

--- a/examples/clients/src/streamable_http.rs
+++ b/examples/clients/src/streamable_http.rs
@@ -2,8 +2,7 @@ use anyhow::Result;
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt,
     model::{
-        CallToolRequestParams, ClientCapabilities, Implementation, InitializeRequestParams,
-        ProtocolVersion,
+        CallToolRequestParams, ClientCapabilities, ClientConfig, Implementation, ProtocolVersion,
     },
     transport::StreamableHttpClientTransport,
 };
@@ -19,7 +18,7 @@ async fn main() -> Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
     let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
-    let client_info = InitializeRequestParams::new(
+    let client_info = ClientConfig::new(
         ClientCapabilities::default(),
         Implementation::new("streamable-http-client", "0.0.1"),
     );

--- a/examples/clients/src/subscriptions_streamhttp.rs
+++ b/examples/clients/src/subscriptions_streamhttp.rs
@@ -1,6 +1,6 @@
 use rmcp::{
     ClientLifecycleMode, ClientServiceExt,
-    model::{InitializeRequestParams, ProtocolVersion, SubscriptionFilter},
+    model::{ClientConfig, ProtocolVersion, SubscriptionFilter},
     transport::StreamableHttpClientTransport,
 };
 
@@ -13,7 +13,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let transport = StreamableHttpClientTransport::from_uri("http://127.0.0.1:8000/mcp");
-    let client = InitializeRequestParams::default()
+    let client = ClientConfig::default()
         .serve_with_lifecycle(
             transport,
             ClientLifecycleMode::Discover {

--- a/examples/clients/src/task_stdio.rs
+++ b/examples/clients/src/task_stdio.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Declare the tasks extension in our client capabilities (SEP-2663).
-    let client_info = rmcp::model::InitializeRequestParams::new(
+    let client_info = rmcp::model::ClientConfig::new(
         ClientCapabilities::builder().enable_tasks().build(),
         rmcp::model::Implementation::from_build_env(),
     );

--- a/examples/servers/src/common/counter.rs
+++ b/examples/servers/src/common/counter.rs
@@ -206,8 +206,8 @@ impl Counter {
 #[tool_handler(meta = MetaObject(rmcp::object!({"tool_meta_key": "tool_meta_value"})))]
 #[prompt_handler(meta = MetaObject(rmcp::object!({"router_meta_key": "router_meta_value"})))]
 impl ServerHandler for Counter {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_prompts()
                 .enable_resources()

--- a/examples/servers/src/common/progress_demo.rs
+++ b/examples/servers/src/common/progress_demo.rs
@@ -131,8 +131,8 @@ impl ProgressDemo {
 
 #[tool_handler]
 impl ServerHandler for ProgressDemo {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
             .with_protocol_version(ProtocolVersion::V_2024_11_05)
             .with_server_info(Implementation::from_build_env())
             .with_instructions(

--- a/examples/servers/src/common/task_demo.rs
+++ b/examples/servers/src/common/task_demo.rs
@@ -151,8 +151,8 @@ impl ServerHandler for TaskDemo {
         self.tasks.cancel_task(&request.task_id)
     }
 
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tasks()

--- a/examples/servers/src/completion_stdio.rs
+++ b/examples/servers/src/completion_stdio.rs
@@ -310,8 +310,8 @@ impl SqlQueryServer {
 
 #[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for SqlQueryServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_completions()
                 .enable_prompts()

--- a/examples/servers/src/elicitation_enum_inference.rs
+++ b/examples/servers/src/elicitation_enum_inference.rs
@@ -155,8 +155,8 @@ impl ElicitationEnumFormServer {
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for ElicitationEnumFormServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::from_build_env())
             .with_instructions(
                 "Simple server demonstrating elicitation for enum selection".to_string(),

--- a/examples/servers/src/elicitation_stdio.rs
+++ b/examples/servers/src/elicitation_stdio.rs
@@ -147,8 +147,8 @@ impl ElicitationServer {
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for ElicitationServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::from_build_env())
             .with_instructions(
                 "Simple server demonstrating elicitation for user name collection".to_string(),

--- a/examples/servers/src/mrtr.rs
+++ b/examples/servers/src/mrtr.rs
@@ -113,8 +113,8 @@ fn finish_weather_request(
 }
 
 impl ServerHandler for WeatherServer {
-    fn get_info(&self) -> InitializeResult {
-        let mut info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
+    fn get_info(&self) -> ServerConfig {
+        let mut info = ServerConfig::new(ServerCapabilities::builder().enable_tools().build());
         // MRTR requires 2026-07-28 or newer.
         info.protocol_version = ProtocolVersion::V_2026_07_28;
         info
@@ -173,8 +173,8 @@ impl ServerHandler for WeatherServer {
 struct InteractiveClient;
 
 impl ClientHandler for InteractiveClient {
-    fn get_info(&self) -> InitializeRequestParams {
-        InitializeRequestParams::new(
+    fn get_info(&self) -> ClientConfig {
+        ClientConfig::new(
             ClientCapabilities::builder().enable_elicitation().build(),
             Implementation::new("mrtr-example-client", env!("CARGO_PKG_VERSION")),
         )

--- a/examples/servers/src/prompt_stdio.rs
+++ b/examples/servers/src/prompt_stdio.rs
@@ -363,13 +363,12 @@ impl PromptServer {
 
 #[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for PromptServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_prompts().build())
-            .with_instructions(
-                "This server provides various prompt templates for code review, data analysis, \
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_prompts().build()).with_instructions(
+            "This server provides various prompt templates for code review, data analysis, \
                  writing assistance, debugging help, and personalized learning paths. \
                  All prompts are designed to provide structured, context-aware assistance.",
-            )
+        )
     }
 }
 

--- a/examples/servers/src/sampling_stdio.rs
+++ b/examples/servers/src/sampling_stdio.rs
@@ -21,8 +21,8 @@ use tracing_subscriber::{self, EnvFilter};
 pub struct SamplingDemoServer;
 
 impl ServerHandler for SamplingDemoServer {
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(concat!(
                 "This is a demo server that requests sampling from clients. It provides tools that use LLM capabilities.\n\n",
                 "IMPORTANT: This server requires a client that supports the 'sampling/createMessage' method. ",

--- a/examples/servers/src/subscriptions_streamhttp.rs
+++ b/examples/servers/src/subscriptions_streamhttp.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, time::Duration};
 
 use rmcp::{
     ErrorData, ServerHandler,
-    model::{InitializeResult, ProtocolVersion, ServerCapabilities, SubscriptionFilter},
+    model::{ProtocolVersion, ServerCapabilities, ServerConfig, SubscriptionFilter},
     service::SubscriptionContext,
     transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
@@ -18,8 +18,8 @@ impl ServerHandler for SubscriptionServer {
         Cow::Borrowed(&[ProtocolVersion::V_2026_07_28])
     }
 
-    fn get_info(&self) -> InitializeResult {
-        InitializeResult::new(
+    fn get_info(&self) -> ServerConfig {
+        ServerConfig::new(
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()


### PR DESCRIPTION
## Motivation and Context

Follow-up to #1156. This PR introduces `ServerConfig` and `ClientConfig` as the recommended names for the values returned by `ServerHandler::get_info` and `ClientHandler::get_info`, and updates the `ServerInfo` and `ClientInfo` deprecation notes to point to them.

## How Has This Been Tested?

Added tests

## Breaking Changes

None

Public API Check is a false neative in CI. It does not check return types at all. A type alias is transparent, so a downstream `fn get_info(&self) -> ServerInfo` still satisfies a trait declared as `-> ServerConfig`. A newtype would have broken it, but an alias cannot.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed